### PR TITLE
Add task status selection

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { POST_TYPES } from '../../constants/options';
+import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { addPost } from '../../api/post';
 import { Button, TextArea, Select, Label, FormSection } from '../ui';
 import CollaberatorControls from '../controls/CollaberatorControls';
@@ -38,6 +38,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   boardId,
 }) => {
   const [type, setType] = useState<PostType>(initialType);
+  const [status, setStatus] = useState<string>('To Do');
   const [content, setContent] = useState<string>('');
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
@@ -73,13 +74,14 @@ const CreatePost: React.FC<CreatePostProps> = ({
       autoLinkItems.push({ itemId: questIdFromBoard, itemType: 'quest' });
     }
 
-    const payload: Partial<Post> = {
-      type,
-      content,
-      visibility: 'public',
-      linkedItems: autoLinkItems,
-      ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
-      ...(targetBoard ? { boardId: targetBoard } : {}),
+      const payload: Partial<Post> = {
+        type,
+        content,
+        visibility: 'public',
+        linkedItems: autoLinkItems,
+        ...(type === 'task' ? { status } : {}),
+        ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
+        ...(targetBoard ? { boardId: targetBoard } : {}),
       ...(replyTo ? { replyTo: replyTo.id, parentPostId: replyTo.id, linkType: 'reply' } : {}),
       ...(repostSource
         ? {
@@ -129,7 +131,11 @@ const CreatePost: React.FC<CreatePostProps> = ({
           <Select
             id="post-type"
             value={type}
-            onChange={(e) => setType(e.target.value as PostType)}
+            onChange={(e) => {
+              const val = e.target.value as PostType;
+              setType(val);
+              if (val === 'task') setStatus('To Do');
+            }}
             options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
           />
         </FormSection>
@@ -145,9 +151,25 @@ const CreatePost: React.FC<CreatePostProps> = ({
         <Select
           id="post-type"
           value={type}
-          onChange={(e) => setType(e.target.value as PostType)}
+          onChange={(e) => {
+            const val = e.target.value as PostType;
+            setType(val);
+            if (val === 'task') setStatus('To Do');
+          }}
           options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
+
+        {type === 'task' && (
+          <>
+            <Label htmlFor="task-status">Status</Label>
+            <Select
+              id="task-status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              options={STATUS_OPTIONS.map(({ value, label }) => ({ value, label }))}
+            />
+          </>
+        )}
 
         <Label htmlFor="content">Content</Label>
         <TextArea

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -5,7 +5,7 @@ import type { FormEvent } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { updatePost } from '../../api/post';
-import { POST_TYPES } from '../../constants/options';
+import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
 import type { PostType, Post, CollaberatorRoles, LinkedItem } from '../../types/postTypes';
 
@@ -21,6 +21,7 @@ interface EditPostProps {
 
 const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
   const [type, setType] = useState<PostType>(post.type);
+  const [status, setStatus] = useState<string>(post.status || 'To Do');
   const [content, setContent] = useState<string>(post.content || '');
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>(post.collaborators || []);
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>(post.linkedItems || []);
@@ -46,6 +47,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       type,
       content,
       ...(type === 'quest' && { collaborators }),
+      ...(type === 'task' ? { status } : {}),
       linkedItems,
       repostedFrom: repostedFrom || null,
     };
@@ -69,9 +71,25 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
         <Select
           id="post-type"
           value={type}
-          onChange={(e) => setType(e.target.value as PostType)}
+          onChange={(e) => {
+            const val = e.target.value as PostType;
+            setType(val);
+            if (val === 'task') setStatus('To Do');
+          }}
           options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
+
+        {type === 'task' && (
+          <>
+            <Label htmlFor="task-status">Status</Label>
+            <Select
+              id="task-status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              options={STATUS_OPTIONS.map(({ value, label }) => ({ value, label }))}
+            />
+          </>
+        )}
 
         <Label htmlFor="content">Content (Markdown supported)</Label>
         <TextArea

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -25,6 +25,12 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
 
 export const LINK_TYPES = ['solution', 'duplicate', 'citation'];
 
+export const STATUS_OPTIONS = [
+  { value: 'To Do', label: 'To Do' },
+  { value: 'In Progress', label: 'In Progress' },
+  { value: 'Done', label: 'Done' },
+] as const;
+
 /**
  * Defines the shape of each select option.
  */


### PR DESCRIPTION
## Summary
- provide STATUS_OPTIONS constant for tasks
- add status field to task posts in CreatePost
- allow editing task status in EditPost

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm test` in backend *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685345272458832f960819fdf639acb4