### PR TITLE
Add theme context with dark mode switch

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { BoardProvider } from './contexts/BoardContext';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './utils/queryClient';
 import { TimelineProvider } from './contexts/TimelineContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 import NavBar from './components/ui/NavBar';
 import PrivateRoute from './routes/ProtectedRoute';
@@ -41,7 +42,8 @@ const App: React.FC = () => {
       <QueryClientProvider client={queryClient}>
         <TimelineProvider>
           <BoardProvider>
-            <div className="min-h-screen flex flex-col bg-white text-gray-900">
+            <ThemeProvider>
+            <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
               {/* Top-level navigation */}
               <NavBar />
 
@@ -68,7 +70,8 @@ const App: React.FC = () => {
                 </Routes>
               </Suspense>
             </main>
-          </div>
+            </div>
+            </ThemeProvider>
           </BoardProvider>
         </TimelineProvider>
       </QueryClientProvider>

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { AuthContext } from '../../contexts/AuthContext';
 import type { AuthContextType } from '../../types/authTypes';
 import { logoutUser } from '../../utils/authUtils';
+import { useTheme } from '../../contexts/ThemeContext';
 
 /**
  * NavBar component for displaying top-level navigation.
@@ -11,9 +12,10 @@ import { logoutUser } from '../../utils/authUtils';
 const NavBar: React.FC = () => {
   // Access authenticated user context
   const { user } = useContext(AuthContext as React.Context<AuthContextType>);
+  const { theme, toggleTheme } = useTheme();
 
   return (
-    <nav className="w-full px-4 sm:px-6 lg:px-8 py-4 border-b border-gray-200 bg-white backdrop-blur">
+    <nav className="w-full px-4 sm:px-6 lg:px-8 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 backdrop-blur">
       <div className="w-full max-w-[1440px] px-4 sm:px-6 lg:px-12 xl:px-24 mx-auto flex items-center justify-between flex-wrap gap-4">
         
         {/* Logo or brand name linking to home */}
@@ -43,6 +45,9 @@ const NavBar: React.FC = () => {
               </button>
             </>
           )}
+          <button onClick={toggleTheme} className="px-2 py-1 rounded border text-xs sm:text-sm border-gray-300 dark:border-gray-600">
+            {theme === 'light' ? 'Light' : 'Dark'}
+          </button>
         </div>
       </div>
     </nav>

--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') return stored;
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error('useTheme must be used within a ThemeProvider');
+  return context;
+};

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -10,6 +10,11 @@
   --text-primary: #1f2937; /* slate-800 */
 }
 
+.dark {
+  --bg-soft: #1f2937; /* slate-800 */
+  --text-primary: #f9fafb; /* light gray */
+}
+
 html, body {
   background-color: var(--bg-soft);
   color: var(--text-primary);

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: 'class',
     content: [
       "./index.html",
       "./src/**/*.{js,ts,jsx,tsx}"


### PR DESCRIPTION
## Summary
- add ThemeProvider with `useTheme` hook
- enable class-based dark mode in Tailwind
- add dark variables in CSS
- wrap App with ThemeProvider and style container
- let NavBar toggle theme

## Testing
- `npm test --prefix ethos-frontend` *(fails: Multiple configurations found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d522717c832fac48d3312a1d3c09