### PR TITLE
Add system theme support

### DIFF
--- a/ethos-frontend/index.html
+++ b/ethos-frontend/index.html
@@ -9,7 +9,8 @@
       (function () {
         try {
           const stored = localStorage.getItem('theme');
-          if (stored === 'dark') {
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (stored === 'dark' || (stored === 'system' && prefersDark)) {
             document.documentElement.classList.add('dark');
             document.body.classList.add('dark');
           }

--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -1,7 +1,7 @@
 export default {
   preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  roots: ['<rootDir>/src'],
+  testEnvironment: 'jest-environment-jsdom',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   globals: {
     'ts-jest': {

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -45,8 +45,12 @@ const NavBar: React.FC = () => {
               </button>
             </>
           )}
-          <button onClick={toggleTheme} className="px-2 py-1 rounded border text-xs sm:text-sm border-gray-300 dark:border-gray-600">
-            {theme === 'light' ? 'Light' : 'Dark'}
+          <button
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+            className="px-2 py-1 rounded border text-xs sm:text-sm border-gray-300 dark:border-gray-600"
+          >
+            {theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System'}
           </button>
         </div>
       </div>

--- a/ethos-frontend/tests/ThemeProvider.test.js
+++ b/ethos-frontend/tests/ThemeProvider.test.js
@@ -1,0 +1,31 @@
+const React = require('react');
+const { render } = require('@testing-library/react');
+const { ThemeProvider } = require('../src/contexts/ThemeContext');
+
+function setupMatchMedia(matches) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  });
+}
+
+describe('ThemeProvider', () => {
+  it('applies system preference when theme is system', () => {
+    setupMatchMedia(true);
+    localStorage.setItem('theme', 'system');
+    render(React.createElement(ThemeProvider, {}, React.createElement('div')));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('applies selected theme', () => {
+    setupMatchMedia(false);
+    localStorage.setItem('theme', 'dark');
+    render(React.createElement(ThemeProvider, {}, React.createElement('div')));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend theme type to include system preference and add detection helper
- react to system theme changes in ThemeProvider
- cycle through light, dark, and system modes
- display selected theme in NavBar
- initialize dark class for system setting in index.html
- enable tests folder and add ThemeProvider tests

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685345641dc0832fa4dde3d6ce7f1d0b