### PR TITLE
Fix dark mode backgrounds

### DIFF
--- a/ethos-frontend/jest.setup.ts
+++ b/ethos-frontend/jest.setup.ts
@@ -13,3 +13,6 @@ if (typeof global.TextDecoder === 'undefined') {
   // @ts-ignore
   global.TextDecoder = TextDecoder;
 }
+
+// Provide a default API base for modules that read from import.meta.env
+process.env.VITE_API_URL = 'http://localhost:3001/api';

--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
         <TimelineProvider>
           <BoardProvider>
             <ThemeProvider>
-            <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+            <div className="min-h-screen flex flex-col bg-soft dark:bg-soft-dark text-gray-900 dark:text-gray-100">
               {/* Top-level navigation */}
               <NavBar />
 

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -23,8 +23,15 @@ let socket: Socket | null = null;
  */
 export const getSocket = (): Socket => {
   if (!socket) {
-    const SOCKET_URL =
-      import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+    const getEnv = () => {
+      try {
+        return Function('return import.meta.env')();
+      } catch {
+        return {};
+      }
+    };
+
+    const SOCKET_URL = getEnv().VITE_SOCKET_URL || process.env.VITE_SOCKET_URL || 'http://localhost:3001';
     socket = io(SOCKET_URL, {
       autoConnect: false,
       transports: ['websocket'],

--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -119,7 +119,7 @@ const Login: React.FC = () => {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+    <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4">
       <section className="w-full max-w-md bg-white p-8 rounded-lg shadow-lg">
         <header className="mb-6 text-center">
           <h1 className="text-3xl font-bold text-gray-800">

--- a/ethos-frontend/src/pages/NotFound.tsx
+++ b/ethos-frontend/src/pages/NotFound.tsx
@@ -31,7 +31,7 @@ const NotFound: React.FC = () => {
   const hasPosts = user && userPostBoard?.enrichedItems?.length;
 
   return (
-    <main className="min-h-screen bg-gray-100 px-4 py-12">
+    <main className="min-h-screen bg-soft dark:bg-soft-dark px-4 py-12">
       <section className="text-center max-w-2xl mx-auto mb-12">
         <h1 className="text-6xl font-extrabold text-gray-900 mb-4">404</h1>
         <h2 className="text-2xl font-semibold text-gray-700 mb-2">

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -46,7 +46,7 @@ const ProfilePage: React.FC = () => {
   const castUser = user as unknown as User;
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-6xl">
+    <main className="container mx-auto px-4 py-8 max-w-6xl bg-soft dark:bg-soft-dark">
       
       <Banner user={castUser} />
 

--- a/ethos-frontend/src/pages/PublicProfile.tsx
+++ b/ethos-frontend/src/pages/PublicProfile.tsx
@@ -86,7 +86,7 @@ const PublicProfilePage: React.FC = () => {
   }
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-10">
+    <main className="max-w-6xl mx-auto px-4 py-10 bg-soft dark:bg-soft-dark">
       <Banner user={profile} readOnly />
 
       {/* 📘 Public Quests */}

--- a/ethos-frontend/src/pages/ResetPassword.tsx
+++ b/ethos-frontend/src/pages/ResetPassword.tsx
@@ -100,7 +100,7 @@ const ResetPassword: React.FC = () => {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+    <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4">
       <section className="w-full max-w-md bg-white p-8 rounded-lg shadow-lg">
         <header className="mb-6 text-center">
           <h1 className="text-2xl font-bold text-gray-800">Reset Your Password</h1>

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -89,7 +89,7 @@ const BoardPage: React.FC = () => {
   const editable = canEditBoard(boardData.id);
 
   return (
-    <main className="max-w-7xl mx-auto p-4 space-y-8">
+    <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
       <div className="bg-gray-100 dark:bg-gray-900 rounded-xl shadow-lg p-6 space-y-6">
         <div className="flex justify-between items-center">
           <h1 className="text-3xl font-bold">{boardData.title}</h1>

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -21,7 +21,7 @@ const HomePage: React.FC = () => {
   }
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-6xl space-y-12">
+    <main className="container mx-auto px-4 py-8 max-w-6xl space-y-12 bg-soft dark:bg-soft-dark">
       <header className="mb-4">
         <h1 className="text-4xl font-bold tracking-tight text-gray-900 mb-2">
           Welcome to Ethos

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -88,7 +88,7 @@ const QuestPage: React.FC = () => {
   }
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-10 space-y-12">
+    <main className="max-w-6xl mx-auto px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark">
       {/* 🎯 Quest Summary Card */}
       <Banner quest={quest} />
       <Board

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -4,7 +4,15 @@ import axios, { type AxiosInstance, AxiosError } from 'axios';
 /**
  * 📡 Base API URL — should be environment-configurable
  */
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+const getEnv = () => {
+  try {
+    return Function('return import.meta.env')();
+  } catch {
+    return {};
+  }
+};
+
+const API_BASE = getEnv().VITE_API_URL || process.env.VITE_API_URL || 'http://localhost:3001/api';
 
 /**
  * 🔐 In-memory access token used for Authorization header


### PR DESCRIPTION
## Summary
- use `bg-soft` colors for root container and pages
- avoid `import.meta` during tests
- set API env in jest setup

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: ReferenceError require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685409784f9c832fa9afcb39e43d768b