### PR TITLE
Add socket env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If the plugin cannot be found after installing, try running `npm install --legac
 
 ```env
 VITE_API_URL=http://localhost:3001/api
+VITE_SOCKET_URL=http://localhost:3001
 ```
 
 ### 3. Setup Backend

--- a/ethos-frontend/.env.example
+++ b/ethos-frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3001/api
+VITE_SOCKET_URL=http://localhost:3001

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -23,7 +23,9 @@ let socket: Socket | null = null;
  */
 export const getSocket = (): Socket => {
   if (!socket) {
-    socket = io(import.meta.env.VITE_API_URL || 'http://localhost:3001', {
+    const SOCKET_URL =
+      import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+    socket = io(SOCKET_URL, {
       autoConnect: false,
       transports: ['websocket'],
     });


### PR DESCRIPTION
## Summary
- add `.env.example` to the frontend project
- let `useSocket` use `VITE_SOCKET_URL`
- document `VITE_SOCKET_URL` in README

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend -- --config jest.config.cjs` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext')*

------
https://chatgpt.com/codex/tasks/task_e_6846cdc25408832fa6915e565a602d93