### PR TITLE
Improve post linking controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Current build includes:
 - Posting messages, logs and tasks
 - Quests linking posts with Git repo metadata
 - Boards to visualize posts and quests in grid, graph or thread views
+- Inline linking of quests and posts
+- Link dropdowns support node ID search and sorting
 
 Planned enhancements before stable release:
 - In-app file change views for Git commits

--- a/ethos-backend/package-lock.json
+++ b/ethos-backend/package-lock.json
@@ -31,7 +31,7 @@
         "@types/nodemailer": "^6.4.17",
         "@types/supertest": "^2.0.12",
         "jest": "^29.7.0",
-        "supertest": "^6.3.3",
+        "supertest": "^6.3.4",
         "ts-jest": "^29.3.4",
         "typescript": "^5.8.3"
       }

--- a/ethos-backend/package.json
+++ b/ethos-backend/package.json
@@ -36,7 +36,7 @@
     "@types/nodemailer": "^6.4.17",
     "@types/supertest": "^2.0.12",
     "jest": "^29.7.0",
-    "supertest": "^6.3.3",
+    "supertest": "^6.3.4",
     "ts-jest": "^29.3.4",
     "typescript": "^5.8.3"
   }

--- a/ethos-backend/src/utils/nodeIdUtils.ts
+++ b/ethos-backend/src/utils/nodeIdUtils.ts
@@ -1,0 +1,35 @@
+export type NodeIdParams = {
+  quest: { id: string; title: string };
+  posts: Array<{ id: string; questId?: string | null; type: string; nodeId?: string; replyTo?: string | null }>;
+  postType: string;
+  parentPost?: { id: string; nodeId?: string } | null;
+};
+
+const slugify = (str: string): string => str.toLowerCase().replace(/[^a-z0-9]+/g, '').replace(/^-+|-+$/g, '');
+const zeroPad = (num: number): string => num.toString().padStart(2, '0');
+
+const typeMap: Record<string, string> = {
+  quest: 'T',
+  task: 'T',
+  log: 'L',
+  commit: 'C',
+  issue: 'I',
+};
+
+export const generateNodeId = ({ quest, posts, postType, parentPost = null }: NodeIdParams): string => {
+  const segment = typeMap[postType];
+  if (!segment) return '';
+
+  const questSlug = slugify(quest.title);
+  const baseQuest = `Q:${questSlug}`;
+
+  if (segment === 'T') {
+    const count = posts.filter(p => p.questId === quest.id && p.nodeId && typeMap[p.type] === 'T').length;
+    return `${baseQuest}:T${zeroPad(count)}`;
+  }
+
+  const basePath = parentPost?.nodeId || baseQuest;
+  const prefix = `${basePath}:${segment}`;
+  const count = posts.filter(p => p.questId === quest.id && p.nodeId?.startsWith(prefix) && typeMap[p.type] === segment).length;
+  return `${prefix}${zeroPad(count)}`;
+};

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -14,6 +14,7 @@ jest.mock('../src/models/stores', () => ({
   postsStore: { read: jest.fn(() => []), write: jest.fn() },
   usersStore: { read: jest.fn(() => []), write: jest.fn() },
   reactionsStore: { read: jest.fn(() => []), write: jest.fn() },
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
 const app = express();

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -16,6 +16,14 @@ export const fetchPostById = async (id: string): Promise<Post> => {
 };
 
 /**
+ * 📃 Fetch all posts
+ */
+export const fetchAllPosts = async (): Promise<Post[]> => {
+  const res = await axiosWithAuth.get(BASE_URL);
+  return res.data;
+};
+
+/**
  * ➕ Add a new post
  * @param data - Partial post data
  */

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -3,6 +3,7 @@ import { fetchBoard, fetchBoardItems } from '../../api/board';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSocketListener } from '../../hooks/useSocket';
 import { getDisplayTitle } from '../../utils/displayUtils';
+import { getRenderableBoardItems } from '../../utils/boardUtils';
 import { useBoardContext } from '../../contexts/BoardContext';
 
 import EditBoard from './EditBoard';
@@ -38,7 +39,7 @@ const Board: React.FC<BoardProps> = ({
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
 
   const { canEditBoard } = usePermissions();
-  const { setSelectedBoard } = useBoardContext();
+  const { setSelectedBoard, appendToBoard } = useBoardContext();
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<'createdAt' | 'displayTitle'>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
@@ -117,9 +118,37 @@ const Board: React.FC<BoardProps> = ({
       });
   }, [items, filter, filterText, sortKey, sortOrder]);
 
+  const renderableItems = useMemo(
+    () => getRenderableBoardItems(filteredItems),
+    [filteredItems]
+  );
+
+  const questItems = useMemo(
+    () => renderableItems.filter((it) => 'headPostId' in it),
+    [renderableItems]
+  );
+  const singleQuest = questItems.length === 1 ? (questItems[0] as Quest) : null;
+  const graphEligible = singleQuest !== null;
+
+  const graphItems = useMemo(() => {
+    if (!graphEligible) return renderableItems;
+    const qid = singleQuest!.id;
+    return renderableItems.filter(
+      (item) =>
+        'headPostId' in item ||
+        (item as Post).questId === qid ||
+        (item as Post).linkedItems?.some(
+          (l) => l.itemType === 'quest' && l.itemId === qid
+        )
+    );
+  }, [renderableItems, graphEligible, singleQuest]);
+
   const handleAdd = async (item: Post | Quest) => {
     setItems((prev) => [item as Post, ...prev]);
     setShowCreateForm(false);
+    if (board) {
+      appendToBoard(board.id, item as any);
+    }
   };
 
   const resolvedStructure: BoardLayout =
@@ -181,7 +210,7 @@ const Board: React.FC<BoardProps> = ({
             onChange={(e) => setViewMode(e.target.value as BoardLayout)}
             options={[
               { value: 'grid', label: 'Grid' },
-              { value: 'graph', label: 'Graph' },
+              ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
               { value: 'thread', label: 'Timeline' },
             ]}
           />
@@ -233,7 +262,7 @@ const Board: React.FC<BoardProps> = ({
         </div>
       ) : (
         <Layout
-          items={filteredItems}
+          items={resolvedStructure === 'graph' ? graphItems : renderableItems}
           compact={compact}
           user={user}
           onScrollEnd={onScrollEnd}

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -146,14 +146,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           <FaReply /> {showReplyPanel ? 'Cancel' : 'Reply'}
         </button>
 
-        {typeof replyCount === 'number' && replyCount > 0 && (
-          <button
-            onClick={onToggleReplies}
-            className="text-xs text-blue-600 underline"
-          >
-            {showReplies ? 'Hide Replies' : `View Replies (${replyCount})`}
-          </button>
-        )}
       </div>
 
       {showReplyPanel && (

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -108,10 +108,11 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
 
       <FormSection title="Linked Items">
         <LinkControls
-          label="Link to quests/projects"
+          label="Item"
           value={[]}
           onChange={(newLinks: LinkedItem[]) => setLinkedItems(newLinks)}
           allowCreateNew={false}
+          itemTypes={['quest', 'post']}
         />
         {linkedItems.length > 0 && (
           <ul className="list-disc pl-6 mt-2 text-sm text-blue-700">

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -32,3 +32,39 @@ export const getBoardIdFromParams = (
   const { questId, type } = input;
   return `${type}-${questId}`;
 };
+
+/**
+ * Filter and deduplicate board items before rendering.
+ * - Removes duplicate IDs
+ * - Hides posts linked to quests that already appear on the board
+ */
+export const getRenderableBoardItems = (
+  items: Array<any>
+): Array<any> => {
+  const seen = new Set<string>();
+  const questIds = new Set<string>();
+  items.forEach((item) => {
+    if ('headPostId' in item) {
+      questIds.add(item.id);
+    }
+  });
+
+  const result: any[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+
+    if (!('headPostId' in item)) {
+      const questId = item.questId;
+      const linkedQuest = item.linkedItems?.find(
+        (l: any) => l.itemType === 'quest' && questIds.has(l.itemId)
+      );
+      if ((questId && questIds.has(questId)) || linkedQuest) {
+        continue;
+      }
+    }
+
+    result.push(item);
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary
- support fetching all posts
- extend LinkControls with search across posts and quests
- allow linking posts or quests when creating or editing posts
- toggle link editor in PostCard to add links
- fix QuestCard link rendering when repoUrl is missing
- support graph-only view when a board contains a single quest
- collapse quest cards by default and expand to map view on click
- add Node ID generator
- persist board items when posts are added
- add See Replies button and metadata labels on posts
- filter duplicate board items and hide quest-linked posts
- add quest posts API endpoint
- **fix posts route order** and **improve link dropdown filters**
- document inline linking in README
- **link dropdowns can sort by node ID**
- **quest cards display link controls**

## Testing
- `npm test --prefix ethos-backend --silent`


------
https://chatgpt.com/codex/tasks/task_e_6844e9831f6c832fbbb497ae9ec16c2d