### PR TITLE
Fix duplicate declaration

### DIFF
--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -146,11 +146,6 @@ const LinkControls: React.FC<LinkControlsProps> = ({
     if (sortBy === 'node') return (a.nodeId || '').localeCompare(b.nodeId || '');
     return a.label.localeCompare(b.label);
   });
-  const filtered = allOptions.filter(
-    (o) =>
-      o.label.toLowerCase().includes(search.toLowerCase()) ||
-      o.value.includes(search)
-  );
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## Summary
- remove redundant `filtered` variable to fix TypeScript build error

## Testing
- `npx jest -c jest.config.cjs` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` in backend *(fails to run tests due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6845eec36144832fbdb90da1824bac5d