### PR TITLE
Display status badges in PostCard

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -8,7 +8,7 @@ import type { User } from '../../types/userTypes';
 
 import { fetchRepliesByPostId, updatePost } from '../../api/post';
 import ReactionControls from '../controls/ReactionControls';
-import { PostTypeBadge, Spinner } from '../ui';
+import { PostTypeBadge, StatusBadge, Spinner } from '../ui';
 import MarkdownRenderer from '../ui/MarkdownRenderer';
 import MediaPreview from '../ui/MediaPreview';
 import LinkViewer from '../ui/LinkViewer';
@@ -166,6 +166,7 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />
+          {post.status && <StatusBadge status={post.status} />}
           <button
             type="button"
             onClick={() =>

--- a/ethos-frontend/src/components/ui/StatusBadge.tsx
+++ b/ethos-frontend/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { QuestTaskStatus } from '../../types/postTypes';
+
+interface StatusBadgeProps {
+  status: QuestTaskStatus;
+  className?: string;
+}
+
+const statusStyles: Record<string, string> = {
+  'To Do': 'bg-gray-100 text-gray-700',
+  'In Progress': 'bg-yellow-100 text-yellow-800',
+  Done: 'bg-green-100 text-green-800',
+};
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className }) => {
+  const style = statusStyles[status] || 'bg-gray-200 text-gray-700';
+  return (
+    <span
+      className={clsx(
+        'inline-block text-xs font-semibold px-2 py-1 rounded',
+        style,
+        className
+      )}
+    >
+      {status}
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/ethos-frontend/src/components/ui/index.tsx
+++ b/ethos-frontend/src/components/ui/index.tsx
@@ -11,5 +11,6 @@ export { default as Select } from './Select';
 export { default as TextArea } from './TextArea';
 export { default as ActionMenu } from './ActionMenu';
 export { default as PostTypeBadge } from './PostTypeBadge';
+export { default as StatusBadge } from './StatusBadge';
 export { default as Footer } from './Footer';
 export { default as Spinner } from './Spinner';


### PR DESCRIPTION
## Summary
- add `StatusBadge` component for task status labels
- export `StatusBadge` from UI module
- show a status badge in `PostCard` when a post has a status

## Testing
- `npm test` *(fails: cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_685369cf8abc832f9812711a9a026d3c