### PR TITLE
Fix linked items persistence on edit post

### DIFF
--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -109,7 +109,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       <FormSection title="Linked Items">
         <LinkControls
           label="Item"
-          value={[]}
+          value={linkedItems}
           onChange={(newLinks: LinkedItem[]) => setLinkedItems(newLinks)}
           allowCreateNew={false}
           itemTypes={['quest', 'post']}


### PR DESCRIPTION
## Summary
- ensure linked items are loaded into LinkControls when editing a post
- update LinkControls on change so edits persist

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run build` *(fails: tsc errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb4ce860832fa901a749a9c88945