### PR TITLE
Fix repost toggling

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -180,6 +180,27 @@ router.post(
 );
 
 //
+// ✅ DELETE /api/posts/:id/repost – Remove current user's repost
+//
+router.delete(
+  '/:id/repost',
+  authMiddleware,
+  (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
+    const posts = postsStore.read();
+    const index = posts.findIndex(
+      (p) => p.repostedFrom === req.params.id && p.authorId === req.user!.id
+    );
+    if (index === -1) {
+      res.status(404).json({ error: 'Repost not found' });
+      return;
+    }
+    const [removed] = posts.splice(index, 1);
+    postsStore.write(posts);
+    res.json({ success: true, id: removed.id });
+  }
+);
+
+//
 // ✅ GET /api/posts/:id/reposts/user – Get current user's repost of a post
 //
 router.get(

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -160,6 +160,17 @@ export const addRepost = async (post: Post): Promise<Post> => {
 };
 
 /**
+ * 🔁 Remove current user's repost of a post
+ * @param postId - Original post ID
+ */
+export const removeRepost = async (
+  postId: string
+): Promise<{ success: boolean; id: string }> => {
+  const res = await axiosWithAuth.delete(`${BASE_URL}/${postId}/repost`);
+  return res.data;
+};
+
+/**
  * 🧪 (Utility) Enrich a post client-side
  * @param post - Raw post object
  */

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -12,6 +12,7 @@ import CreatePost from '../post/CreatePost';
 import {
   updateReaction,
   addRepost,
+  removeRepost,
   fetchReactions,
   fetchRepostCount,
   fetchUserRepost,
@@ -99,14 +100,20 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     if (!user?.id || repostLoading) return;
     setRepostLoading(true);
     try {
-      const res = await addRepost(post);
-      if (res?.id) {
-        setCounts(prev => ({ ...prev, repost: prev.repost + 1 }));
-        setUserRepostId(res.id);
-        onUpdate?.(res);
+      if (userRepostId) {
+        await removeRepost(post.id);
+        setCounts(prev => ({ ...prev, repost: Math.max(0, prev.repost - 1) }));
+        setUserRepostId(null);
+      } else {
+        const res = await addRepost(post);
+        if (res?.id) {
+          setCounts(prev => ({ ...prev, repost: prev.repost + 1 }));
+          setUserRepostId(res.id);
+          onUpdate?.(res);
+        }
       }
     } catch (err) {
-      console.error('[ReactionControls] Failed to repost:', err);
+      console.error('[ReactionControls] Failed to toggle repost:', err);
     } finally {
       setRepostLoading(false);
     }


### PR DESCRIPTION
## Summary
- allow removing a repost via API
- expose `removeRepost` client helper
- toggle repost button in the UI

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'bcryptjs')*
- `npm test --prefix ethos-frontend -- --config jest.config.js` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b4133918832fa490de5bb39478eb