### PR TITLE
Fix board context loading state check

### DIFF
--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -37,7 +37,7 @@ export interface BoardContextType {
 const BoardContext = createContext<BoardContextType | undefined>(undefined);
 
 export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   const [boards, setBoards] = useState<BoardMap>({});
   const [selectedBoard, setSelectedBoard] = useState<string | null>(null);
@@ -49,6 +49,7 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   };
 
   useEffect(() => {
+    if (authLoading) return;
     const loadBoards = async () => {
       setLoading(true);
       try {
@@ -68,7 +69,7 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     };
 
     loadBoards();
-  }, [user]);
+  }, [user, authLoading]);
 
   const appendToBoard = (boardId: string, newItem: BoardItem) => {
     setBoards((prev) => {


### PR DESCRIPTION
## Summary
- ensure `BoardProvider` waits for auth state before loading

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68540c1b78f0832f844f1e567f218f50