### PR TITLE
Add diff viewer and board highlight

### DIFF
--- a/ethos-frontend/src/components/git/GitDiffViewer.tsx
+++ b/ethos-frontend/src/components/git/GitDiffViewer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import MarkdownRenderer from '../ui/MarkdownRenderer';
+
+interface GitDiffViewerProps {
+  markdown: string;
+}
+
+const GitDiffViewer: React.FC<GitDiffViewerProps> = ({ markdown }) => {
+  return (
+    <div className="border rounded bg-gray-50 dark:bg-gray-800 p-2 text-sm overflow-x-auto">
+      <MarkdownRenderer content={markdown} />
+    </div>
+  );
+};
+
+export default GitDiffViewer;

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import ContributionCard from '../contribution/ContributionCard';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
@@ -24,6 +24,20 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   onEdit,
   onDelete,
 }) => {
+  useEffect(() => {
+    const handler = (e: any) => {
+      const id = e.detail?.taskId;
+      if (!id) return;
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.classList.add('ring-2', 'ring-blue-500');
+        setTimeout(() => el.classList.remove('ring-2', 'ring-blue-500'), 2000);
+      }
+    };
+    window.addEventListener('questTaskSelect', handler);
+    return () => window.removeEventListener('questTaskSelect', handler);
+  }, []);
   if (!items || items.length === 0) {
     return (
       <div className="text-center text-gray-400 py-12 text-sm">

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -162,7 +162,10 @@ const PostCard: React.FC<PostCardProps> = ({
   }
 
   return (
-    <div className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100 max-w-prose mx-auto">
+    <div
+      id={post.id}
+      className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100 max-w-prose mx-auto"
+    >
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -1,0 +1,51 @@
+const React = require('react');
+const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+jest.mock('../src/hooks/useGit', () => ({
+  useGitDiff: jest.fn(() => ({ data: { diffMarkdown: 'diff' }, isLoading: false }))
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn()
+}));
+
+const { useGitDiff } = require('../src/hooks/useGit');
+
+describe('GraphLayout node interaction', () => {
+  it('loads git diff and dispatches event on node click', async () => {
+    const posts = [
+      {
+        id: 'p1',
+        type: 'task',
+        content: 'Task',
+        authorId: 'u1',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+        gitFilePath: 'file.js',
+        gitCommitSha: 'abc'
+      }
+    ];
+
+    const listener = jest.fn();
+    window.addEventListener('questTaskSelect', listener);
+
+    render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    fireEvent.click(screen.getByText('Task'));
+
+    await waitFor(() => {
+      expect(useGitDiff).toHaveBeenCalledWith({
+        questId: 'q1',
+        filePath: 'file.js',
+        commitId: 'abc'
+      });
+    });
+
+    expect(listener).toHaveBeenCalled();
+    expect(screen.getByText('diff')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add GitDiffViewer component
- add click-to-load diff in GraphLayout
- dispatch questTaskSelect event on node click and display diff
- highlight matching item in GridLayout
- expose post id on PostCard for scrolling
- unit test for GraphLayout node click

## Testing
- `npm test` *(fails: Jest could not run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853472dcaf0832fb31f0787a755ba9c