### PR TITLE
Fix GridLayout containerRef

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -78,6 +78,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   onScrollEnd,
   loadingMore = false,
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const handler = (e: any) => {
       const id = e.detail?.taskId;


### PR DESCRIPTION
## Summary
- ensure `containerRef` is declared in `GridLayout`

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_685383a504b8832f9ae498d771c0212e