### PR TITLE
Update backend startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ VITE_API_URL=http://localhost:3001/api
 ```bash
 cd ethos-backend
 npm install
-node src/server.js
+npx ts-node src/server.ts       # or: npm run dev
 ```
+
+For production builds, run `npm run build` and then start with `node dist/server.js`.
 
 ### Running Tests
 


### PR DESCRIPTION
## Summary
- update README backend start script to use ts-node and dev mode
- mention building and starting from compiled JavaScript for production

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6846cdc3525c832fa91c5e6310f2f567