### PR TITLE
Add reply button and quest node logic

### DIFF
--- a/ethos-backend/src/utils/nodeIdUtils.ts
+++ b/ethos-backend/src/utils/nodeIdUtils.ts
@@ -1,0 +1,35 @@
+export type NodeIdParams = {
+  quest: { id: string; title: string };
+  posts: Array<{ id: string; questId?: string | null; type: string; nodeId?: string; replyTo?: string | null }>;
+  postType: string;
+  parentPost?: { id: string; nodeId?: string } | null;
+};
+
+const slugify = (str: string): string => str.toLowerCase().replace(/[^a-z0-9]+/g, '').replace(/^-+|-+$/g, '');
+const zeroPad = (num: number): string => num.toString().padStart(2, '0');
+
+const typeMap: Record<string, string> = {
+  quest: 'T',
+  task: 'T',
+  log: 'L',
+  commit: 'C',
+  issue: 'I',
+};
+
+export const generateNodeId = ({ quest, posts, postType, parentPost = null }: NodeIdParams): string => {
+  const segment = typeMap[postType];
+  if (!segment) return '';
+
+  const questSlug = slugify(quest.title);
+  const baseQuest = `Q:${questSlug}`;
+
+  if (segment === 'T') {
+    const count = posts.filter(p => p.questId === quest.id && p.nodeId && typeMap[p.type] === 'T').length;
+    return `${baseQuest}:T${zeroPad(count)}`;
+  }
+
+  const basePath = parentPost?.nodeId || baseQuest;
+  const prefix = `${basePath}:${segment}`;
+  const count = posts.filter(p => p.questId === quest.id && p.nodeId?.startsWith(prefix) && typeMap[p.type] === segment).length;
+  return `${prefix}${zeroPad(count)}`;
+};

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -14,6 +14,7 @@ jest.mock('../src/models/stores', () => ({
   postsStore: { read: jest.fn(() => []), write: jest.fn() },
   usersStore: { read: jest.fn(() => []), write: jest.fn() },
   reactionsStore: { read: jest.fn(() => []), write: jest.fn() },
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
 const app = express();

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -146,14 +146,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           <FaReply /> {showReplyPanel ? 'Cancel' : 'Reply'}
         </button>
 
-        {typeof replyCount === 'number' && replyCount > 0 && (
-          <button
-            onClick={onToggleReplies}
-            className="text-xs text-blue-600 underline"
-          >
-            {showReplies ? 'Hide Replies' : `View Replies (${replyCount})`}
-          </button>
-        )}
       </div>
 
       {showReplyPanel && (

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -115,7 +115,7 @@ const CreatePost: React.FC<CreatePostProps> = ({ onSave, onCancel, replyTo = nul
         />
       </FormSection>
 
-      {requiresQuestLink(type) && (
+      {requiresQuestLink(type) && !replyTo && (
         <FormSection title="Linked Quest">
           <LinkControls
             label="Quest"
@@ -127,7 +127,7 @@ const CreatePost: React.FC<CreatePostProps> = ({ onSave, onCancel, replyTo = nul
         </FormSection>
       )}
 
-      {requiresQuestRoles(type) && (
+      {requiresQuestRoles(type) && !replyTo && (
         <FormSection title="Collaborators">
           <CollaberatorControls value={collaborators} onChange={setCollaborators} />
         </FormSection>

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -202,14 +202,31 @@ const PostCard: React.FC<PostCardProps> = ({
       {renderCommitDiff()}
       {renderLinkSummary()}
 
+      {['request','quest','task','log','commit','issue'].includes(post.type) && (
+        <div className="text-xs text-gray-500 space-y-1">
+          {post.linkedItems && post.linkedItems.length > 0 && (
+            <div>🔗 Linked to {post.linkedItems.length} items</div>
+          )}
+          {post.questId && post.nodeId && (
+            <div>🧭 Linked to Quest: {post.nodeId}</div>
+          )}
+        </div>
+      )}
+
       <ReactionControls
         post={post}
         user={user}
         onUpdate={onUpdate}
-        replyCount={replies.length || initialReplies}
-        showReplies={showReplies}
-        onToggleReplies={toggleReplies}
       />
+
+      {(initialReplies > 0 || replies.length > 0) && (
+        <button
+          onClick={toggleReplies}
+          className="text-blue-600 underline text-xs"
+        >
+          {showReplies ? 'Hide Replies' : `\u{1F4AC} See Replies (${initialReplies || replies.length})`}
+        </button>
+      )}
 
       {!compact && (
         <div>


### PR DESCRIPTION
## Summary
- generate quest node IDs server-side
- expose quest store to post creation route
- remove view replies toggle from reaction controls
- use existing create post form for replies
- show See Replies button and metadata on posts
- update tests for new quest store mocking

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844e9831f6c832fbbb497ae9ec16c2d