### PR TITLE
Add author links for posts and quests

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -166,6 +166,19 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />
+          <button
+            type="button"
+            onClick={() =>
+              navigate(
+                post.authorId === user?.id
+                  ? ROUTES.PROFILE
+                  : ROUTES.PUBLIC_PROFILE(post.authorId)
+              )
+            }
+            className="text-blue-600 underline"
+          >
+            @{post.author?.username || post.authorId}
+          </button>
           <span>{timestamp}</span>
         </div>
         <ActionMenu

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -87,6 +87,19 @@ const QuestCard: React.FC<QuestCardProps> = ({
         <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">{questData.title}</h2>
         <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
           <PostTypeBadge type="quest" />
+          <button
+            type="button"
+            onClick={() =>
+              navigate(
+                questData.authorId === user?.id
+                  ? ROUTES.PROFILE
+                  : ROUTES.PUBLIC_PROFILE(questData.authorId)
+              )
+            }
+            className="text-blue-600 underline"
+          >
+            @{questData.headPost?.author?.username || questData.authorId}
+          </button>
           <span>{questData.createdAt?.slice(0, 10)}</span>
           {questData.gitRepo?.repoUrl && (
             <a


### PR DESCRIPTION
## Summary
- link to author profile from PostCard and QuestCard
- navigate to own profile when clicking your own name

## Testing
- `npm test --prefix ethos-backend` *(fails: cannot find module 'bcryptjs' or 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68471375197c832fa6cd961f4762f56d