### PR TITLE
Add drag and graph reorg tests

### DIFF
--- a/ethos-frontend/tests/GraphLayoutReorg.test.js
+++ b/ethos-frontend/tests/GraphLayoutReorg.test.js
@@ -1,0 +1,24 @@
+const React = require('react');
+const { render, within } = require('@testing-library/react');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+jest.mock('../src/hooks/useGit', () => ({
+  useGitDiff: () => ({ data: null, isLoading: false })
+}));
+
+describe('GraphLayout task graph reorg', () => {
+  it('nests child tasks when edges define hierarchy', () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'Parent', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'Child', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+    const edges = [{ from: 'p1', to: 'p2' }];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, edges, questId: 'q1' }));
+    const rootNodes = container.querySelectorAll(':scope > div.relative');
+    expect(rootNodes.length).toBe(1);
+    const root = rootNodes[0];
+    expect(within(root).getByText('Parent')).toBeInTheDocument();
+    expect(within(root).getByText('Child')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/tests/GridLayoutKanban.test.js
+++ b/ethos-frontend/tests/GridLayoutKanban.test.js
@@ -1,0 +1,67 @@
+const React = require('react');
+const { render, act } = require('@testing-library/react');
+const GridLayout = require('../src/components/layout/GridLayout').default;
+
+// Capture the drag handler to simulate drag end
+let dragHandler;
+
+jest.mock('@dnd-kit/core', () => ({
+  DndContext: ({ onDragEnd, children }) => {
+    dragHandler = onDragEnd;
+    return React.createElement('div', {}, children);
+  },
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({
+    setNodeRef: jest.fn(),
+    isOver: false,
+  }),
+}), { virtual: true });
+
+jest.mock('@dnd-kit/utilities', () => ({ CSS: { Translate: { toString: () => '' } } }), { virtual: true });
+
+jest.mock('../src/api/post', () => ({
+  updatePost: jest.fn(() => Promise.resolve({ id: 't1', status: 'In Progress' }))
+}));
+
+const updateBoardItem = jest.fn();
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem })
+}));
+
+const { updatePost } = require('../src/api/post');
+
+const basePost = {
+  id: 't1',
+  type: 'task',
+  content: 'Task 1',
+  authorId: 'u1',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+  status: 'To Do'
+};
+
+describe('GridLayout kanban drag', () => {
+  it('calls updatePost and updates board state', async () => {
+    render(React.createElement(GridLayout, { items: [basePost], questId: 'q1', layout: 'kanban' }));
+
+    await act(async () => {
+      await dragHandler({
+        active: { id: basePost.id, data: { current: { item: basePost } } },
+        over: { id: 'In Progress' }
+      });
+    });
+
+    expect(updatePost).toHaveBeenCalledWith('t1', { status: 'In Progress' });
+    expect(updateBoardItem).toHaveBeenCalledWith('b1', { id: 't1', status: 'In Progress' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a kanban drag test for `GridLayout`
- add a graph reorganization test verifying child nesting

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest encountered unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_685369d11484832f96baabcbf0d57495