### PR TITLE
Fix public profile boards

### DIFF
--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -84,17 +84,17 @@ export const useBoard = (
 
   const loadPublicBoards = useCallback(async (userId: string) => {
       const [questBoard, postBoard, profileRes, quests, posts] = await Promise.all([
-        fetchBoard(`quests-${userId}`, { userId }).catch(() => null),
-        fetchBoard(`posts-${userId}`, { userId }).catch(() => null),
+        fetchBoard('my-quests', { userId }).catch(() => null),
+        fetchBoard('my-posts', { userId }).catch(() => null),
         fetchUserById(userId).catch(() => null), // ✅ Use the API
-        fetchQuestsByBoardId(`quests-${userId}`, userId).catch(() => []),
-        fetchPostsByBoardId(`posts-${userId}`, userId).catch(() => []),
+        fetchQuestsByBoardId('my-quests', userId).catch(() => []),
+        fetchPostsByBoardId('my-posts', userId).catch(() => []),
       ]);
 
     const qb: BoardData = questBoard
       ? { ...questBoard, items: quests.map(q => q.id), enrichedItems: quests }
       : {
-          id: `quests-${userId}`,
+          id: 'my-quests',
           title: 'Quests',
           layout: 'grid',
           items: quests.map(q => q.id),
@@ -105,7 +105,7 @@ export const useBoard = (
     const pb: BoardData = postBoard
       ? { ...postBoard, items: posts.map(p => p.id), enrichedItems: posts }
       : {
-          id: `posts-${userId}`,
+          id: 'my-posts',
           title: 'Posts',
           layout: 'grid',
           items: posts.map(p => p.id),


### PR DESCRIPTION
## Summary
- fetch public boards by using `my-quests`/`my-posts` IDs instead of non-existent dynamic board IDs

## Testing
- `npm test --prefix ethos-backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533fc3184c832fa1b04e0aecdfc6bb