### PR TITLE
Add board state sync effect

### DIFF
--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -128,6 +128,15 @@ export const useBoard = (
     }
   }, [boardId, pageSize]);
 
+  // Keep local board state in sync with context
+  useEffect(() => {
+    if (!boardId) return;
+    const ctxBoard = boards[boardId];
+    if (ctxBoard && ctxBoard !== board) {
+      setBoard(ctxBoard);
+    }
+  }, [boards, boardId]);
+
   return {
     board,
     setBoard,


### PR DESCRIPTION
## Summary
- keep the board state in sync with BoardContext by watching context changes

## Testing
- `npm test` *(fails: Jest couldn't find necessary env or modules)*
- `npm test` in `ethos-backend` *(fails: supertest and bcryptjs missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b361ccd40832f93c1e34d60ac2745