### PR TITLE
Improve board layout style

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -200,7 +200,7 @@ const Board: React.FC<BoardProps> = ({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 p-6 bg-gray-50 dark:bg-gray-800 rounded-xl shadow-lg max-w-5xl mx-auto">
       {/* Board Header */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -100,7 +100,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
       className={
         isSingle
           ? 'flex justify-center items-start p-2'
-          : 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6 px-2'
+          : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 px-2'
       }
     >
       {items.map((item) => (

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -90,24 +90,26 @@ const BoardPage: React.FC = () => {
 
   return (
     <main className="max-w-7xl mx-auto p-4 space-y-8">
-      <div className="flex justify-between items-center mb-4">
-        <h1 className="text-3xl font-bold">{boardData.title}</h1>
-        {editable && (
-          <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-            Edit Board
-          </button>
-        )}
-      </div>
+      <div className="bg-gray-100 dark:bg-gray-900 rounded-xl shadow-lg p-6 space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-3xl font-bold">{boardData.title}</h1>
+          {editable && (
+            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+              Edit Board
+            </button>
+          )}
+        </div>
 
-      <Board
-        boardId={id}
-        board={boardData}
-        layout={boardData.layout}
-        editable={editable}
-        showCreate={editable}
-        onScrollEnd={loadMore}
-        loading={loadingMore}
-      />
+        <Board
+          boardId={id}
+          board={boardData}
+          layout={boardData.layout}
+          editable={editable}
+          showCreate={editable}
+          onScrollEnd={loadMore}
+          loading={loadingMore}
+        />
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- style board container with spacing and dark background to appear elevated
- limit grid layout to three columns max for better spacing
- wrap board page content in gray container

## Testing
- `npm test --silent` in `ethos-backend`
- `npm test --silent` in `ethos-frontend` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684738c9bf9c832f925d98583a90d8b4