### PR TITLE
Fix linking of system posts

### DIFF
--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -28,7 +28,8 @@ const LinkControls: React.FC<LinkControlsProps> = ({
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [search, setSearch] = useState('');
-  const [postTypeFilter, setPostTypeFilter] = useState<'all' | 'request' | 'task' | 'log' | 'commit' | 'issue'>('all');
+  const [postTypeFilter, setPostTypeFilter] =
+    useState<'all' | 'request' | 'task' | 'log' | 'commit' | 'issue' | 'meta_system'>('all');
   const [sortBy, setSortBy] = useState<'label' | 'node'>('label');
 
   const linkTypes = ['solution', 'duplicate', 'related', 'quote', 'reference'];
@@ -37,7 +38,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      const promises = [] as PromiseSettledResult<any>[];
+      const promises: Promise<any>[] = [];
 
       if (itemTypes.includes('quest')) promises.push(fetchAllQuests());
       if (itemTypes.includes('post')) promises.push(fetchAllPosts());
@@ -155,7 +156,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
         <> 
           {itemTypes.includes('post') && (
             <div className="flex gap-1 mb-1 flex-wrap">
-              {['all', 'request', 'task', 'log', 'commit', 'issue'].map((t) => (
+              {['all', 'request', 'task', 'log', 'commit', 'issue', 'meta_system'].map((t) => (
                 <button
                   key={t}
                   type="button"

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -197,7 +197,7 @@ function requiresQuestRoles(type: PostType): boolean {
 }
 
 function showLinkControls(type: PostType): boolean {
-  return ['request', 'quest', 'task', 'log', 'commit', 'issue'].includes(type);
+  return ['request', 'quest', 'task', 'log', 'commit', 'issue', 'meta_system'].includes(type);
 }
 
 export default CreatePost;

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -206,7 +206,7 @@ const PostCard: React.FC<PostCardProps> = ({
       {renderCommitDiff()}
       {renderLinkSummary()}
 
-      {['request','quest','task','log','commit','issue'].includes(post.type) && (
+      {['request','quest','task','log','commit','issue', 'meta_system'].includes(post.type) && (
         <div className="text-xs text-gray-500 space-y-1">
           <button
             type="button"

--- a/ethos-frontend/tsconfig.test.json
+++ b/ethos-frontend/tsconfig.test.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "verbatimModuleSyntax": false,
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "@testing-library/jest-dom"],
     "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary
- allow `meta_system` posts in link filters
- show link controls for system posts when creating posts or editing posts
- add jest-dom types for tests

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend -- --config jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_6846408a7980832fa6ee13ec740e6c2e