### PR TITLE
Add consolidated API types

### DIFF
--- a/ethos-frontend-ts/src/types/api.ts
+++ b/ethos-frontend-ts/src/types/api.ts
@@ -1,0 +1,19 @@
+// Central API types re-exported for convenience
+
+export * from './boardTypes';
+export * from './questTypes';
+export * from './postTypes';
+export * from './userTypes';
+export * from './gitTypes';
+export * from './common';
+
+export type UUID = string;
+export type Timestamp = string;
+
+export interface ApiResponse<T> {
+  data: T;
+  success: boolean;
+  error?: string;
+}
+
+export type AppItem = Post | Quest | Board | RenderableItem;

--- a/ethos-frontend-ts/src/types/boardTypes.ts
+++ b/ethos-frontend-ts/src/types/boardTypes.ts
@@ -15,6 +15,7 @@ export interface Board {
   defaultFor?: 'home' | 'profile' | 'quests';
   createdAt: string;
   category?: string; // Optional board grouping
+  userId: string;
 }
 
 /**

--- a/ethos-frontend-ts/src/types/gitTypes.ts
+++ b/ethos-frontend-ts/src/types/gitTypes.ts
@@ -1,6 +1,19 @@
 // Shared type for linking Git data to quests or posts
 export type GitItemType = 'post' | 'quest';
 
+// Complete repository representation used across API responses
+export interface GitRepo {
+  id: string;
+  repoUrl: string;
+  defaultBranch: string;
+  branches: string[];
+  lastCommitSha: string;
+  lastSync?: string;
+  status: GitStatus;
+  fileTree: GitFileNode[];
+  commits: GitCommit[];
+}
+
 export interface GitLinkedItem {
   itemId: string;
   itemType: GitItemType;
@@ -62,6 +75,12 @@ export interface DBGitCommit {
   metadata?: GitMetaData;
 }
 
+export interface GitFileChange {
+  fileId: string;
+  type: 'add' | 'modify' | 'delete';
+  diff?: string;
+}
+
 export interface GitMetaData {
   size?: number;           // Size in bytes
   linesChanged?: number;
@@ -102,16 +121,21 @@ export interface GitBranch {
 // Git status relative to origin
 export interface GitStatus {
   branch?: string;
-  ahead: number;
-  behind: number;
+  ahead?: number;
+  behind?: number;
   isDirty?: boolean;
-  uncommittedChanges: GitFile[];
+  uncommittedChanges?: GitFile[];
 }
 
 export interface GitFileNode {
+  id?: string;
   path: string;
+  name?: string;
   type: 'file' | 'dir';
+  status?: 'added' | 'modified' | 'deleted' | 'unchanged';
   children?: GitFileNode[];
+  commitIds?: string[];
+  linkedItem?: GitLinkedItem;
 }
 
   
@@ -122,4 +146,4 @@ export interface GitRepoMeta {
   branch?: string;
 }
 
-  
+

--- a/ethos-frontend-ts/src/types/questTypes.ts
+++ b/ethos-frontend-ts/src/types/questTypes.ts
@@ -11,18 +11,18 @@ export interface Quest {
   description?: string;
   status: 'active' | 'completed' | 'archived';
   headPostId: string;
-  linkedPosts: LinkedItem[];
-  collaborators: CollaberatorRoles[]; // ✅ Change this line
   createdAt?: string;
-  ownerId?: string;
 
-  // Git metadata
-  gitRepoUrl?: string;
-  repoStatus?: GitStatus;
-  repoTree?: GitFileNode[];
-  
-  // 🆕 Optional additions
+  linkedPosts: LinkedItem[];
+  collaborators: CollaberatorRoles[];
+  gitRepo: {
+    repoId: string;
+    headCommitId?: string;
+    defaultBranch?: string;
+  };
+
   tags?: string[];
+  defaultBoardId?: string;
 }
 
 

--- a/ethos-frontend-ts/src/types/userTypes.ts
+++ b/ethos-frontend-ts/src/types/userTypes.ts
@@ -16,6 +16,8 @@ export interface User {
   tags: string[];
   location?: string;
 
+  gitAccounts?: GitAccount[];
+
   // Public-facing links and portfolio sites
   links: {
     github?: string;
@@ -43,6 +45,13 @@ export interface User {
   status?: 'active' | 'archived' | 'banned';
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface GitAccount {
+  provider: 'github' | 'gitlab';
+  username: string;
+  tokenHash?: string;
+  linkedRepoIds?: string[];
 }
 
 


### PR DESCRIPTION
## Summary
- centralize API types for frontend
- align board, quest, git and user type definitions with backend

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run build` in `ethos-backend-ts` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68435129efc4832fa2f899d98c303b10