### PR TITLE
Fix action menu and board filters

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -76,18 +76,39 @@ const Board: React.FC<BoardProps> = ({
 
   const filteredItems = useMemo(() => {
     let result = [...items];
-    if (filter?.type) {
-      result = result.filter((item) => item.type === filter.type);
+
+    if (filter?.itemType) {
+      result = result.filter((item) =>
+        filter.itemType === 'quest'
+          ? 'headPostId' in item
+          : 'content' in item
+      );
+    }
+
+    if (filter?.postType) {
+      result = result.filter((item) =>
+        'type' in item && (item as Post).type === filter.postType
+      );
+    }
+
+    if (filter?.linkType) {
+      result = result.filter(
+        (item) =>
+          'linkedItems' in item &&
+          (item as Post).linkedItems?.some((l) => l.linkType === filter.linkType)
+      );
     }
 
     return result
       .filter((item: Post) => {
-        const title = getDisplayTitle(item) ?? '';
+        const title = getDisplayTitle(item as Post) ?? '';
         return title.toLowerCase().includes(filterText.toLowerCase());
       })
       .sort((a, b) => {
-        const aVal = sortKey === 'createdAt' ? a.createdAt ?? '' : getDisplayTitle(a) ?? '';
-        const bVal = sortKey === 'createdAt' ? b.createdAt ?? '' : getDisplayTitle(b) ?? '';
+        const aVal =
+          sortKey === 'createdAt' ? a.createdAt ?? '' : getDisplayTitle(a as Post) ?? '';
+        const bVal =
+          sortKey === 'createdAt' ? b.createdAt ?? '' : getDisplayTitle(b as Post) ?? '';
         return sortOrder === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
       });
   }, [items, filter, filterText, sortKey, sortOrder]);

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -82,7 +82,9 @@ const CreatePost: React.FC<CreatePostProps> = ({ onSave, onCancel, replyTo = nul
               id="post-type"
               value={type}
               onChange={(e) => setType(e.target.value as PostType)}
-              options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
+              options={POST_TYPES.filter(
+                ({ value }) => value !== 'quest' || linkedItems.length === 0
+              ).map(({ value, label }) => ({ value, label }))}
             />
           </>
         )}
@@ -150,11 +152,11 @@ const CreatePost: React.FC<CreatePostProps> = ({ onSave, onCancel, replyTo = nul
 };
 
 function requiresQuestLink(type: PostType): boolean {
-  return ['quest_log', 'quest_task'].includes(type);
+  return ['log', 'task'].includes(type);
 }
 
 function requiresQuestRoles(type: PostType): boolean {
-  return ['quest_log', 'quest_task'].includes(type);
+  return ['log', 'task'].includes(type);
 }
 
 export default CreatePost;

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -5,6 +5,7 @@ import type { FormEvent } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { updatePost } from '../../api/post';
+import { POST_TYPES } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
 import type { PostType, Post, CollaberatorRoles, LinkedItem } from '../../types/postTypes';
 
@@ -69,16 +70,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
           id="post-type"
           value={type}
           onChange={(e) => setType(e.target.value as PostType)}
-          options={[
-            { value: 'free_speech', label: 'Free Speech' },
-            { value: 'request', label: 'Request' },
-            { value: 'review', label: 'Review' },
-            { value: 'quest_log', label: 'Quest Log' },
-            { value: 'quest_task', label: 'Quest Task' },
-            { value: 'commit', label: 'Git Commit' },
-            { value: 'log', label: 'Code Log' },
-            { value: 'quest', label: 'Quest Root' },
-          ]}
+          options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
 
         <Label htmlFor="content">Content (Markdown supported)</Label>

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -175,6 +175,9 @@ const PostCard: React.FC<PostCardProps> = ({
           id={post.id}
           type="post"
           canEdit={canEdit}
+          onEdit={() => setEditMode(true)}
+          onDelete={() => onDelete?.(post.id)}
+          permalink={`${window.location.origin}/posts/${post.id}`}
         />
       </div>
 

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -17,6 +17,8 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },
   { value: 'request', label: 'Request' },
   { value: 'quest', label: 'Quest' },
+  { value: 'task', label: 'Quest Task' },
+  { value: 'log', label: 'Quest Log' },
   { value: 'commit', label: 'Commit' },
   { value: 'issue', label: 'Issue' },
 ];


### PR DESCRIPTION
## Summary
- expand post type options to include quest logs and tasks
- disable quest post option when a quest is already linked
- ensure quest log/task detection works when creating posts
- use shared post type options in EditPost
- wire up edit, delete and copy link actions for PostCard
- support itemType, postType and linkType filters in Board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844afa808d8832fa8c23ab3a9207c3e