### PR TITLE
Add setup script for npm install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install root dependencies using package-lock
+npm ci
+
+# Install backend dependencies
+npm ci --prefix ethos-backend


### PR DESCRIPTION
## Summary
- add `setup.sh` script to install npm dependencies using lockfiles

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6853476a6278832fa8a6974f5b0d8f04