### PR TITLE
Fix duplicate devDependencies

### DIFF
--- a/ethos-frontend/package.json
+++ b/ethos-frontend/package.json
@@ -46,11 +46,6 @@
     "tailwindcss": "^4.1.8",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.3.4",
-    "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.1.2",
-    "jest-environment-jsdom": "^29.7.0"
+    "vite": "^6.3.5"
   }
 }


### PR DESCRIPTION
## Summary
- remove repeated devDependencies in ethos-frontend

## Testing
- `npm install --legacy-peer-deps`

------
https://chatgpt.com/codex/tasks/task_e_684703d943e0832fa9e693ee54684e60