### PR TITLE
Add task_edge link type

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -61,7 +61,13 @@ export type PostType = 'free_speech'
 
 export type LinkStatus = 'active' | 'solved' | 'private' | 'pending';
 
-export type LinkType = 'related' | 'solution' | 'duplicate' | 'quote' | 'reference';
+export type LinkType =
+  | 'related'
+  | 'solution'
+  | 'duplicate'
+  | 'quote'
+  | 'reference'
+  | 'task_edge';
 
 export type ItemType = 'post' | 'quest' | 'board';
 

--- a/ethos-frontend/src/components/controls/LinkControls.test.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.test.tsx
@@ -30,4 +30,22 @@ describe('LinkControls', () => {
       expect(screen.getByText(/hello world/)).toBeInTheDocument();
     });
   });
+
+  it('includes task_edge link type option', () => {
+    const linked = [
+      {
+        itemId: 'p1',
+        itemType: 'post',
+        nodeId: '',
+        linkType: 'task_edge',
+        linkStatus: 'active',
+      },
+    ];
+
+    render(<LinkControls value={linked} onChange={() => {}} itemTypes={['post']} />);
+
+    expect(
+      screen.getByText(/Link to parent \/ mark as sub-problem/)
+    ).toBeInTheDocument();
+  });
 });

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -32,7 +32,14 @@ const LinkControls: React.FC<LinkControlsProps> = ({
     useState<'all' | 'request' | 'task' | 'log' | 'commit' | 'issue' | 'meta_system'>('all');
   const [sortBy, setSortBy] = useState<'label' | 'node'>('label');
 
-  const linkTypes = ['solution', 'duplicate', 'related', 'quote', 'reference'];
+  const linkTypes = [
+    { value: 'solution', label: 'solution' },
+    { value: 'duplicate', label: 'duplicate' },
+    { value: 'related', label: 'related' },
+    { value: 'quote', label: 'quote' },
+    { value: 'reference', label: 'reference' },
+    { value: 'task_edge', label: 'Link to parent / mark as sub-problem' },
+  ];
   const linkStatuses = ['active', 'solved', 'pending', 'private'];
 
   useEffect(() => {
@@ -248,7 +255,9 @@ const LinkControls: React.FC<LinkControlsProps> = ({
                   className="border rounded px-1 py-0.5"
                 >
                   {linkTypes.map((t) => (
-                    <option key={t} value={t}>{t}</option>
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
                   ))}
                 </select>
 

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -121,7 +121,13 @@ export interface LinkedItem {
   cascadeSolution?: boolean;   // Triggers downstream propagation
 }
 
-export type LinkType = 'related' | 'solution' | 'duplicate' | 'quote' | 'reference';
+export type LinkType =
+  | 'related'
+  | 'solution'
+  | 'duplicate'
+  | 'quote'
+  | 'reference'
+  | 'task_edge';
 export type LinkStatus = 'active' | 'solved' | 'private' | 'pending';
 
 /**


### PR DESCRIPTION
## Summary
- extend `LinkType` with a `task_edge` option for both backend and frontend
- allow selecting the new link type via `LinkControls`
- show it in the dropdown as "Link to parent / mark as sub-problem"
- test presence of the new option

## Testing
- `npm test -- --config jest.config.js --silent` *(fails: jest-environment-jsdom not found)*
- `npm test --silent` in `ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6846d3862b4c832f9af7ad133009b41b