### PR TITLE
Fix duplicated hideControls props

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -30,11 +30,9 @@ const Board: React.FC<BoardProps> = ({
   showCreate = true,
   hideControls = false,
   filter = {},
-  hideControls = false,
   onScrollEnd,
   loading: loadingMore = false,
   quest,
-  hideControls = false,
 }) => {
   const [board, setBoard] = useState<BoardData | null>(null);
   const [loading, setLoading] = useState(true);

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -73,12 +73,6 @@ export interface BoardProps {
   onScrollEnd?: () => void;
   loading?: boolean;
   quest?: Quest;
-  /**
-   * Hide filter and sorting controls in the board header.
-   * Useful for compact or embedded boards where controls would be noisy.
-   */
-
-  hideControls?: boolean;
 }
 
 /** Props for the EditBoard component */


### PR DESCRIPTION
## Summary
- remove duplicate `hideControls` prop in `Board` component
- dedupe `hideControls` property in board types

## Testing
- `npx tsc -b` *(fails: Property errors)*
- `npm test` *(fails: multiple Jest configs)*

------
https://chatgpt.com/codex/tasks/task_e_68460a4c7fc8832fa23f8638b4972e02