### PR TITLE
Fix board sync and add post management APIs

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -280,6 +280,46 @@ router.post(
 );
 
 //
+// ✅ POST /api/posts/:id/archive – Archive a post
+//
+router.post(
+  '/:id/archive',
+  authMiddleware,
+  (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
+    const posts = postsStore.read();
+    const post = posts.find((p) => p.id === req.params.id);
+    if (!post) {
+      res.status(404).json({ error: 'Post not found' });
+      return;
+    }
+
+    post.tags = Array.from(new Set([...(post.tags || []), 'archived']));
+    postsStore.write(posts);
+    res.json({ success: true });
+  }
+);
+
+//
+// ✅ DELETE /api/posts/:id – Permanently remove a post
+//
+router.delete(
+  '/:id',
+  authMiddleware,
+  (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
+    const posts = postsStore.read();
+    const index = posts.findIndex((p) => p.id === req.params.id);
+    if (index === -1) {
+      res.status(404).json({ error: 'Post not found' });
+      return;
+    }
+
+    posts.splice(index, 1);
+    postsStore.write(posts);
+    res.json({ success: true });
+  }
+);
+
+//
 // ✅ GET /api/posts/:id/linked – Get all posts linked to a post
 //
 router.get('/:id/linked', (req: Request<{ id: string }>, res: Response) => {

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -84,8 +84,8 @@ export const fetchPostsByQuestId = async (questId: string): Promise<Post[]> => {
  * @param boardId - Board ID
  */
 export const fetchPostsByBoardId = async (boardId: string): Promise<Post[]> => {
-  const res = await axiosWithAuth.get(`/boards/${boardId}/posts`);
-  return res.data || [];
+  const res = await axiosWithAuth.get(`/boards/${boardId}/items?enrich=true`);
+  return (res.data || []).filter((item: any) => 'content' in item);
 };
 
 /**

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -81,6 +81,13 @@ const CreatePost: React.FC<CreatePostProps> = ({
           console.error('[CreatePost] Failed to persist board items:', err)
         );
       }
+      if (boards?.['my-posts'] && selectedBoard !== 'my-posts') {
+        appendToBoard('my-posts', newPost);
+        const myItems = [newPost.id, ...(boards['my-posts'].items || [])];
+        updateBoard('my-posts', { items: myItems }).catch((err) =>
+          console.error('[CreatePost] Failed to update my-posts board:', err)
+        );
+      }
       onSave?.(newPost);
     } catch (err) {
       console.error('[CreatePost] Error creating post:', err);


### PR DESCRIPTION
## Summary
- ensure new posts/quests also appear on profile boards
- implement post archive/delete endpoints
- fix API helper to fetch posts from boards

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs' / multiple Jest configs)*

------
https://chatgpt.com/codex/tasks/task_e_68463beb74d8832faa3e56566b973eb2