### PR TITLE
Fix missing auth header

### DIFF
--- a/ethos-frontend/src/api/auth.ts
+++ b/ethos-frontend/src/api/auth.ts
@@ -1,6 +1,6 @@
 // src/api/auth.ts
 
-import { axiosWithAuth } from '../utils/authUtils';
+import { axiosWithAuth, setAccessToken } from '../utils/authUtils';
 import type { User } from '../types/userTypes';
 
 /**
@@ -25,6 +25,10 @@ export const login = async (
   password: string
 ): Promise<{ accessToken: string }> => {
   const res = await axiosWithAuth.post('/auth/login', { email, password });
+  // Store access token for subsequent authenticated requests
+  if (res.data?.accessToken) {
+    setAccessToken(res.data.accessToken);
+  }
   return res.data;
 };
 
@@ -34,6 +38,7 @@ export const login = async (
  */
 export const logout = async (): Promise<void> => {
   await axiosWithAuth.post('/auth/logout');
+  setAccessToken(null);
 };
 
 /**


### PR DESCRIPTION
## Summary
- keep `accessToken` in localStorage and attach to axios requests
- persist token on login and clear it on logout

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs'...)*

------
https://chatgpt.com/codex/tasks/task_e_6844a5b60628832f97305b4997c14555