### PR TITLE
Add initialExpanded option for thread view

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -35,6 +35,7 @@ const Board: React.FC<BoardProps> = ({
   loading: loadingMore = false,
   quest,
   gridLayout,
+  initialExpanded = false,
 }) => {
   const [board, setBoard] = useState<BoardData | null>(boardProp ?? null);
   const [loading, setLoading] = useState(true);
@@ -300,6 +301,7 @@ const Board: React.FC<BoardProps> = ({
           loadingMore={loadingMore}
           contributions={items}
           questId={quest?.id || ''}
+          initialExpanded={initialExpanded}
           {...(resolvedStructure === 'graph'
             ? { edges: quest?.taskGraph }
             : {})}

--- a/ethos-frontend/src/components/layout/ThreadLayout.tsx
+++ b/ethos-frontend/src/components/layout/ThreadLayout.tsx
@@ -12,6 +12,8 @@ interface ThreadLayoutProps {
   depth?: number;
   maxDepth?: number;
   questId?: string;
+  /** Expand all posts by default */
+  initialExpanded?: boolean;
 }
 
 /**
@@ -27,17 +29,25 @@ const ThreadLayout: React.FC<ThreadLayoutProps> = ({
   onDelete,
   depth = 0,
   maxDepth = 10,
-  questId
+  questId,
+  initialExpanded = false
 }) => {
-  const [expandedPosts, setExpandedPosts] = useState<Record<string, boolean>>({});
+  const childItems = contributions.filter(
+    (item) => item.replyTo === parentId || item.repostedFrom?.originalPostId === parentId
+  );
+
+  const [expandedPosts, setExpandedPosts] = useState<Record<string, boolean>>(() => {
+    if (!initialExpanded) return {};
+    const all: Record<string, boolean> = {};
+    childItems.forEach((it) => {
+      all[it.id] = true;
+    });
+    return all;
+  });
 
   const toggleExpand = (id: string) => {
     setExpandedPosts((prev) => ({ ...prev, [id]: !prev[id] }));
   };
-
-  const childItems = contributions.filter(
-    (item) => item.replyTo === parentId || item.repostedFrom?.originalPostId === parentId
-  );
 
   if (childItems.length === 0 || depth > maxDepth) return null;
 
@@ -86,6 +96,7 @@ const ThreadLayout: React.FC<ThreadLayoutProps> = ({
                 depth={depth + 1}
                 maxDepth={maxDepth}
                 questId={questId}
+                initialExpanded={initialExpanded}
               />
             )}
           </div>

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -103,6 +103,7 @@ const PostPage: React.FC = () => {
           board={createMockBoard(`post-${post.id}`, 'Post', [post])}
           editable={false}
           compact={false}
+          initialExpanded={true}
         />
       </section>
 
@@ -134,6 +135,7 @@ const PostPage: React.FC = () => {
             loading={loadingMore}
             editable={false}
             compact={true}
+            initialExpanded={true}
           />
         ) : (
           <p className="text-sm text-gray-500">No replies yet.</p>

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -77,6 +77,8 @@ export interface BoardProps {
   quest?: Quest;
   /** Layout variant for GridLayout */
   gridLayout?: 'vertical' | 'horizontal' | 'kanban';
+  /** Expand all threads when using ThreadLayout */
+  initialExpanded?: boolean;
 }
 
 /** Props for the EditBoard component */


### PR DESCRIPTION
## Summary
- allow ThreadLayout to expand all posts on initial render
- plumb initialExpanded prop through Board and PostPage to show full threads by default

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68534625886c832f997abd56ba219fa4