### PR TITLE
Fix quest log permissions

### DIFF
--- a/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import QuestPage from '../quest/[id]';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'viewer' } })
+}));
+
+jest.mock('../../hooks/useQuest', () => ({
+  useQuest: () => ({
+    quest: {
+      id: 'q1',
+      authorId: 'owner',
+      title: 'Quest',
+      headPostId: '',
+      status: 'active',
+      linkedPosts: [],
+      collaborators: []
+    },
+    error: null,
+    isLoading: false
+  })
+}));
+
+jest.mock('../../hooks/useBoard', () => ({
+  useBoard: () => ({
+    board: {
+      id: 'log-q1',
+      title: 'Log',
+      layout: 'grid',
+      items: [],
+      enrichedItems: [],
+      createdAt: ''
+    },
+    refresh: jest.fn(),
+    isLoading: false
+  })
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  useBoardContext: () => ({ refreshBoards: jest.fn() })
+}));
+
+jest.mock('../../hooks/useSocket', () => ({
+  useSocketListener: jest.fn()
+}));
+
+jest.mock('../../api/board', () => ({
+  addBoard: jest.fn()
+}));
+
+describe('QuestLog permissions', () => {
+  it('hides editing controls for unauthorized users', async () => {
+    render(<QuestPage />);
+    await waitFor(() =>
+      expect(screen.getByText('📜 Quest Log')).toBeInTheDocument()
+    );
+    expect(screen.queryByText('✏️ Edit Board')).toBeNull();
+  });
+});

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -130,7 +130,10 @@ const QuestPage: React.FC = () => {
             boardId={`log-${id}`}
             board={logBoard}
             layout="grid"
-            editable={true}
+            editable={
+              user?.id === quest.authorId ||
+              quest.collaborators?.some((c) => c.userId === user?.id)
+            }
             quest={quest}
             user={user as User}
             showCreate


### PR DESCRIPTION
## Summary
- only allow owners or collaborators to edit quest log boards
- cover log board permissions in tests

## Testing
- `npm test --silent` *(fails: Cannot find module 'bcryptjs' and others)*
- `cd ethos-frontend && npm test --silent` *(fails: Jest failed to parse a file due to unsupported syntax)*

------
https://chatgpt.com/codex/tasks/task_e_685345d32458832fae98a1f74de11e3f