### PR TITLE
Fix edges not defined in GraphLayout

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -26,6 +26,7 @@ interface NodeMap {
 
 const GraphLayout: React.FC<GraphLayoutProps> = ({
   items,
+  edges,
   user,
   compact = false,
   onScrollEnd,


### PR DESCRIPTION
## Summary
- fix `edges` prop destructuring in `GraphLayout`

## Testing
- `npm test --prefix ethos-backend` *(fails: cannot find module 'bcryptjs' or 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6847093a8f08832fa3b70316ca9be037