### PR TITLE
Fix EditPost link display

### DIFF
--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -109,7 +109,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       <FormSection title="Linked Items">
         <LinkControls
           label="Item"
-          value={[]}
+          value={linkedItems}
           onChange={(newLinks: LinkedItem[]) => setLinkedItems(newLinks)}
           allowCreateNew={false}
           itemTypes={['quest', 'post']}


### PR DESCRIPTION
## Summary
- ensure linked items show up when editing posts

## Testing
- `npm test` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_684b361bbaec832fa4940163aaf6ce09