### PR TITLE
Fix quest board persistence

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -253,18 +253,20 @@ router.post(
   authMiddleware,
   (req: AuthenticatedRequest, res: Response): void => {
     const {
+      id: customId,
       title,
       description = '',
       items = [],
       filters = {},
       featured = false,
       defaultFor = null,
-      layout = "grid"
+      layout = "grid",
+      questId,
     } = req.body;
 
     const boards = boardsStore.read();
     const newBoard: BoardData = {
-      id: uuidv4(),
+      id: customId || uuidv4(),
       title,
       description,
       items,
@@ -273,7 +275,8 @@ router.post(
       defaultFor,
       layout,
       createdAt: new Date().toISOString(),
-      userId: (req.user as any)?.id || ""
+      userId: (req.user as any)?.id || "",
+      questId,
     };
 
     boards.push(newBoard);

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -187,6 +187,7 @@ export interface Board {
   createdAt: string;
   category?: string;
   userId: string;
+  questId?: string;
 }
 
 /**

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -93,6 +93,8 @@ export interface DBBoard {
   createdAt: string;
   category?: string;
   userId: string;
+  /** Optional quest association */
+  questId?: string;
 }
 
 // Efficient DB model for quick lookups and storage

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -47,9 +47,11 @@ const QuestPage: React.FC = () => {
     if (!quest) return;
     try {
       const newBoard = await addBoard({
+        id: `map-${quest.id}`,
         title: `${quest.title} Map`,
         layout: 'graph',
         items: [],
+        questId: quest.id,
       });
       setMapBoard(newBoard);
       await refreshBoards();

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -28,6 +28,7 @@ export interface BoardData extends Board {
 
 /** Payload used when creating a new board */
 export interface CreateBoardPayload {
+  id?: string;
   title: string;
   description?: string;
   layout: BoardLayout;
@@ -36,6 +37,7 @@ export interface CreateBoardPayload {
   featured?: boolean;
   defaultFor?: 'home' | 'profile' | 'quests' | null;
   category?: string;
+  questId?: string;
 }
 
 export interface RenderableItem {


### PR DESCRIPTION
## Summary
- allow custom id and questId when creating boards
- persist quest map boards by giving them deterministic ids
- update Board schema definitions for questId field

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684712f7b6f4832f96ad734b95a2068e