### PR TITLE
Improve backend logging for easier testing

### DIFF
--- a/ethos-backend/src/middleware/cookieAuth.ts
+++ b/ethos-backend/src/middleware/cookieAuth.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+import { error } from '../utils/logger';
 
 dotenv.config();
 
@@ -16,7 +17,7 @@ export const cookieAuth: RequestHandler = (req, res, next) => {
     (req as any).user = decoded; // Extend `req` to include `user`
     return next(); // ✅ properly ends function with void return
   } catch (err) {
-    console.error('[COOKIE AUTH ERROR]', err);
+    error('[COOKIE AUTH ERROR]', err);
     res.status(403).json({ error: 'Invalid or expired token' });
     return; // ✅ ensures return type is void
   }

--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -15,6 +15,7 @@ import { hashPassword, comparePasswords } from '../utils/passwordUtils';
 import type { User } from '../types/api';
 
 import { asyncHandler } from '../utils/asyncHandler';
+import { error } from '../utils/logger';
 
 import type { AuthenticatedRequest } from '../types/express';
 
@@ -86,7 +87,7 @@ router.post( '/forgot-password', asyncHandler(async (req: Request, res: Response
     await sendResetEmail(email, resetUrl);
     res.json({ message: 'Password reset link sent' });
   } catch (err) {
-    console.error('[EMAIL ERROR]', err);
+    error('[EMAIL ERROR]', err);
     res.status(500).json({ error: 'Failed to send reset email' });
   }
 }));
@@ -149,7 +150,7 @@ router.post('/register', asyncHandler(async (req: Request, res: Response) => {
 
     res.status(201).json({ message: 'User registered', userId: newUser.id });
   } catch (err) {
-    console.error('[REGISTER ERROR]', err);
+    error('[REGISTER ERROR]', err);
     res.status(500).json({ error: 'Registration failed' });
   }
 }));
@@ -176,7 +177,7 @@ router.post('/login', asyncHandler( async (req: Request, res: Response) => {
 
     res.json({ message: 'Login successful', accessToken });
   } catch (err) {
-    console.error('[LOGIN ERROR]', err);
+    error('[LOGIN ERROR]', err);
     res.status(500).json({ error: 'Internal error' });
   }
 }));

--- a/ethos-backend/src/routes/gitRoutes.ts
+++ b/ethos-backend/src/routes/gitRoutes.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import path from 'path';
+import { error } from '../utils/logger';
 import { authMiddleware } from '../middleware/authMiddleware';
 import {
   getQuestRepoMeta,
@@ -34,7 +35,7 @@ router.get(
       const meta = await getQuestRepoMeta(req.params.questId);
       res.json(meta);
     } catch (err) {
-      console.error('[GIT STATUS ERROR]', err);
+      error('[GIT STATUS ERROR]', err);
       res.status(500).json({ error: 'Failed to get git status' });
     }
   }
@@ -56,7 +57,7 @@ router.post(
       const meta = await connectRepo(questId, repoUrl, branch);
       res.json(meta);
     } catch (err) {
-      console.error('[GIT CONNECT ERROR]', err);
+      error('[GIT CONNECT ERROR]', err);
       res.status(500).json({ error: 'Failed to connect git repo' });
     }
   }
@@ -76,7 +77,7 @@ router.post(
       const meta = await syncRepo(req.body.questId);
       res.json(meta);
     } catch (err) {
-      console.error('[GIT SYNC ERROR]', err);
+      error('[GIT SYNC ERROR]', err);
       res.status(500).json({ error: 'Git sync failed' });
     }
   }
@@ -96,7 +97,7 @@ router.delete(
       const result = await removeRepo(req.params.questId);
       res.json(result);
     } catch (err) {
-      console.error('[GIT DISCONNECT ERROR]', err);
+      error('[GIT DISCONNECT ERROR]', err);
       res.status(500).json({ error: 'Failed to remove git repo' });
     }
   }
@@ -116,7 +117,7 @@ router.post(
       const archive = await archiveHistory(req.body.questId);
       res.json(archive);
     } catch (err) {
-      console.error('[GIT ARCHIVE ERROR]', err);
+      error('[GIT ARCHIVE ERROR]', err);
       res.status(500).json({ error: 'Failed to archive git history' });
     }
   }
@@ -142,7 +143,7 @@ router.get(
       );
       res.json(diff);
     } catch (err) {
-      console.error('[GIT DIFF ERROR]', err);
+      error('[GIT DIFF ERROR]', err);
       res.status(500).json({ error: 'Failed to fetch git diff' });
     }
   }
@@ -162,7 +163,7 @@ router.get(
       const fileTree = await getFileTree(req.params.questId);
       res.json(fileTree);
     } catch (err) {
-      console.error('[GIT FILES ERROR]', err);
+      error('[GIT FILES ERROR]', err);
       res.status(500).json({ error: 'Failed to fetch git file tree' });
     }
   }
@@ -182,7 +183,7 @@ router.get(
       const commits = await getCommits(req.params.questId);
       res.json(commits);
     } catch (err) {
-      console.error('[GIT COMMITS ERROR]', err);
+      error('[GIT COMMITS ERROR]', err);
       res.status(500).json({ error: 'Failed to fetch git commit history' });
     }
   }
@@ -198,7 +199,7 @@ router.post('/create', authMiddleware, async (
     const repo = await initRepo(req.body.questId, req.body.name);
     res.json(repo);
   } catch (err) {
-    console.error('[GIT CREATE ERROR]', err);
+    error('[GIT CREATE ERROR]', err);
     res.status(500).json({ error: 'Failed to create repo' });
   }
 });
@@ -214,7 +215,7 @@ router.post('/folders', authMiddleware, async (
     const repo = await createFolder(req.body.questId, req.body.folderPath);
     res.json(repo);
   } catch (err) {
-    console.error('[GIT CREATE FOLDER ERROR]', err);
+    error('[GIT CREATE FOLDER ERROR]', err);
     res.status(500).json({ error: 'Failed to create folder' });
   }
 });
@@ -230,7 +231,7 @@ router.post('/files', authMiddleware, async (
     const repo = await createFile(req.body.questId, req.body.filePath, req.body.content || '');
     res.json(repo);
   } catch (err) {
-    console.error('[GIT CREATE FILE ERROR]', err);
+    error('[GIT CREATE FILE ERROR]', err);
     res.status(500).json({ error: 'Failed to create file' });
   }
 });
@@ -246,7 +247,7 @@ router.put('/files', authMiddleware, async (
     const repo = await updateFile(req.body.questId, req.body.filePath, req.body.content);
     res.json(repo);
   } catch (err) {
-    console.error('[GIT UPDATE FILE ERROR]', err);
+    error('[GIT UPDATE FILE ERROR]', err);
     res.status(500).json({ error: 'Failed to update file' });
   }
 });
@@ -263,7 +264,7 @@ router.get('/download/:questId', authMiddleware, async (
     await downloadRepo(req.params.questId, zipPath);
     res.download(zipPath);
   } catch (err) {
-    console.error('[GIT DOWNLOAD ERROR]', err);
+    error('[GIT DOWNLOAD ERROR]', err);
     res.status(500).json({ error: 'Failed to download repo' });
   }
 });

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
 import type { CorsOptions } from 'cors';
+import { requestLogger, info } from './utils/logger';
 
 import authRoutes from './routes/authRoutes';
 import gitRoutes from './routes/gitRoutes';
@@ -45,6 +46,7 @@ const corsOptions: CorsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 app.use(cookieParser());
+app.use(requestLogger);
 
 /**
  * API Routes
@@ -68,6 +70,6 @@ const PORT: number = parseInt(process.env.PORT || '3001', 10);
  * Logs a message with the active port and frontend origin
  */
 app.listen(PORT, () => {
-  console.log(`🚀 Backend server running at http://localhost:${PORT}`);
-  console.log(`🌐 Accepting requests from: ${CLIENT_URL}`);
+  info(`🚀 Backend server running at http://localhost:${PORT}`);
+  info(`🌐 Accepting requests from: ${CLIENT_URL}`);
 });

--- a/ethos-backend/src/utils/logger.ts
+++ b/ethos-backend/src/utils/logger.ts
@@ -1,0 +1,24 @@
+import { RequestHandler } from 'express';
+
+/**
+ * Simple logging helpers for consistent server logs.
+ */
+export const info = (...args: unknown[]): void => {
+  console.log('[INFO]', ...args);
+};
+
+export const warn = (...args: unknown[]): void => {
+  console.warn('[WARN]', ...args);
+};
+
+export const error = (...args: unknown[]): void => {
+  console.error('[ERROR]', ...args);
+};
+
+/**
+ * Express middleware that logs the incoming request method and URL.
+ */
+export const requestLogger: RequestHandler = (req, _res, next) => {
+  info(`${req.method} ${req.originalUrl}`);
+  next();
+};


### PR DESCRIPTION
## Summary
- create logger utility with request logger middleware
- use request logger middleware in server startup
- replace console.error calls with logger.error in backend

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs'...)*

------
https://chatgpt.com/codex/tasks/task_e_6845d8a27484832f8156527749c328f6