### PR TITLE
Improve board fetch handling

### DIFF
--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -48,8 +48,12 @@ export const useBoard = (arg?: BoardArg) => {
         });
         setBoard(result);
         return result;
-      } catch (err) {
-        console.error(`[useBoard] Failed to load board ${id}:`, err);
+      } catch (err: any) {
+        if (err?.response?.status === 404) {
+          console.info(`[useBoard] Board ${id} not found`);
+        } else {
+          console.error(`[useBoard] Failed to load board ${id}:`, err);
+        }
         return undefined;
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- log a friendly message when board routes return 404

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_684725deca68832f9d7830dfe98ad25c