### PR TITLE
Fix theme initialization and grid layout

### DIFF
--- a/ethos-frontend/index.html
+++ b/ethos-frontend/index.html
@@ -5,6 +5,19 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script>
+      (function () {
+        try {
+          const stored = localStorage.getItem('theme');
+          if (stored === 'dark') {
+            document.documentElement.classList.add('dark');
+            document.body.classList.add('dark');
+          }
+        } catch (e) {
+          console.warn('Theme init error', e);
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -95,12 +95,15 @@ const GridLayout: React.FC<GridLayoutProps> = ({
 
   /** 📌 Vertical Grid Layout (default) */
   const isSingle = items.length === 1;
+  const isPair = items.length === 2;
   return (
     <div
       className={
         isSingle
           ? 'flex justify-center items-start p-2'
-          : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 px-2'
+          : isPair
+            ? 'grid grid-cols-1 sm:grid-cols-2 gap-6 px-2'
+            : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 px-2'
       }
     >
       {items.map((item) => (


### PR DESCRIPTION
## Summary
- preload theme class in `index.html`
- adjust `GridLayout` to use two columns when there are exactly two items

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `cd ethos-backend && npm test --silent` *(fails to find supertest module)*

------
https://chatgpt.com/codex/tasks/task_e_68473b049514832f81d920a65ff40169