### PR TITLE
Fix board loading and integrate board data

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -21,6 +21,7 @@ import type { Quest } from '../../types/questTypes';
 
 const Board: React.FC<BoardProps> = ({
   boardId,
+  board: boardProp,
   title: forcedTitle,
   layout: forcedStructure,
   user,
@@ -34,7 +35,7 @@ const Board: React.FC<BoardProps> = ({
   loading: loadingMore = false,
   quest,
 }) => {
-  const [board, setBoard] = useState<BoardData | null>(null);
+  const [board, setBoard] = useState<BoardData | null>(boardProp ?? null);
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<Post[]>([]);
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
@@ -70,8 +71,16 @@ const Board: React.FC<BoardProps> = ({
         setLoading(false);
       }
     };
-    loadBoard();
-  }, [boardId]);
+
+    if (boardProp) {
+      setSelectedBoard(boardProp.id);
+      setBoard(boardProp);
+      setItems((boardProp.enrichedItems || []) as Post[]);
+      setLoading(false);
+    } else {
+      loadBoard();
+    }
+  }, [boardId, boardProp]);
 
   useSocketListener('board:update', (payload: { boardId: string }) => {
     if (!board?.id || payload.boardId !== board.id) return;

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -96,6 +96,7 @@ const BoardPage: React.FC = () => {
       </div>
 
       <Board
+        boardId={id}
         board={boardData}
         layout={boardData.layout}
         editable={editable}

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -127,6 +127,7 @@ const PostPage: React.FC = () => {
         <h2 className="text-xl font-semibold text-gray-800 mb-4">💬 Replies</h2>
         {replyBoard ? (
           <Board
+            boardId={`thread-${id}`}
             board={replyBoard}
             layout={viewMode}
             onScrollEnd={loadMoreReplies}

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -84,6 +84,7 @@ const QuestPage: React.FC = () => {
         <h2 className="text-xl font-semibold text-gray-800 mb-4">🗺 Quest Map</h2>
         {mapBoard ? (
           <Board
+            boardId={`map-${id}`}
             board={mapBoard}
             layout="graph"
             editable={user?.id === quest.ownerId}
@@ -101,6 +102,7 @@ const QuestPage: React.FC = () => {
         <h2 className="text-xl font-semibold text-gray-800 mb-4">📜 Quest Log</h2>
         {logBoard ? (
           <Board
+            boardId={`log-${id}`}
             board={logBoard}
             layout="grid"
             editable={true}


### PR DESCRIPTION
## Summary
- allow `Board` component to accept board data props
- wire up boardId in board, quest and post pages

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6846c5338e10832f8fff1b129aacc2ca