### PR TITLE
Fix post fetching routes and auth token refresh

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -41,7 +41,40 @@ router.get(
       result = result.filter(board => board.featured === true); 
     }
 
-    res.json(result);
+  res.json(result);
+  }
+);
+
+//
+// ✅ GET thread board for a post
+//
+router.get(
+  '/thread/:postId',
+  (req: Request<{ postId: string }, any, undefined, { enrich?: string }>, res: Response): void => {
+    const { postId } = req.params;
+    const { enrich } = req.query;
+
+    const posts = postsStore.read();
+    const quests = questsStore.read();
+
+    const replies = posts.filter(p => p.replyTo === postId);
+
+    const board: BoardData = {
+      id: `thread-${postId}`,
+      title: 'Thread',
+      items: replies.map(r => r.id),
+      layout: 'thread',
+      createdAt: new Date().toISOString(),
+      userId: '',
+    };
+
+    if (enrich === 'true') {
+      const enriched = enrichBoard(board, { posts, quests });
+      res.json(enriched);
+      return;
+    }
+
+    res.json(board);
   }
 );
 
@@ -140,6 +173,7 @@ router.get(
     res.json(items);
   }
 );
+
 
 //
 // ✅ POST create a new board

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -62,7 +62,7 @@ axiosWithAuth.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest: any = error.config;
     if (
-      error.response?.status === 401 &&
+      (error.response?.status === 401 || error.response?.status === 403) &&
       !originalRequest._retry &&
       !originalRequest.url?.includes('/auth/refresh')
     ) {


### PR DESCRIPTION
## Summary
- add missing API to fetch posts
- support thread boards for reply chains
- attempt auth refresh on 403 responses

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6844be9faf44832faa851caa4500a791