### PR TITLE
Fix React 19 testing library peer dependency

### DIFF
--- a/ethos-frontend/package-lock.json
+++ b/ethos-frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@eslint/js": "^9.25.0",
         "@tailwindcss/postcss": "^4.1.8",
         "@testing-library/jest-dom": "^6.2.1",
-        "@testing-library/react": "^14.2.1",
+        "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.29",
         "@types/react": "^19.1.2",
@@ -2747,9 +2747,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-zjkCABYL3iRyqMqs7Y7YgXbxLBcT+k2uxPnGygwd7PwUTflDMjPkmlmgzd14j2+aVWdn7NtRIgxXitVEkR92Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2819,32 +2819,32 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
-      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-DvFRWDeYM60fCDdhaE+BupO+xRtreWwiEI/K6UiBHTi1PP36IcFjFIoYOFVqsE/sUmlCNxZj5sgrZeM5qyH0WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
-        "@types/react-dom": "^18.0.0"
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^19.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@testing-library/react/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4O2A0tEBM7sWzvlyzSgmzmbFqR4GBvbY5Xi7YoEPeJVgsJmUGi1eTi7eYs7gBvLZrkE7UmFtt5Q39gxMVecvkw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/ethos-frontend/package.json
+++ b/ethos-frontend/package.json
@@ -39,7 +39,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.3.4",
     "@types/jest": "^29.5.14",
-    "@testing-library/react": "^14.2.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/jest-dom": "^6.2.1",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.5.4",


### PR DESCRIPTION
## Summary
- update `@testing-library/react` to a version that supports React 19
- regenerate lockfile entries

## Testing
- `npm run lint` *(fails: ban-ts-comment, no-unused-vars, no-explicit-any, etc.)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684725682e1c832f91aa131d9b0db78e