### PR TITLE
Add container ref for ThreadLayout

### DIFF
--- a/ethos-frontend/src/components/layout/ThreadLayout.tsx
+++ b/ethos-frontend/src/components/layout/ThreadLayout.tsx
@@ -36,6 +36,7 @@ const ThreadLayout: React.FC<ThreadLayoutProps> = ({
   loadingMore = false,
   initialExpanded = false
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const childItems = contributions.filter(
     (item) => item.replyTo === parentId || item.repostedFrom?.originalPostId === parentId
   );


### PR DESCRIPTION
## Summary
- provide a `containerRef` for `ThreadLayout` and use it on the top-level div

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm run lint` *(fails: eslint-plugin-react-hooks not found)*

------
https://chatgpt.com/codex/tasks/task_e_685383a6c248832f9a1715b7f119db92