### PR TITLE
Sync board items with context updates

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -42,12 +42,19 @@ const Board: React.FC<BoardProps> = ({
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
 
   const { canEditBoard } = usePermissions();
-  const { setSelectedBoard, appendToBoard } = useBoardContext();
+  const { setSelectedBoard, appendToBoard, updateBoardItem, boards } = useBoardContext();
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<'createdAt' | 'displayTitle'>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editMode, setEditMode] = useState(false);
+
+  // Keep items state in sync with BoardContext updates
+  useEffect(() => {
+    if (!board?.id) return;
+    const enriched = boards[board.id]?.enrichedItems || [];
+    setItems(enriched as Post[]);
+  }, [board?.id, boards[board?.id]?.enrichedItems]);
 
   useEffect(() => {
     const loadBoard = async () => {


### PR DESCRIPTION
## Summary
- access `updateBoardItem` from board context
- keep local board state synced with the context

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6853443e3bb0832f9e50a70969b161c7