### PR TITLE
Fix LinkViewer link resolution guard

### DIFF
--- a/ethos-frontend/src/components/ui/LinkViewer.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.tsx
@@ -16,6 +16,9 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items }) => {
       const updated = await Promise.all(
         items.map(async (item) => {
           try {
+            if (!item.itemId) {
+              return item;
+            }
             if (item.itemType === 'quest') {
               const q = await fetchQuestById(item.itemId);
               return { ...item, title: q.title };


### PR DESCRIPTION
## Summary
- check for `item.itemId` before resolving a linked quest or post

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6853864b74a0832fbc66327548033111