### PR TITLE
Add scroll end props to layouts

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import ContributionCard from '../contribution/ContributionCard';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
+import { Spinner } from '../ui';
 
 type GridLayoutProps = {
   items: Post[];
@@ -11,6 +12,8 @@ type GridLayoutProps = {
   compact?: boolean;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
+  onScrollEnd?: () => void;
+  loadingMore?: boolean;
 };
 
 const defaultKanbanColumns = ['To Do', 'In Progress', 'Done'];
@@ -23,7 +26,34 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   compact = false,
   onEdit,
   onDelete,
+  onScrollEnd,
+  loadingMore = false,
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!onScrollEnd) return;
+    const el = containerRef.current;
+    const handleScroll = () => {
+      if (!onScrollEnd) return;
+      if (el) {
+        const { scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth } = el;
+        const reachedBottom =
+          layout === 'horizontal' || layout === 'kanban'
+            ? scrollLeft + clientWidth >= scrollWidth - 100
+            : scrollTop + clientHeight >= scrollHeight - 100;
+        if (reachedBottom) onScrollEnd();
+      } else {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
+          onScrollEnd();
+        }
+      }
+    };
+
+    const target = el || window;
+    target.addEventListener('scroll', handleScroll);
+    return () => target.removeEventListener('scroll', handleScroll);
+  }, [onScrollEnd, layout]);
   if (!items || items.length === 0) {
     return (
       <div className="text-center text-gray-400 py-12 text-sm">
@@ -43,7 +73,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   /** 📌 Kanban Layout */
   if (layout === 'kanban') {
     return (
-      <div className="flex overflow-auto space-x-4 pb-4 px-2">
+      <div ref={containerRef} className="flex overflow-auto space-x-4 pb-4 px-2">
         {defaultKanbanColumns.map((col) => (
           <div
             key={col}
@@ -67,13 +97,17 @@ const GridLayout: React.FC<GridLayoutProps> = ({
         <div className="min-w-[280px] w-[320px] flex items-center justify-center text-blue-500 hover:text-blue-700 font-medium border rounded-lg shadow-sm bg-white cursor-pointer">
           + Add Column
         </div>
+        {loadingMore && (
+          <div className="w-full flex justify-center">
+            <Spinner />
+          </div>
+        )}
       </div>
     );
   }
 
   /** 📌 Horizontal Grid Layout */
   if (layout === 'horizontal') {
-    const containerRef = useRef<HTMLDivElement>(null);
     const [index, setIndex] = useState(0);
 
     const scrollToIndex = (i: number) => {
@@ -137,6 +171,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
             </div>
           </>
         )}
+        {loadingMore && <Spinner />}
       </div>
     );
   }
@@ -146,7 +181,6 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   const isPair = items.length === 2;
 
   if (layout === 'vertical' && items.length > 6) {
-    const containerRef = useRef<HTMLDivElement>(null);
     const handlePrev = () => containerRef.current?.scrollBy({ top: -200, behavior: 'smooth' });
     const handleNext = () => containerRef.current?.scrollBy({ top: 200, behavior: 'smooth' });
     return (
@@ -162,6 +196,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               onDelete={onDelete}
             />
           ))}
+          {loadingMore && <Spinner />}
         </div>
         <button
           type="button"
@@ -183,6 +218,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
 
   return (
     <div
+      ref={containerRef}
       className={
         isSingle
           ? 'flex justify-center items-start p-2'
@@ -202,6 +238,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
           />
         </div>
       ))}
+      {loadingMore && <Spinner />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- support `onScrollEnd` and `loadingMore` in `GridLayout`
- support `onScrollEnd` and `loadingMore` in `ThreadLayout`
- wire up scroll listeners for infinite scrolling

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*
- `npm test -- -w=1` in frontend *(fails: Jest encountered an unexpected token)*
- `npm test -- -w=1` in backend *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68534624fa88832fa45d3f7f3935d41b