### PR TITLE
Add dark mode theme with ThemeProvider

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route } from 'react-router-dom';
 import { ROUTES } from './constants/routes';
 import { AuthProvider } from './contexts/AuthContext';
 import { BoardProvider } from './contexts/BoardContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './utils/queryClient';
 import { TimelineProvider } from './contexts/TimelineContext';
@@ -37,13 +38,14 @@ const ResetPassword = lazy(() => import('./pages/ResetPassword'));
  */
 const App: React.FC = () => {
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <TimelineProvider>
-          <BoardProvider>
-            <div className="min-h-screen flex flex-col bg-white text-gray-900">
-              {/* Top-level navigation */}
-              <NavBar />
+    <ThemeProvider>
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <TimelineProvider>
+            <BoardProvider>
+              <div className="min-h-screen flex flex-col bg-white text-gray-900">
+                {/* Top-level navigation */}
+                <NavBar />
 
               <main className="flex-1 w-full">
                 {/* Suspense fallback while lazy routes are loading */}
@@ -68,11 +70,12 @@ const App: React.FC = () => {
                 </Routes>
               </Suspense>
             </main>
-          </div>
-          </BoardProvider>
-        </TimelineProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+              </div>
+            </BoardProvider>
+          </TimelineProvider>
+        </QueryClientProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 };
 

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -184,7 +184,7 @@ const Board: React.FC<BoardProps> = ({
   }[resolvedStructure] ?? GridLayout;
 
   if (loading) {
-    return <div className="text-gray-500 p-4">Loading board...</div>;
+    return <div className="text-gray-500 dark:text-gray-400 p-4">Loading board...</div>;
   }
 
   if (!board) {
@@ -195,7 +195,7 @@ const Board: React.FC<BoardProps> = ({
     <div className="space-y-4">
       {/* Board Header */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
-        <h2 className="text-xl font-semibold text-gray-800">
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">
           {forcedTitle || board.title || 'Board'}
         </h2>
 
@@ -255,7 +255,7 @@ const Board: React.FC<BoardProps> = ({
 
       {/* Create Post Form */}
       {showCreate && showCreateForm && (
-        <div className="border rounded-lg p-4 bg-white shadow">
+        <div className="border rounded-lg p-4 bg-white dark:bg-gray-800 shadow">
           <CreatePost
             onSave={handleAdd}
             onCancel={() => setShowCreateForm(false)}
@@ -265,7 +265,7 @@ const Board: React.FC<BoardProps> = ({
 
       {/* Edit Board Form */}
       {editMode ? (
-        <div className="border rounded-lg p-4 bg-white shadow">
+        <div className="border rounded-lg p-4 bg-white dark:bg-gray-800 shadow">
           <EditBoard
             board={board}
             onCancel={() => setEditMode(false)}

--- a/ethos-frontend/src/components/layout/ThreadLayout.tsx
+++ b/ethos-frontend/src/components/layout/ThreadLayout.tsx
@@ -56,7 +56,7 @@ const ThreadLayout: React.FC<ThreadLayoutProps> = ({
         return (
           <div key={contribution.id} className={`${alignmentClass} max-w-2xl w-full`}>
             <div
-              className="cursor-pointer hover:bg-gray-50 rounded"
+              className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 rounded"
               onClick={() => toggleExpand(contribution.id)}
             >
               <ContributionCard

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -75,9 +75,9 @@ const PostCard: React.FC<PostCardProps> = ({
     const quote = post.repostedFrom;
     if (!quote?.originalContent) return null;
     return (
-      <blockquote className="border-l-4 pl-4 text-gray-500 italic bg-gray-50 rounded">
+      <blockquote className="border-l-4 pl-4 text-gray-500 dark:text-gray-400 italic bg-gray-50 dark:bg-gray-700 rounded">
         “{quote.originalContent.length > 180 ? quote.originalContent.slice(0, 180) + '…' : quote.originalContent}”
-        <div className="text-xs mt-1 text-gray-400">
+        <div className="text-xs mt-1 text-gray-400 dark:text-gray-500">
           — @{quote.username || 'unknown'}
         </div>
       </blockquote>
@@ -114,9 +114,9 @@ const PostCard: React.FC<PostCardProps> = ({
     }
 
     return (
-      <div className="text-sm bg-gray-50 rounded p-2 font-mono border">
+      <div className="text-sm bg-gray-50 dark:bg-gray-900 rounded p-2 font-mono border">
         {post.commitSummary && (
-          <div className="mb-1 text-gray-700 italic">{post.commitSummary}</div>
+          <div className="mb-1 text-gray-700 dark:text-gray-300 italic">{post.commitSummary}</div>
         )}
         {!showFullDiff && (
           <div className="mb-2">
@@ -129,7 +129,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {visibleLines.map((line, idx) => (
             <div key={idx} className={
               line.startsWith('+') ? 'text-green-600' :
-              line.startsWith('-') ? 'text-red-600' : 'text-gray-800'}>
+              line.startsWith('-') ? 'text-red-600' : 'text-gray-800 dark:text-gray-200'}>
               {line}
             </div>
           ))}
@@ -162,8 +162,8 @@ const PostCard: React.FC<PostCardProps> = ({
   }
 
   return (
-    <div className="relative border rounded bg-white shadow-sm p-4 space-y-3">
-      <div className="flex justify-between text-sm text-gray-500">
+    <div className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100">
+      <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />
           <span>{timestamp}</span>
@@ -180,14 +180,14 @@ const PostCard: React.FC<PostCardProps> = ({
       </div>
 
       {post.linkedNodeId && post.author?.username && (
-        <div className="text-xs text-gray-500 italic">
+        <div className="text-xs text-gray-500 dark:text-gray-400 italic">
           @{post.author.username} committed changes to <strong>{post.linkedNodeId}</strong> {timestamp}
         </div>
       )}
 
       {renderRepostInfo()}
 
-      <div className="text-sm text-gray-800">
+      <div className="text-sm text-gray-800 dark:text-gray-200">
         {compact && (post.renderedContent || post.content).length > 240 ? (
           <>
             <MarkdownRenderer content={(post.renderedContent || post.content).slice(0, 240) + '…'} />
@@ -208,7 +208,7 @@ const PostCard: React.FC<PostCardProps> = ({
       {renderLinkSummary()}
 
       {['request','quest','task','log','commit','issue', 'meta_system'].includes(post.type) && (
-        <div className="text-xs text-gray-500 space-y-1">
+        <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
           <button
             type="button"
             onClick={() => setShowLinkEditor((v) => !v)}
@@ -287,7 +287,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
       {replies.length > 0 && showReplies && (
         <div className="mt-2 space-y-2 border-l-2 border-blue-200 pl-4">
-          {loadingReplies && <p className="text-xs text-gray-400">Loading replies…</p>}
+          {loadingReplies && <p className="text-xs text-gray-400 dark:text-gray-500">Loading replies…</p>}
           {replyError && <p className="text-xs text-red-500">{replyError}</p>}
           {replies.map((r) => (
             <PostCard

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -84,8 +84,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const renderHeader = () => (
     <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4">
       <div className="space-y-1">
-        <h2 className="text-xl font-bold text-gray-800">{questData.title}</h2>
-        <div className="flex items-center gap-2 text-sm text-gray-600">
+        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">{questData.title}</h2>
+        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
           <PostTypeBadge type="quest" />
           <span>{questData.createdAt?.slice(0, 10)}</span>
           {questData.gitRepo?.repoUrl && (
@@ -237,9 +237,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
   };
 
   return (
-    <div className="border rounded-lg shadow bg-white p-6">
+    <div className="border rounded-lg shadow bg-white dark:bg-gray-800 p-6 text-gray-900 dark:text-gray-100">
       {renderHeader()}
-      <div className="text-xs text-gray-500 space-y-1 mb-2">
+      <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1 mb-2">
         <button
           type="button"
           onClick={() => setShowLinkEditor((v) => !v)}

--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface ThemeContextValue {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = localStorage.getItem('theme');
+    return stored === 'dark' ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error('useTheme must be used within a ThemeProvider');
+  return context;
+};

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -1,13 +1,16 @@
 @import "tailwindcss";
-/* Import Tailwind base styles */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Custom theme extension fallback for bg-soft and text-primary */
 :root {
-  --bg-soft: #f9fafb; /* light gray background */
-  --text-primary: #1f2937; /* slate-800 */
+  --bg-soft: #f9fafb;
+  --text-primary: #1f2937;
+}
+
+.dark {
+  --bg-soft: #1f2937;
+  --text-primary: #f9fafb;
 }
 
 html, body {

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: 'class',
     content: [
       "./index.html",
       "./src/**/*.{js,ts,jsx,tsx}"
@@ -14,6 +15,8 @@ module.exports = {
           primary: "#111827",
           accent: "#4F46E5",
           soft: "#F3F4F6",
+          "primary-dark": "#f9fafb",
+          "soft-dark": "#1f2937",
         },
         borderRadius: {
           xl: "1rem",


### PR DESCRIPTION
## Summary
- implement `ThemeProvider` and `useTheme` hook with localStorage persistence
- enable dark mode in Tailwind and base styles
- wrap the application in `ThemeProvider`
- apply `dark:` styles to Board, QuestCard, PostCard and ThreadLayout

## Testing
- `npm test -- --config jest.config.cjs` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5218e34832fa48c08870816c2ed