### PR TITLE
Fix board patch upsert

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -312,9 +312,26 @@ router.patch(
   authMiddleware,
   (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
     const boards = boardsStore.read();
-    const board = boards.find(b => b.id === req.params.id);
+    let board = boards.find(b => b.id === req.params.id);
+
     if (!board) {
-      res.status(404).json({ error: 'Board not found' });
+      board = {
+        id: req.params.id,
+        title: req.body.title || 'Untitled Board',
+        description: req.body.description || '',
+        layout: req.body.layout || 'grid',
+        items: req.body.items ?? [],
+        filters: req.body.filters ?? {},
+        featured: req.body.featured ?? false,
+        defaultFor: req.body.defaultFor ?? null,
+        createdAt: new Date().toISOString(),
+        userId: (req.user as any)?.id || '',
+        category: req.body.category,
+        questId: req.body.questId,
+      } as BoardData;
+      boards.push(board);
+      boardsStore.write(boards);
+      res.status(201).json(board);
       return;
     }
 

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -245,4 +245,19 @@ describe('route handlers', () => {
     expect(res.status).toBe(200);
     expect(res.body[0]).toHaveProperty('logs');
   });
+
+  it('PATCH /boards/:id creates board when not found', async () => {
+    const { boardsStore } = require('../src/models/stores');
+    const store: any[] = [];
+    boardsStore.read.mockReturnValue(store);
+
+    const res = await request(app)
+      .patch('/boards/new-board')
+      .send({ title: 'New Board', items: ['i1'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe('new-board');
+    expect(store).toHaveLength(1);
+    expect(store[0].items).toContain('i1');
+  });
 });


### PR DESCRIPTION
## Summary
- create a board if `PATCH /boards/:id` can't find it
- test board upsert behavior

## Testing
- `npm test` (backend)
- `npm test` *(failed: jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68472f30fe08832f805fdaa6816ae71a