### PR TITLE
Fix profile board filtering

### DIFF
--- a/ethos-frontend/src/api/board.ts
+++ b/ethos-frontend/src/api/board.ts
@@ -25,11 +25,12 @@ export const fetchBoards = async (userId?: string): Promise<BoardData[]> => {
  */
 export const fetchBoard = async (
   id: string,
-  options: { enrich?: boolean; page?: number; limit?: number } = {}
+  options: { enrich?: boolean; page?: number; limit?: number; userId?: string } = {}
 ): Promise<BoardData> => {
   const params = new URLSearchParams();
   if (options.enrich) params.set('enrich', 'true');
   if (options.page) params.set('page', options.page.toString());
+  if (options.userId) params.set('userId', options.userId);
   params.set('limit', (options.limit ?? DEFAULT_PAGE_SIZE).toString());
   const url = `${BASE_URL}/${id}${params.toString() ? `?${params.toString()}` : ''}`;
   const res = await axiosWithAuth.get(url);
@@ -42,10 +43,11 @@ export const fetchBoard = async (
  */
 export const fetchBoardItems = async (
   id: string,
-  options: { enrich?: boolean } = {}
+  options: { enrich?: boolean; userId?: string } = {}
 ): Promise<(Post | Quest)[]> => {
   const params = new URLSearchParams();
   if (options.enrich) params.set('enrich', 'true');
+  if (options.userId) params.set('userId', options.userId);
   const url = `${BASE_URL}/${id}/items${params.toString() ? `?${params.toString()}` : ''}`;
   const res = await axiosWithAuth.get(url);
   return res.data;

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -83,8 +83,16 @@ export const fetchPostsByQuestId = async (questId: string): Promise<Post[]> => {
  * 📌 Fetch posts by board ID
  * @param boardId - Board ID
  */
-export const fetchPostsByBoardId = async (boardId: string): Promise<Post[]> => {
-  const res = await axiosWithAuth.get(`/boards/${boardId}/items?enrich=true`);
+export const fetchPostsByBoardId = async (
+  boardId: string,
+  userId?: string
+): Promise<Post[]> => {
+  const params = new URLSearchParams();
+  params.set('enrich', 'true');
+  if (userId) params.set('userId', userId);
+  const res = await axiosWithAuth.get(
+    `/boards/${boardId}/items?${params.toString()}`
+  );
   return (res.data || []).filter((item: any) => 'content' in item);
 };
 

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -101,8 +101,15 @@ export const fetchQuestMapData = async (
  * @function fetchQuestsByBoardId  
  * @param boardId Board ID
  */
-export const fetchQuestsByBoardId = async (boardId: string): Promise<Quest[]> => {
-  const res = await axiosWithAuth.get(`/boards/${boardId}/quests`);
+export const fetchQuestsByBoardId = async (
+  boardId: string,
+  userId?: string
+): Promise<Quest[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  const res = await axiosWithAuth.get(
+    `/boards/${boardId}/quests${params.toString() ? `?${params.toString()}` : ''}`
+  );
   return res.data;
 };
 

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -58,8 +58,14 @@ const Board: React.FC<BoardProps> = ({
 
       setLoading(true);
       try {
-        const boardData = await fetchBoard(boardId, { enrich: true });
-        const boardItems = await fetchBoardItems(boardId, { enrich: true });
+        const boardData = await fetchBoard(boardId, {
+          enrich: true,
+          userId: user?.id,
+        });
+        const boardItems = await fetchBoardItems(boardId, {
+          enrich: true,
+          userId: user?.id,
+        });
 
         setSelectedBoard(boardId);
 
@@ -85,8 +91,10 @@ const Board: React.FC<BoardProps> = ({
   useSocketListener('board:update', (payload: { boardId: string }) => {
     if (!board?.id || payload.boardId !== board.id) return;
 
-    fetchBoard(board.id, { enrich: true }).then(setBoard);
-    fetchBoardItems(board.id, { enrich: true }).then((items) => setItems(items as Post[]));
+    fetchBoard(board.id, { enrich: true, userId: user?.id }).then(setBoard);
+    fetchBoardItems(board.id, { enrich: true, userId: user?.id }).then((items) =>
+      setItems(items as Post[])
+    );
   });
 
   const filteredItems = useMemo(() => {
@@ -271,13 +279,13 @@ const Board: React.FC<BoardProps> = ({
             onCancel={() => setEditMode(false)}
             onSave={() => {
               if (!board?.id) return;
-              fetchBoard(board.id, { enrich: true }).then((updatedBoard) => {
-                setBoard(updatedBoard);
-                setEditMode(false);
-                fetchBoardItems(board.id, { enrich: true }).then((items) =>
-                  setItems(items as Post[])
-                );
-              });
+                fetchBoard(board.id, { enrich: true, userId: user?.id }).then((updatedBoard) => {
+                  setBoard(updatedBoard);
+                  setEditMode(false);
+                  fetchBoardItems(board.id, { enrich: true, userId: user?.id }).then((items) =>
+                    setItems(items as Post[])
+                  );
+                });
             }}
           />
         </div>

--- a/ethos-frontend/src/hooks/usePost.ts
+++ b/ethos-frontend/src/hooks/usePost.ts
@@ -17,9 +17,9 @@ import {
  * - propagateSolution: Check and handle solution propagation
  */
 export const usePost = () => {
-  const fetchPostsForBoard = useCallback(async (boardId: string): Promise<Post[]> => {
+  const fetchPostsForBoard = useCallback(async (boardId: string, userId?: string): Promise<Post[]> => {
     try {
-      const posts = await fetchPostsByBoardId(boardId);
+        const posts = await fetchPostsByBoardId(boardId, userId);
       return posts;
     } catch (err) {
       console.error(`[usePost] Failed to fetch posts for board ${boardId}:`, err);

--- a/ethos-frontend/src/hooks/useQuest.ts
+++ b/ethos-frontend/src/hooks/useQuest.ts
@@ -55,9 +55,9 @@ export const useQuest = (questId?: string) => {
     load();
   }, [questId]);
 
-  const fetchQuestsForBoard = useCallback(async (boardId: string): Promise<Quest[]> => {
+  const fetchQuestsForBoard = useCallback(async (boardId: string, userId?: string): Promise<Quest[]> => {
     try {
-      return await fetchQuestsByBoardId(boardId);
+      return await fetchQuestsByBoardId(boardId, userId);
     } catch (err) {
       console.error(`[useQuest] Failed to fetch quests for board: ${boardId}`, err);
       return [];

--- a/ethos-frontend/src/hooks/useTimeline.ts
+++ b/ethos-frontend/src/hooks/useTimeline.ts
@@ -43,9 +43,9 @@ export const useTimeline = () => {
    *
    * @param boardId - ID of the board to load timeline for
    */
-  const loadTimeline = useCallback(async (boardId: string) => {
+  const loadTimeline = useCallback(async (boardId: string, userId?: string) => {
     try {
-      const posts = await fetchPostsByBoardId(boardId);
+      const posts = await fetchPostsByBoardId(boardId, userId);
       const timelineEvents: TimelineEvent[] = posts
         .filter(p => p.type === 'meta_system')
         .map(p => ({

--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -90,9 +90,9 @@ const Login: React.FC = () => {
           
           await Promise.all([
             loadPermissions(defaultBoard.id),
-            fetchPostsForBoard(defaultBoard.id),
-            fetchQuestsForBoard(defaultBoard.id),
-            loadTimeline(defaultBoard.id),
+              fetchPostsForBoard(defaultBoard.id, user.id),
+              fetchQuestsForBoard(defaultBoard.id, user.id),
+              loadTimeline(defaultBoard.id, user.id),
             loadGraph(defaultBoard.id),
           ]);
         }

--- a/ethos-frontend/src/pages/PublicProfile.tsx
+++ b/ethos-frontend/src/pages/PublicProfile.tsx
@@ -61,14 +61,14 @@ const PublicProfilePage: React.FC = () => {
     try {
       // 🧭 If it's a quest board
       if (updatedBoard.id === questBoard?.id) {
-        const quests = await fetchQuestsForBoard(updatedBoard.id);
+        const quests = await fetchQuestsForBoard(updatedBoard.id, userId);
         const enriched = await enrichQuests(quests);
         setQuestBoard({ ...updatedBoard, enrichedItems: enriched });
       }
 
       // 📬 If it's a post board
       if (updatedBoard.id === postBoard?.id) {
-        const posts = await fetchPostsForBoard(updatedBoard.id);
+        const posts = await fetchPostsForBoard(updatedBoard.id, userId);
         const enriched = await enrichPosts(posts);
         setPostBoard({ ...updatedBoard, enrichedItems: enriched });
       }

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -5,6 +5,7 @@ import { fetchBoard } from '../../api/board';
 import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
 import { useBoardContext } from '../../contexts/BoardContext';
 import { useSocket } from '../../hooks/useSocket';
+import { useAuth } from '../../contexts/AuthContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import Board from '../../components/board/Board';
 import { Spinner } from '../../components/ui';
@@ -15,6 +16,7 @@ const BoardPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { socket } = useSocket();
   const { canEditBoard } = usePermissions();
+  const { user } = useAuth();
   const { setBoardMeta } = useBoardContext();
   const { board: boardData, setBoard, isLoading, refresh: refetch } = useBoard(id);
 
@@ -55,6 +57,7 @@ const BoardPage: React.FC = () => {
         page: page + 1,
         limit: DEFAULT_PAGE_SIZE,
         enrich: true,
+        userId: user?.id,
       });
       if (moreData?.items?.length) {
         setBoard((prev) =>


### PR DESCRIPTION
## Summary
- return user's posts/quests when filtering board routes with `userId`
- expose `userId` to board APIs
- request board data with `userId` so profile boards populate
- propagate `userId` through hooks and pages
- update login flow to load data with `userId`

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847177fbcd4832f993a4efde6bd9c44