### PR TITLE
Implement dynamic link label updates

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -77,27 +77,29 @@ router.patch(
   authMiddleware,
   (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
     const posts = postsStore.read();
-    const quests = questsStore.read();
-    const post = posts.find((p) => p.id === req.params.id);
-    if (!post) {
-      res.status(404).json({ error: 'Post not found' });
-      return;
-    }
+  const quests = questsStore.read();
+  const post = posts.find((p) => p.id === req.params.id);
+  if (!post) {
+    res.status(404).json({ error: 'Post not found' });
+    return;
+  }
 
-    const originalQuestId = post.questId;
-    const originalReplyTo = post.replyTo;
+  const originalQuestId = post.questId;
+  const originalReplyTo = post.replyTo;
+  const originalType = post.type;
 
-    Object.assign(post, req.body);
+  Object.assign(post, req.body);
 
-    const questIdChanged =
-      'questId' in req.body && req.body.questId !== originalQuestId;
-    const replyToChanged =
-      'replyTo' in req.body && req.body.replyTo !== originalReplyTo;
+  const questIdChanged =
+    'questId' in req.body && req.body.questId !== originalQuestId;
+  const replyToChanged =
+    'replyTo' in req.body && req.body.replyTo !== originalReplyTo;
+  const typeChanged = 'type' in req.body && req.body.type !== originalType;
 
-    if (questIdChanged || replyToChanged) {
-      const quest = post.questId
-        ? quests.find((q) => q.id === post.questId)
-        : null;
+  if (questIdChanged || replyToChanged || typeChanged) {
+    const quest = post.questId
+      ? quests.find((q) => q.id === post.questId)
+      : null;
       const parent = post.replyTo
         ? posts.find((p) => p.id === post.replyTo) || null
         : null;

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -172,4 +172,39 @@ describe('post routes', () => {
     expect(posts[2].nodeId).toBe(expected);
     expect(res.body.nodeId).toBe(expected);
   });
+
+  it('PATCH /posts/:id regenerates nodeId on type change', async () => {
+    const posts = [
+      {
+        id: 't1',
+        authorId: 'u1',
+        type: 'task',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        questId: 'q1',
+        replyTo: null,
+        nodeId: 'Q:firstquest:T00',
+      },
+    ];
+
+    postsStore.read.mockReturnValue(posts);
+    questsStore.read.mockReturnValue([
+      { id: 'q1', title: 'First Quest', status: 'active', headPostId: '', linkedPosts: [], collaborators: [] },
+    ]);
+    usersStore.read.mockReturnValue([]);
+
+    const res = await request(app).patch('/posts/t1').send({ type: 'issue' });
+
+    const expected = generateNodeId({
+      quest: { id: 'q1', title: 'First Quest' },
+      posts: [],
+      postType: 'issue',
+      parentPost: null,
+    });
+
+    expect(res.status).toBe(200);
+    expect(posts[0].nodeId).toBe(expected);
+    expect(res.body.nodeId).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- refresh link labels by fetching linked quest or post metadata when displaying links
- regenerate node IDs if a post's type changes
- test that nodeId recalculation works on type update

## Testing
- `npm test --prefix ethos-backend` *(fails: jest not found)*
- `npm test --prefix ethos-frontend` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685340ccaae8832fa75c79449c1f2c15