### PR TITLE
Fix font import and duplicate dark theme

### DIFF
--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -1,4 +1,4 @@
-@import "@fontsource/inter/variable.css";
+@import "@fontsource/inter/index.css";
 @import "tailwindcss";
 @tailwind base;
 @tailwind components;
@@ -7,11 +7,6 @@
 :root {
   --bg-soft: #f9fafb;
   --text-primary: #1f2937;
-}
-
-.dark {
-  --bg-soft: #1f2937;
-  --text-primary: #f9fafb;
 }
 
 .dark {


### PR DESCRIPTION
## Summary
- correct Inter font path in index.css
- remove duplicate `.dark` theme block
- verify CSS compilation with tailwind

## Testing
- `npx tailwindcss -i ./src/index.css -o /tmp/out.css`

------
https://chatgpt.com/codex/tasks/task_e_684703d8e91c832fb3e361ab6b4d98ed