### PR TITLE
Fix quest card reload state

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -65,6 +65,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
   };
 
   useEffect(() => {
+    if (!expanded) return;
+
     const fetchData = async () => {
       try {
         const [questDetails, questLogs] = await Promise.all([
@@ -79,7 +81,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       }
     };
     fetchData();
-  }, [quest.id]);
+  }, [quest.id, expanded]);
 
   const renderHeader = () => (
     <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-4">


### PR DESCRIPTION
## Summary
- ensure quest posts are fetched when expanding a quest card

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom not found)*
- `npm run lint --silent` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847175422c0832f8c98a1cf761f43a2