### PR TITLE
Add Blocked status column

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -20,7 +20,7 @@ type GridLayoutProps = {
   loadingMore?: boolean;
 };
 
-const defaultKanbanColumns = ['To Do', 'In Progress', 'Done'];
+const defaultKanbanColumns = ['To Do', 'In Progress', 'Blocked', 'Done'];
 
 const DraggableCard: React.FC<{
   item: Post;

--- a/ethos-frontend/src/components/ui/StatusBadge.tsx
+++ b/ethos-frontend/src/components/ui/StatusBadge.tsx
@@ -10,6 +10,7 @@ interface StatusBadgeProps {
 const statusStyles: Record<string, string> = {
   'To Do': 'bg-gray-100 text-gray-700',
   'In Progress': 'bg-yellow-100 text-yellow-800',
+  Blocked: 'bg-red-100 text-red-800',
   Done: 'bg-green-100 text-green-800',
 };
 

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -28,6 +28,7 @@ export const LINK_TYPES = ['solution', 'duplicate', 'citation'];
 export const STATUS_OPTIONS = [
   { value: 'To Do', label: 'To Do' },
   { value: 'In Progress', label: 'In Progress' },
+  { value: 'Blocked', label: 'Blocked' },
   { value: 'Done', label: 'Done' },
 ] as const;
 


### PR DESCRIPTION
## Summary
- show a Blocked column in kanban boards
- style Blocked status badges
- expose Blocked in status options

## Testing
- `npx jest` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685377d78b24832fa6a992771eb12ca3