### PR TITLE
Fix missing add item button in quest graph view

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -219,8 +219,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 />
               </div>
             )}
-            <GraphLayout items={logs as any} user={user} edges={questData.taskGraph} />
-            <div className="text-right mt-2">
+            <div className="text-right mb-2">
               <Button
                 size="sm"
                 variant="secondary"
@@ -229,6 +228,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 + Add Item
               </Button>
             </div>
+            <GraphLayout items={logs as any} user={user} edges={questData.taskGraph} />
           </>
         );
       default:


### PR DESCRIPTION
## Summary
- adjust quest card layout so the add-item button is visible above the graph view

## Testing
- `npm test` *(fails: Jest couldn't find jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6847132ce0d4832f8ade3da50df91092