### PR TITLE
Update socket url fallback

### DIFF
--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -31,7 +31,10 @@ export const getSocket = (): Socket => {
       }
     };
 
-    const SOCKET_URL = getEnv().VITE_SOCKET_URL || process.env.VITE_SOCKET_URL || 'http://localhost:3001';
+    const SOCKET_URL =
+      getEnv().VITE_SOCKET_URL ||
+      (typeof process !== 'undefined' ? process.env.VITE_SOCKET_URL : undefined) ||
+      'http://localhost:3001';
     socket = io(SOCKET_URL, {
       autoConnect: false,
       transports: ['websocket'],


### PR DESCRIPTION
## Summary
- better check for `process.env` when setting the socket URL

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68541a1d019c832fbc21ac75089729e5