### PR TITLE
Add request board post type filter

### DIFF
--- a/ethos-frontend/src/components/board/PostTypeFilter.tsx
+++ b/ethos-frontend/src/components/board/PostTypeFilter.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Select from '../ui/Select';
+
+interface PostTypeFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const options = [
+  { value: '', label: 'All Posts' },
+  { value: 'quest', label: 'Quests' },
+  { value: 'request', label: 'Requests' },
+  { value: 'issue', label: 'Issues' },
+];
+
+const PostTypeFilter: React.FC<PostTypeFilterProps> = ({ value, onChange }) => {
+  return (
+    <div className="max-w-xs">
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        options={options}
+      />
+    </div>
+  );
+};
+
+export default PostTypeFilter;

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import Board from '../components/board/Board';
+import PostTypeFilter from '../components/board/PostTypeFilter';
+import { Link } from 'react-router-dom';
 
 import type { User } from '../types/userTypes';
 
 const HomePage: React.FC = () => {
   const { user, loading: authLoading } = useAuth();
+  const [postType, setPostType] = useState('');
 
   if (authLoading) {
     return (
@@ -36,14 +39,21 @@ const HomePage: React.FC = () => {
         />
       </section>
 
-      <section>
+      <section className="space-y-4">
+        <PostTypeFilter value={postType} onChange={setPostType} />
         <Board
           boardId="request-board"
           title="🙋 Requests"
           layout="grid"
           user={user as User}
           hideControls
+          filter={postType ? { postType } : {}}
         />
+        <div className="text-right">
+          <Link to="/board/request-board" className="text-blue-600 underline text-sm">
+            View full board
+          </Link>
+        </div>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- add `PostTypeFilter` component for selecting posts by type
- use filter state on home page so the request board shows chosen post types
- link to the full request board

## Testing
- `npm test -- --config jest.config.cjs` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846b41a0000832f9aee4802995eb235