### PR TITLE
Fix theme init timing

### DIFF
--- a/ethos-frontend/index.html
+++ b/ethos-frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
     <script>
-      (function () {
+      window.addEventListener('DOMContentLoaded', () => {
         try {
           const stored = localStorage.getItem('theme');
           const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -17,7 +17,7 @@
         } catch (e) {
           console.warn('Theme init error', e);
         }
-      })();
+      });
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- ensure theme code runs after DOM loads

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --prefix ethos-frontend --legacy-peer-deps` *(fails: No matching version found for @dnd-kit/core@^7.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_685383a3e720832faf4590a78a28d300