### PR TITLE
Fix PostCSS config for Tailwind CSS

### DIFF
--- a/ethos-frontend/postcss.config.cjs
+++ b/ethos-frontend/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` in `postcss.config.cjs` to match Tailwind 4 requirements

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_6847079fcc04832f8d568197102e3d39