### PR TITLE
Improve Ethos frontend styles

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -120,7 +120,10 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   return (
     <div
       ref={containerRef}
-      className="overflow-auto w-full h-full p-4 max-w-7xl mx-auto"
+      className={
+        'overflow-auto w-full h-full p-4 max-w-7xl mx-auto ' +
+        (rootNodes.length === 1 ? 'flex justify-center' : '')
+      }
       style={{ minHeight: '50vh' }}
     >
       {rootNodes.map((node) => renderNode(node))}

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -94,17 +94,25 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   }
 
   /** 📌 Vertical Grid Layout (default) */
+  const isSingle = items.length === 1;
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 px-2">
+    <div
+      className={
+        isSingle
+          ? 'flex justify-center items-start p-2'
+          : 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 px-2'
+      }
+    >
       {items.map((item) => (
-        <ContributionCard
-          key={item.id}
-          contribution={item}
-          user={user}
-          compact={compact}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
+        <div key={item.id} className={isSingle ? 'max-w-prose w-full' : ''}>
+          <ContributionCard
+            contribution={item}
+            user={user}
+            compact={compact}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        </div>
       ))}
     </div>
   );

--- a/ethos-frontend/src/components/layout/ThreadLayout.tsx
+++ b/ethos-frontend/src/components/layout/ThreadLayout.tsx
@@ -42,7 +42,15 @@ const ThreadLayout: React.FC<ThreadLayoutProps> = ({
   if (childItems.length === 0 || depth > maxDepth) return null;
 
   return (
-    <div className={depth === 0 ? 'space-y-6' : 'ml-6 border-l-2 border-gray-200 pl-4 space-y-4'}>
+    <div
+      className={
+        depth === 0
+          ? childItems.length === 1
+            ? 'flex justify-center space-y-6'
+            : 'space-y-6'
+          : 'ml-6 border-l-2 border-gray-200 pl-4 space-y-4'
+      }
+    >
       {childItems.map((contribution) => {
         const isAuthor = contribution.authorId === user?.id;
         const isCollaborator = contribution.collaborators?.some((c) => c.userId === user?.id);

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -162,7 +162,7 @@ const PostCard: React.FC<PostCardProps> = ({
   }
 
   return (
-    <div className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100">
+    <div className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100 max-w-prose mx-auto">
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />

--- a/ethos-frontend/src/components/ui/Button.tsx
+++ b/ethos-frontend/src/components/ui/Button.tsx
@@ -24,7 +24,7 @@ const Button: React.FC<ButtonProps> = ({
     'inline-flex items-center justify-center font-medium rounded-md focus:outline-none transition-colors duration-150';
 
   const variantStyles: Record<ButtonVariant, string> = {
-    primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-400',
+    primary: 'bg-accent text-white hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-400',
     secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300 focus:ring-2 focus:ring-gray-300',
     ghost: 'bg-transparent text-gray-600 hover:bg-gray-100 focus:ring-2 focus:ring-gray-200',
     danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500',

--- a/ethos-frontend/src/components/ui/Input.tsx
+++ b/ethos-frontend/src/components/ui/Input.tsx
@@ -17,7 +17,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <div className="w-full space-y-1">
         {srOnlyLabel && <label htmlFor={id} className="sr-only">{srOnlyLabel}</label>}
 
-        <div className="flex items-center border rounded-md shadow-sm focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500 overflow-hidden">
+        <div className="flex items-center border rounded-md shadow-sm focus-within:ring-2 focus-within:ring-accent focus-within:border-accent overflow-hidden">
           {prefix && <span className="px-2 text-gray-500 bg-gray-100">{prefix}</span>}
           <input
             id={id}

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -17,9 +17,9 @@ const NavBar: React.FC = () => {
   return (
     <nav className="w-full px-4 sm:px-6 lg:px-8 py-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 backdrop-blur">
       <div className="w-full max-w-[1440px] px-4 sm:px-6 lg:px-12 xl:px-24 mx-auto flex items-center justify-between flex-wrap gap-4">
-        
+
         {/* Logo or brand name linking to home */}
-        <Link to="/" className="text-xl font-bold tracking-tight">
+        <Link to="/" className="text-xl font-bold tracking-tight text-accent">
           Ethos
         </Link>
 
@@ -27,13 +27,13 @@ const NavBar: React.FC = () => {
         <div className="flex flex-wrap items-center gap-4 text-sm sm:text-base">
           {!user ? (
             // Guest user view
-            <Link to="/login" className="hover:text-indigo-600 transition">
+            <Link to="/login" className="hover:text-accent transition">
               Login
             </Link>
           ) : (
             // Authenticated user view
             <>
-              <Link to="/profile" className="hover:text-indigo-600 transition">
+              <Link to="/profile" className="hover:text-accent transition">
                 Account
               </Link>
               <button

--- a/ethos-frontend/src/components/ui/Select.tsx
+++ b/ethos-frontend/src/components/ui/Select.tsx
@@ -26,7 +26,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             'w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:outline-none',
             error
               ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-              : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500',
+              : 'border-gray-300 focus:ring-accent focus:border-accent',
             'disabled:cursor-not-allowed disabled:opacity-50',
             className
           )}

--- a/ethos-frontend/src/components/ui/Spinner.tsx
+++ b/ethos-frontend/src/components/ui/Spinner.tsx
@@ -5,7 +5,7 @@ import React from 'react';
  */
 const Spinner: React.FC = () => (
   <div className="flex justify-center items-center py-8 w-full">
-    <div className="h-8 w-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+    <div className="h-8 w-8 border-4 border-accent border-t-transparent rounded-full animate-spin" />
   </div>
 );
 

--- a/ethos-frontend/src/components/ui/TextArea.tsx
+++ b/ethos-frontend/src/components/ui/TextArea.tsx
@@ -46,7 +46,7 @@ const TextArea: React.FC<TextAreaProps> = ({
           'w-full p-3 rounded-md border shadow-sm resize-y text-sm text-gray-900 focus:outline-none',
           error
             ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-            : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500',
+            : 'border-gray-300 focus:ring-accent focus:border-accent',
           {
             'bg-gray-100 cursor-not-allowed': disabled || readOnly,
           },

--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -21,6 +21,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.body.classList.toggle('dark', theme === 'dark');
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -7,11 +7,13 @@
 :root {
   --bg-soft: #f9fafb;
   --text-primary: #1f2937;
+  --accent: #4f46e5; /* indigo-600 */
 }
 
 .dark {
   --bg-soft: #1f2937; /* slate-800 */
   --text-primary: #f9fafb; /* light gray */
+  --accent: #818cf8; /* indigo-400 */
 }
 
 html, body {
@@ -21,4 +23,16 @@ html, body {
   min-height: 100%;
   margin: 0;
   padding: 0;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.prose {
+  max-width: 700px;
 }


### PR DESCRIPTION
## Summary
- enhance theme colors and add accent variable
- center single items in Grid, Thread and Graph layouts
- limit PostCard width for better readability
- use accent color in buttons, inputs and other components
- ensure dark mode class applied to body

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*
- `npm test` in frontend *(fails: jest-environment-jsdom not found)*
- `npm test` in backend *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684730869e5c832fbaf508f7f5be2d7d