### PR TITLE
Fix TODO comments and enforce typings

### DIFF
--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -86,7 +86,10 @@ router.patch('/:id', (req: Request<{ id: string }, any, { logId: string }>, res:
 router.get(
   '/:id',
   authOptional,
-  async (req: AuthRequest<{ id: string }, any, any, { enrich?: string }>, res: Response) => { //TODO: No overload matches this call.
+  async (
+    req: AuthRequest<{ id: string }, any, any, { enrich?: string }>,
+    res: Response
+  ): Promise<void> => {
   const { id } = req.params;
   const { enrich } = req.query;
   const userId = req.user?.id || null;
@@ -129,7 +132,10 @@ router.post(
 });
 
 // GET quest tree (hierarchy)
-router.get('/:id/tree', authOptional, (req: Request<{ id: string }>, res: Response) => {  //TODO: No overload matches this call.
+router.get(
+  '/:id/tree',
+  authOptional,
+  (req: Request<{ id: string }>, res: Response): void => {
   const { id } = req.params;
 
   const quests = questsStore.read();
@@ -155,7 +161,10 @@ router.get('/:id/tree', authOptional, (req: Request<{ id: string }>, res: Respon
 });
 
 // DELETE quest
-router.delete('/:id', authMiddleware, (req: AuthRequest<{ id: string }>, res: Response) => {  //TODO: No overload matches this call.
+router.delete(
+  '/:id',
+  authMiddleware,
+  (req: AuthRequest<{ id: string }>, res: Response): void => {
   const { id } = req.params;
   const quests = questsStore.read();
   const index = quests.findIndex(q => q.id === id);

--- a/ethos-backend/src/services/gitService.ts
+++ b/ethos-backend/src/services/gitService.ts
@@ -18,8 +18,10 @@ function ensureRepoDir(questId: string): string {
 export async function initRepo(questId: string, name: string): Promise<GitRepo> {
   const repoDir = ensureRepoDir(questId);
   const repos = gitStore.read();
-  const existing = repos.find((r) => (r as any).id === questId);
-  const repo: GitRepo = existing || { //TODO: Type 'DBGitRepo | GitRepo' is not assignable to type 'GitRepo'.
+  const existing = repos.find((r) => (r as any).id === questId) as
+    | GitRepo
+    | undefined;
+  const repo: GitRepo = existing ?? {
     id: questId,
     repoUrl: '',
     defaultBranch: 'main',
@@ -28,7 +30,7 @@ export async function initRepo(questId: string, name: string): Promise<GitRepo> 
     status: {},
     fileTree: [],
     commits: [],
-  } as GitRepo;
+  };
   if (!existing) {
     repos.push(repo as any);
     gitStore.write(repos);
@@ -154,7 +156,7 @@ export async function downloadRepo(
     const output = fs.createWriteStream(outPath);
     const archive = archiver('zip', { zlib: { level: 9 } });
     output.on('close', () => resolve());
-    archive.on('error', (err) => reject(err));//TODO: Parameter 'err' implicitly has an 'any' type.t
+    archive.on('error', (err: Error) => reject(err));
     archive.pipe(output);
     archive.directory(repoDir, false);
     archive.finalize();


### PR DESCRIPTION
## Summary
- remove TODO comments in backend service and routes
- provide explicit typings for git service and quest routes

## Testing
- `npx tsc -p ethos-backend/tsconfig.json --noEmit` *(fails: cannot find modules, other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68441094ace4832fb8b4edc369b0adae