### PR TITLE
Fix drag-and-drop setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ everyone on the board.
 
 ### Setup for drag and drop
 
-The Kanban board relies on the `@dnd-kit` libraries. Install them in the
-frontend directory before running the app:
+The Kanban board relies on the `@dnd-kit` libraries. Install `@dnd-kit/core`
+in the frontend directory before running the app. The `@dnd-kit/sortable`
+package is optional if you want additional sorting utilities:
 
 ```bash
-npm install --prefix ethos-frontend @dnd-kit/core @dnd-kit/sortable
+npm install --prefix ethos-frontend @dnd-kit/core
 ```
 
 


### PR DESCRIPTION
## Summary
- update drag and drop instructions to clarify `@dnd-kit/sortable` is optional

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685377d41950832f81d27248f8965292