### PR TITLE
Add new home page boards and hideControls prop

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -32,6 +32,7 @@ const Board: React.FC<BoardProps> = ({
   onScrollEnd,
   loading: loadingMore = false,
   quest,
+  hideControls = false,
 }) => {
   const [board, setBoard] = useState<BoardData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -190,37 +191,41 @@ const Board: React.FC<BoardProps> = ({
         </h2>
 
         <div className="flex gap-2 flex-wrap items-center">
-          <Input
-            value={filterText}
-            onChange={(e) => setFilterText(e.target.value)}
-            placeholder="Filter..."
-            className="w-40 text-sm"
-          />
-          <Select
-            value={sortKey}
-            onChange={(e) => setSortKey(e.target.value as 'createdAt' | 'displayTitle')}
-            options={[
-              { value: 'createdAt', label: 'Date' },
-              { value: 'displayTitle', label: 'Node Label' },
-            ]}
-          />
-          <Select
-            value={sortOrder}
-            onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-            options={[
-              { value: 'asc', label: 'Asc' },
-              { value: 'desc', label: 'Desc' },
-            ]}
-          />
-          <Select
-            value={resolvedStructure}
-            onChange={(e) => setViewMode(e.target.value as BoardLayout)}
-            options={[
-              { value: 'grid', label: 'Grid' },
-              ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
-              { value: 'thread', label: 'Timeline' },
-            ]}
-          />
+          {!hideControls && (
+            <>
+              <Input
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                placeholder="Filter..."
+                className="w-40 text-sm"
+              />
+              <Select
+                value={sortKey}
+                onChange={(e) => setSortKey(e.target.value as 'createdAt' | 'displayTitle')}
+                options={[
+                  { value: 'createdAt', label: 'Date' },
+                  { value: 'displayTitle', label: 'Node Label' },
+                ]}
+              />
+              <Select
+                value={sortOrder}
+                onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
+                options={[
+                  { value: 'asc', label: 'Asc' },
+                  { value: 'desc', label: 'Desc' },
+                ]}
+              />
+              <Select
+                value={resolvedStructure}
+                onChange={(e) => setViewMode(e.target.value as BoardLayout)}
+                options={[
+                  { value: 'grid', label: 'Grid' },
+                  ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
+                  { value: 'thread', label: 'Timeline' },
+                ]}
+              />
+            </>
+          )}
           {editable && viewMode && (
             <Button variant="ghost" size="sm" onClick={() => setViewMode(null)}>
               Reset View

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -128,6 +128,49 @@ const HomePage: React.FC = () => {
           )}
         </div>
       </section>
+
+      {/* Featured Quest */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">🌟 Featured Quest</h2>
+        {defaultFeedBoardId && (
+          <Board
+            boardId={defaultFeedBoardId}
+            layout="grid"
+            title="🌟 Featured Quest"
+            filter={{ itemType: 'quest' }}
+            hideControls
+          />
+        )}
+      </section>
+
+      {/* Request Posts */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">📨 Requests</h2>
+        {defaultFeedBoardId && (
+          <Board
+            boardId={defaultFeedBoardId}
+            layout="grid"
+            title="📨 Requests"
+            filter={{ postType: 'request' }}
+            user={user as User}
+            hideControls
+          />
+        )}
+      </section>
+
+      {/* Timeline Board */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">🧵 Timeline</h2>
+        {defaultFeedBoardId && (
+          <Board
+            boardId={defaultFeedBoardId}
+            layout="thread"
+            title="🧵 Recent Activity"
+            user={user as User}
+            hideControls
+          />
+        )}
+      </section>
     </main>
   );
 };

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -71,6 +71,11 @@ export interface BoardProps {
   onScrollEnd?: () => void;
   loading?: boolean;
   quest?: Quest;
+  /**
+   * Hide filter and sorting controls in the board header.
+   * Useful for compact or embedded boards where controls would be noisy.
+   */
+  hideControls?: boolean;
 }
 
 /** Props for the EditBoard component */


### PR DESCRIPTION
## Summary
- add `hideControls` to `BoardProps` and handle it in `Board`
- show featured quest, request board and timeline board on the home page

## Testing
- `npm test` *(fails: Missing script)*
- `cd ethos-backend && npm test` *(fails: Cannot find module bcryptjs/supertest)*
- `cd ethos-frontend && npm test` *(fails: multiple Jest configs)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6846024c7238832fb0980b8316f3692e