### PR TITLE
Add reply board pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Current build includes:
 - Posting messages, logs and tasks
 - Quests linking posts with Git repo metadata
 - Boards to visualize posts and quests in grid, graph or thread views
+- Thread replies endpoint now supports pagination via `page` and `limit` query options
 - Inline linking of quests and posts
 - Link dropdowns support node ID search and sorting
 - Review system for AI apps, quests and creators

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -67,14 +67,22 @@ router.get(
 //
 router.get(
   '/thread/:postId',
-  (req: Request<{ postId: string }, any, undefined, { enrich?: string }>, res: Response): void => {
+  (
+    req: Request<{ postId: string }, any, undefined, { enrich?: string; page?: string; limit?: string }>,
+    res: Response
+  ): void => {
     const { postId } = req.params;
-    const { enrich } = req.query;
+    const { enrich, page = '1', limit } = req.query;
 
     const posts = postsStore.read();
     const quests = questsStore.read();
 
-    const replies = posts.filter(p => p.replyTo === postId);
+    const pageNum = parseInt(page as string, 10) || 1;
+    const pageSize = parseInt(limit as string, 10) || DEFAULT_PAGE_SIZE;
+    const start = (pageNum - 1) * pageSize;
+    const end = start + pageSize;
+
+    const replies = posts.filter(p => p.replyTo === postId).slice(start, end);
 
     const board: BoardData = {
       id: `thread-${postId}`,

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -260,4 +260,54 @@ describe('route handlers', () => {
     expect(store).toHaveLength(1);
     expect(store[0].items).toContain('i1');
   });
+
+  it('GET /boards/thread/:postId paginates replies', async () => {
+    const { postsStore } = require('../src/models/stores');
+    postsStore.read.mockReturnValue([
+      {
+        id: 'r1',
+        authorId: 'u1',
+        type: 'free_speech',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        replyTo: 'p1',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      },
+      {
+        id: 'r2',
+        authorId: 'u1',
+        type: 'free_speech',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        replyTo: 'p1',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      },
+      {
+        id: 'r3',
+        authorId: 'u1',
+        type: 'free_speech',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        replyTo: 'p1',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      },
+    ]);
+
+    const res1 = await request(app).get('/boards/thread/p1?page=1&limit=2');
+    expect(res1.status).toBe(200);
+    expect(res1.body.items).toEqual(['r1', 'r2']);
+
+    const res2 = await request(app).get('/boards/thread/p1?page=2&limit=2');
+    expect(res2.status).toBe(200);
+    expect(res2.body.items).toEqual(['r3']);
+  });
 });

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -50,11 +50,12 @@ export const updatePost = async (id: string, updates: Partial<Post>): Promise<Po
  */
 export const fetchReplyBoard = async (
   postId: string,
-  options: { enrich?: boolean; page?: number } = {}
+  options: { enrich?: boolean; page?: number; limit?: number } = {}
 ): Promise<BoardData> => {
   const params = new URLSearchParams();
   if (options.enrich) params.set('enrich', 'true');
   if (options.page) params.set('page', options.page.toString());
+  if (options.limit) params.set('limit', options.limit.toString());
 
   const url = `/boards/thread/${postId}${params.toString() ? `?${params.toString()}` : ''}`;
   const res = await axiosWithAuth.get(url);

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -6,6 +6,7 @@ import { useSocket } from '../../hooks/useSocket';
 import { Spinner } from '../../components/ui';
 
 import { fetchPostById, fetchReplyBoard } from '../../api/post';
+import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
 
 import type { Post } from '../../types/postTypes';
 import type { BoardData } from '../../types/boardTypes';
@@ -31,6 +32,7 @@ const PostPage: React.FC = () => {
       const board = await fetchReplyBoard(id, {
         enrich: true,
         page: 1,
+        limit: DEFAULT_PAGE_SIZE,
       });
       setReplyBoard(board);
 
@@ -50,6 +52,7 @@ const PostPage: React.FC = () => {
       const board = await fetchReplyBoard(id, {
         enrich: true,
         page: nextPage,
+        limit: DEFAULT_PAGE_SIZE,
       });
 
       if (board.items?.length) {


### PR DESCRIPTION
## Summary
- paginate replies in `/thread/:postId` endpoint
- propagate limit option through `fetchReplyBoard`
- handle paging on post page
- test reply pagination

## Testing
- `cd ethos-backend && npm test --silent`
- `cd ethos-frontend && npm test --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68534623fb68832fa1e2d67e64132283