### PR TITLE
Add post quote and link menu actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It’s a new operating system for solving problems together.
 * **Boards & Threads** – Navigate via visual boards, timelines, or threaded views.
 * **Adventure Guilds** – Collaborate through guilds with defined roles and ranks.
 * **Quest Logs** – Track the history, updates, and team discussions around any quest.
+* **Quick Sharing** – Use the action menu to copy post quotes or grab a direct link.
 * **Visual Quest Maps** – Tree, grid, or list views of how solutions evolve.
 * **Freelancer-Oriented** – Designed to support real client work, solo projects, and peer-based micro-teams.
 * **Web3-Ready (Future)** – Enable decentralized contracts and token-based achievements.

--- a/ethos-backend/package-lock.json
+++ b/ethos-backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "archiver": "^6.0.2",
+        "bcryptjs": "^3.0.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -29,7 +30,6 @@
         "@types/node": "^22.15.30",
         "@types/nodemailer": "^6.4.17",
         "@types/supertest": "^2.0.12",
-        "bcryptjs": "^3.0.2",
         "jest": "^29.7.0",
         "supertest": "^6.3.4",
         "ts-jest": "^29.3.4",
@@ -1796,7 +1796,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
       "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"

--- a/ethos-backend/package.json
+++ b/ethos-backend/package.json
@@ -15,6 +15,7 @@
   "type": "commonjs",
   "dependencies": {
     "archiver": "^6.0.2",
+    "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -173,6 +173,7 @@ const PostCard: React.FC<PostCardProps> = ({
           canEdit={canEdit}
           onEdit={() => setEditMode(true)}
           onDelete={() => onDelete?.(post.id)}
+          content={post.content}
           permalink={`${window.location.origin}/posts/${post.id}`}
         />
       </div>

--- a/ethos-frontend/src/components/ui/ActionMenu.tsx
+++ b/ethos-frontend/src/components/ui/ActionMenu.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
-  FaEllipsisH, FaEdit, FaTrash, FaArchive, FaLink
+  FaEllipsisH,
+  FaEdit,
+  FaTrash,
+  FaArchive,
+  FaLink,
+  FaCopy,
 } from 'react-icons/fa';
 import { removePost, archivePost } from '../../api/post';
 import { removeQuestById, archiveQuestById } from '../../api/quest';
@@ -14,6 +19,7 @@ interface ActionMenuProps {
   onDelete?: () => void;
   onArchived?: () => void;
   permalink?: string;
+  content?: string;
   boardId?: string;
   className?: string;
 }
@@ -31,6 +37,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   onDelete,
   onArchived,
   permalink,
+  content,
   boardId,
   className = '',
 }) => {
@@ -94,6 +101,20 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
     setShowMenu(false);
   };
 
+  const handleCopyQuote = () => {
+    if (!content) return;
+    navigator.clipboard.writeText(content);
+    alert('Quote copied!');
+    setShowMenu(false);
+  };
+
+  const handleLinkToPost = () => {
+    if (!permalink) return;
+    navigator.clipboard.writeText(permalink);
+    alert(`Link to post ${id} copied!`);
+    setShowMenu(false);
+  };
+
   return (
     <div ref={menuRef} className={`relative ${className}`}>
       <button onClick={() => setShowMenu(!showMenu)} aria-label="More options">
@@ -117,6 +138,22 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
                 <FaArchive className="inline mr-2" /> {isArchiving ? 'Archiving…' : 'Archive'}
               </button>
             </>
+          )}
+          {content && (
+            <button
+              onClick={handleCopyQuote}
+              className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+            >
+              <FaCopy className="inline mr-2" /> Copy Quote
+            </button>
+          )}
+          {permalink && type === 'post' && (
+            <button
+              onClick={handleLinkToPost}
+              className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+            >
+              <FaLink className="inline mr-2" /> Link to This Post
+            </button>
           )}
           <button onClick={handleCopyLink} className="block w-full text-left px-4 py-2 hover:bg-gray-100">
             <FaLink className="inline mr-2" /> Copy Link


### PR DESCRIPTION
## Summary
- extend `ActionMenu` with copy quote and link-to-post options
- wire up new actions from `PostCard`
- document post sharing in README
- add missing `bcryptjs` dependency so backend tests pass

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6845eb563eb0832f9a90ed3becf53754