### PR TITLE
Fix post/quest links to use ROUTES helpers

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
 import { formatDistanceToNow } from 'date-fns';
 
 import type { Post } from '../../types/postTypes';
@@ -136,7 +137,7 @@ const PostCard: React.FC<PostCardProps> = ({
         {!showFullDiff && (
           <div className="mt-1">
             <button
-              onClick={() => navigate(`/posts/${post.id}`)}
+              onClick={() => navigate(ROUTES.POST(post.id))}
               className="text-blue-600 text-xs underline"
             >
               View full file with replies
@@ -174,7 +175,7 @@ const PostCard: React.FC<PostCardProps> = ({
           onEdit={() => setEditMode(true)}
           onDelete={() => onDelete?.(post.id)}
           content={post.content}
-          permalink={`${window.location.origin}/posts/${post.id}`}
+          permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
         />
       </div>
 
@@ -191,7 +192,7 @@ const PostCard: React.FC<PostCardProps> = ({
           <>
             <MarkdownRenderer content={(post.renderedContent || post.content).slice(0, 240) + '…'} />
             <button
-              onClick={() => navigate(`/posts/${post.id}`)}
+              onClick={() => navigate(ROUTES.POST(post.id))}
               className="text-blue-600 underline text-xs ml-1"
             >
               View more
@@ -276,7 +277,7 @@ const PostCard: React.FC<PostCardProps> = ({
       {!compact && (
         <div>
           <button
-            onClick={() => navigate(`/posts/${post.id}`)}
+            onClick={() => navigate(ROUTES.POST(post.id))}
             className="text-blue-600 underline text-xs"
           >
             View details

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -4,6 +4,7 @@ import type { Quest } from '../../types/questTypes';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import { Button, PostTypeBadge, Select } from '../ui';
+import { ROUTES } from '../../constants/routes';
 import ThreadLayout from '../layout/ThreadLayout';
 import GraphLayout from '../layout/GraphLayout';
 import GridLayout from '../layout/GridLayout';
@@ -117,7 +118,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             onArchived={() => {
               console.log(`[QuestCard] Quest ${quest.id} archived`);
             }}
-            permalink={`${window.location.origin}/quests/${quest.id}`}
+            permalink={`${window.location.origin}${ROUTES.QUEST(quest.id)}`}
           />
         )}
   
@@ -128,7 +129,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             options={viewOptions}
           />
         )}
-        <Button onClick={() => navigate(`/quests/${quest.id}`)} variant="ghost">
+        <Button onClick={() => navigate(ROUTES.QUEST(quest.id))} variant="ghost">
           View details
         </Button>
   


### PR DESCRIPTION
## Summary
- use `ROUTES.POST` when linking to posts
- use `ROUTES.QUEST` when linking to quests

## Testing
- `npm test --prefix ethos-frontend -- --config jest.config.cjs` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846badca308832fa39bc53724a513e5