### PR TITLE
Fix API base env check

### DIFF
--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -12,7 +12,10 @@ const getEnv = () => {
   }
 };
 
-const API_BASE = getEnv().VITE_API_URL || process.env.VITE_API_URL || 'http://localhost:3001/api';
+const API_BASE =
+  getEnv().VITE_API_URL ||
+  (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
+  'http://localhost:3001/api';
 
 /**
  * 🔐 In-memory access token used for Authorization header


### PR DESCRIPTION
## Summary
- protect `process.env` access in `authUtils`

## Testing
- `npm run build --prefix ethos-frontend` *(fails: TypeScript errors but no "process is not defined" message)*

------
https://chatgpt.com/codex/tasks/task_e_68541a1b6da8832f9756f6b9b1181b24