### PR TITLE
Fix quest mini board task persistence

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -267,6 +267,7 @@ const Board: React.FC<BoardProps> = ({
           <CreatePost
             onSave={handleAdd}
             onCancel={() => setShowCreateForm(false)}
+            boardId={board.id}
           />
         </div>
       )}

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -167,6 +167,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
               <div className="mb-4">
                 <CreatePost
                   initialType="log"
+                  questId={quest.id}
+                  boardId={`log-${quest.id}`}
                   onSave={(p) => {
                     setLogs((prev) => [...prev, p]);
                     setShowLogForm(false);
@@ -194,6 +196,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
               <div className="mb-4">
                 <CreatePost
                   initialType="task"
+                  questId={quest.id}
+                  boardId={`map-${quest.id}`}
                   onSave={(p) => {
                     setLogs((prev) => [...prev, p]);
                     setShowTaskForm(false);
@@ -226,6 +230,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
               <div className="mb-4">
                 <CreatePost
                   initialType="task"
+                  questId={quest.id}
+                  boardId={`map-${quest.id}`}
                   onSave={(p) => {
                     setLogs((prev) => [...prev, p]);
                     setShowTaskForm(false);


### PR DESCRIPTION
## Summary
- allow `CreatePost` to specify a quest and board for new posts
- persist posts to the correct quest board when using quest mini boards

## Testing
- `npm test` *(fails: jest dependencies missing)*
- `npm run build` in `ethos-frontend` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847269b7da8832f8592fee4c4e38c1e