### PR TITLE
Add hideControls prop to Board component

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -29,6 +29,7 @@ const Board: React.FC<BoardProps> = ({
   compact = false,
   showCreate = true,
   filter = {},
+  hideControls = false,
   onScrollEnd,
   loading: loadingMore = false,
   quest,
@@ -190,37 +191,43 @@ const Board: React.FC<BoardProps> = ({
         </h2>
 
         <div className="flex gap-2 flex-wrap items-center">
-          <Input
-            value={filterText}
-            onChange={(e) => setFilterText(e.target.value)}
-            placeholder="Filter..."
-            className="w-40 text-sm"
-          />
-          <Select
-            value={sortKey}
-            onChange={(e) => setSortKey(e.target.value as 'createdAt' | 'displayTitle')}
-            options={[
-              { value: 'createdAt', label: 'Date' },
-              { value: 'displayTitle', label: 'Node Label' },
-            ]}
-          />
-          <Select
-            value={sortOrder}
-            onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-            options={[
-              { value: 'asc', label: 'Asc' },
-              { value: 'desc', label: 'Desc' },
-            ]}
-          />
-          <Select
-            value={resolvedStructure}
-            onChange={(e) => setViewMode(e.target.value as BoardLayout)}
-            options={[
-              { value: 'grid', label: 'Grid' },
-              ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
-              { value: 'thread', label: 'Timeline' },
-            ]}
-          />
+          {!hideControls && (
+            <>
+              <Input
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                placeholder="Filter..."
+                className="w-40 text-sm"
+              />
+              <Select
+                value={sortKey}
+                onChange={(e) =>
+                  setSortKey(e.target.value as 'createdAt' | 'displayTitle')
+                }
+                options={[
+                  { value: 'createdAt', label: 'Date' },
+                  { value: 'displayTitle', label: 'Node Label' },
+                ]}
+              />
+              <Select
+                value={sortOrder}
+                onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
+                options={[
+                  { value: 'asc', label: 'Asc' },
+                  { value: 'desc', label: 'Desc' },
+                ]}
+              />
+              <Select
+                value={resolvedStructure}
+                onChange={(e) => setViewMode(e.target.value as BoardLayout)}
+                options={[
+                  { value: 'grid', label: 'Grid' },
+                  ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
+                  { value: 'thread', label: 'Timeline' },
+                ]}
+              />
+            </>
+          )}
           {editable && viewMode && (
             <Button variant="ghost" size="sm" onClick={() => setViewMode(null)}>
               Reset View

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -90,6 +90,7 @@ const HomePage: React.FC = () => {
             layout="grid"
             title="🧭 Latest Posts"
             user={user as User}
+            hideControls
             filter={{
               visibility: 'public' satisfies Visibility,
               type: 'free_speech' satisfies PostType,

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -71,6 +71,7 @@ export interface BoardProps {
   onScrollEnd?: () => void;
   loading?: boolean;
   quest?: Quest;
+  hideControls?: boolean;
 }
 
 /** Props for the EditBoard component */


### PR DESCRIPTION
## Summary
- add `hideControls` to `BoardProps`
- support `hideControls` in `Board` UI
- use the flag on the home page for the default feed board

## Testing
- `npm test -- --config jest.config.cjs` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_6846024b8414832fb8c5eea679235f53