### PR TITLE
Allow createMockBoard to accept objects

### DIFF
--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -99,7 +99,7 @@ const PostPage: React.FC = () => {
 
       <section>
         <Board
-          board={createMockBoard(`post-${post.id}`, 'Post', [post.id])}
+          board={createMockBoard(`post-${post.id}`, 'Post', [post])}
           editable={false}
           compact={false}
         />

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -74,7 +74,7 @@ const QuestPage: React.FC = () => {
       {/* 🎯 Quest Summary Card */}
       <Banner quest={quest} />
       <Board
-        board={createMockBoard(`quest-${quest.id}`, 'Quest Overview', [quest.id])}
+        board={createMockBoard(`quest-${quest.id}`, 'Quest Overview', [quest])}
         editable={false}
         compact={false}
       />

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -1,5 +1,7 @@
 // src/utils/boardUtils.ts
 import type { BoardData } from '../types/boardTypes';
+import type { Post } from '../types/postTypes';
+import type { Quest } from '../types/questTypes';
 
 /**
  * Creates a mock BoardData object for temporary or display-only purposes.
@@ -13,13 +15,20 @@ import type { BoardData } from '../types/boardTypes';
 export const createMockBoard = (
   id: string,
   title: string,
-  items: (string | null)[]
+  items: Array<string | Post | Quest | null>
 ): BoardData => {
+  const itemIds = items.map((item) => {
+    if (item && typeof item === 'object') {
+      return item.id;
+    }
+    return item as string | null;
+  });
+
   return {
     id,
     title,
     layout: 'grid',
-    items,
+    items: itemIds,
     enrichedItems: items,
     createdAt: new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary
- accept `Post` and `Quest` objects in `createMockBoard`
- keep `items` as ids but expose objects in `enrichedItems`
- pass fetched `post` or `quest` objects when creating mock boards

## Testing
- `npx jest --config jest.config.cjs` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6846d37e0ce8832f80ec6890e9b17e71