### PR TITLE
Update fetchBoards API usage

### DIFF
--- a/ethos-frontend/src/api/board.ts
+++ b/ethos-frontend/src/api/board.ts
@@ -12,8 +12,13 @@ const BASE_URL = '/boards';
  * 🧠 fetchBoards → Get all boards (optionally filtered by user)
  * @param userId Optional user ID to fetch personal boards
  */
-export const fetchBoards = async (userId?: string): Promise<BoardData[]> => {
-  const url = userId ? `${BASE_URL}?userId=${userId}` : BASE_URL;
+export const fetchBoards = async (
+  options?: { userId?: string; enrich?: boolean }
+): Promise<BoardData[]> => {
+  const params = new URLSearchParams();
+  if (options?.userId) params.set('userId', options.userId);
+  if (options?.enrich) params.set('enrich', 'true');
+  const url = `${BASE_URL}${params.toString() ? `?${params.toString()}` : ''}`;
   const res = await axiosWithAuth.get(url);
   return res.data;
 };

--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -53,7 +53,7 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     const loadBoards = async () => {
       setLoading(true);
       try {
-        const boardList = await fetchBoardsAPI(user?.id);
+        const boardList = await fetchBoardsAPI({ userId: user?.id, enrich: true });
         const boardMap: BoardMap = {};
         boardList.forEach((b: BoardData) => {
           boardMap[b.id] = b;
@@ -144,7 +144,7 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const refreshBoards = async () => {
     if (!user) return;
     try {
-      const boardList = await fetchBoardsAPI(user.id);
+      const boardList = await fetchBoardsAPI({ userId: user.id, enrich: true });
       const boardMap: BoardMap = {};
       boardList.forEach((b: BoardData) => {
         boardMap[b.id] = b;

--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -74,7 +74,7 @@ export const useBoard = (
 
   const fetchAllBoards = useCallback(async (userId?: string) => {
     try {
-      const list = await fetchBoards(userId); // ⬅ pass to actual API call
+      const list = await fetchBoards({ userId, enrich: true });
       return list;
     } catch (err) {
       console.error('[useBoard] Failed to fetch all boards:', err);

--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -82,7 +82,7 @@ const Login: React.FC = () => {
         socket.emit('user_connected', { userId: user.id });
       
         // 🔁 Sync boards
-        const userBoards = await fetchBoards(user.id);
+        const userBoards = await fetchBoards({ userId: user.id, enrich: true });
         const defaultBoard =
           userBoards.find(b => b.defaultFor === 'home') || userBoards[0];
         if (defaultBoard) {


### PR DESCRIPTION
## Summary
- support options object when fetching boards
- request enriched data on login, refresh and hook calls

## Testing
- `npm test -- -w=1` within `ethos-backend` *(fails: cannot find modules)*
- `npm run lint` within `ethos-frontend` *(fails: cannot find modules)*
- `npm run build` within `ethos-frontend` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68540e007e30832f93280be499a6eeab