### PR TITLE
Fix add item buttons on quest views

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -161,14 +161,48 @@ const QuestCard: React.FC<QuestCardProps> = ({
             )}
             <ThreadLayout contributions={logs} user={user} questId={quest.id} />
             <div className="text-right mt-2">
-              <Button size="sm" variant="secondary" onClick={() => setShowLogForm(true)}>
-                + Add Log
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowLogForm(true)}
+              >
+                + Add Item
+              </Button>
+            </div>
+        </>
+      );
+      case 'kanban':
+        return (
+          <>
+            {showTaskForm && (
+              <div className="mb-4">
+                <CreatePost
+                  initialType="task"
+                  onSave={(p) => {
+                    setLogs((prev) => [...prev, p]);
+                    setShowTaskForm(false);
+                  }}
+                  onCancel={() => setShowTaskForm(false)}
+                />
+              </div>
+            )}
+            <GridLayout
+              questId={quest.id}
+              items={logs}
+              user={user}
+              layout="kanban"
+            />
+            <div className="text-right mt-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowTaskForm(true)}
+              >
+                + Add Item
               </Button>
             </div>
           </>
         );
-      case 'kanban':
-        return <GridLayout questId={quest.id} items={logs} user={user} />;
       case 'map':
         return (
           <>
@@ -186,8 +220,12 @@ const QuestCard: React.FC<QuestCardProps> = ({
             )}
             <GraphLayout items={logs as any} user={user} />
             <div className="text-right mt-2">
-              <Button size="sm" variant="secondary" onClick={() => setShowTaskForm(true)}>
-                + Add Task
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowTaskForm(true)}
+              >
+                + Add Item
               </Button>
             </div>
           </>

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -88,6 +88,8 @@ const QuestPage: React.FC = () => {
             layout="graph"
             editable={user?.id === quest.ownerId}
             quest={quest}
+            user={user as User}
+            showCreate
           />
         ) : (
           <p className="text-sm text-gray-500">No quest map defined yet.</p>


### PR DESCRIPTION
## Summary
- show quest map board add-item button
- rename quest log/map buttons to Add Item and enable them in kanban view

## Testing
- `npm test --silent -- --config jest.config.cjs` *(fails: Test environment jsdom cannot be found / ts-jest config issue)*

------
https://chatgpt.com/codex/tasks/task_e_6846b9ef8d88832fb0cd8bbd06470696