### PR TITLE
Add condensed Graph view

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -24,7 +24,7 @@ export type ReactionCountMap = Record<ReactionType, number>;
 //
 // 🧭 BOARD
 //
-export type BoardLayout = 'grid' | 'graph' | 'thread';
+export type BoardLayout = 'grid' | 'graph' | 'graph-condensed' | 'thread';
   
 /**
  * Supported tags for labeling and filtering posts.

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -186,7 +186,9 @@ const Board: React.FC<BoardProps> = ({
   const baseStructure: BoardLayout =
     (viewMode || forcedStructure || board?.layout || 'grid') as BoardLayout;
   const resolvedStructure: BoardLayout =
-    baseStructure === 'graph' && !graphEligible ? 'grid' : baseStructure;
+    (baseStructure === 'graph' || baseStructure === 'graph-condensed') && !graphEligible
+      ? 'grid'
+      : baseStructure;
 
   const editable = useMemo(() => {
     if (readOnly) return false;
@@ -197,6 +199,7 @@ const Board: React.FC<BoardProps> = ({
   const Layout = {
     grid: GridLayout,
     graph: GraphLayout,
+    'graph-condensed': GraphLayout,
     thread: ThreadLayout,
   }[resolvedStructure] ?? GridLayout;
 
@@ -246,7 +249,12 @@ const Board: React.FC<BoardProps> = ({
                 onChange={(e) => setViewMode(e.target.value as BoardLayout)}
                 options={[
                   { value: 'grid', label: 'Grid' },
-                  ...(graphEligible ? [{ value: 'graph', label: 'Graph' }] : []),
+                  ...(graphEligible
+                    ? [
+                        { value: 'graph', label: 'Graph' },
+                        { value: 'graph-condensed', label: 'Graph (Condensed)' },
+                      ]
+                    : []),
                   { value: 'thread', label: 'Timeline' },
                 ]}
               />
@@ -301,7 +309,11 @@ const Board: React.FC<BoardProps> = ({
         </div>
       ) : (
         <Layout
-          items={resolvedStructure === 'graph' ? graphItems : renderableItems}
+          items={
+            resolvedStructure === 'graph' || resolvedStructure === 'graph-condensed'
+              ? graphItems
+              : renderableItems
+          }
           compact={compact}
           user={user}
           onScrollEnd={onScrollEnd}
@@ -309,9 +321,10 @@ const Board: React.FC<BoardProps> = ({
           contributions={items}
           questId={quest?.id || ''}
           initialExpanded={initialExpanded}
-          {...(resolvedStructure === 'graph'
+          {...(resolvedStructure === 'graph' || resolvedStructure === 'graph-condensed'
             ? { edges: quest?.taskGraph }
             : {})}
+          {...(resolvedStructure === 'graph-condensed' ? { condensed: true } : {})}
           {...(resolvedStructure === 'grid' ? { layout: gridLayout } : {})}
         />
       )}

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -5,6 +5,7 @@ import type { PostType } from '../types/postTypes';
 export const STRUCTURE_OPTIONS: { value: BoardLayout; label: string }[] = [
   { value: 'grid', label: 'Grid' },
   { value: 'graph', label: 'Graph' },
+  { value: 'graph-condensed', label: 'Graph (Condensed)' },
   { value: 'thread', label: 'Thread' },
 ];
 

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -55,7 +55,7 @@ export interface RenderableItem {
 
 export type BoardItem = RenderableItem | Post | Quest | Board ;
 
-export type BoardLayout = 'grid' | 'graph' | 'thread';
+export type BoardLayout = 'grid' | 'graph' | 'graph-condensed' | 'thread';
 
 
 /** Props passed to the Board component */

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -48,4 +48,32 @@ describe('GraphLayout node interaction', () => {
     expect(listener).toHaveBeenCalled();
     expect(screen.getByText('diff')).toBeInTheDocument();
   });
+
+  it('renders condensed nodes with labels', () => {
+    const posts = [
+      {
+        id: 'p1',
+        nodeId: 'N1',
+        type: 'task',
+        content: 'Some very long task content that should be trimmed',
+        authorId: 'u1',
+        visibility: 'public',
+        timestamp: '',
+        tags: ['task'],
+        collaborators: [],
+        linkedItems: [],
+      },
+    ];
+
+    render(
+      React.createElement(GraphLayout, {
+        items: posts,
+        questId: 'q1',
+        condensed: true,
+      })
+    );
+
+    expect(screen.getByText('N1')).toBeInTheDocument();
+    expect(screen.queryByText('Some very long task content')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add optional `condensed` mode in `GraphLayout` to render small color-coded nodes
- expose condensed graph layout option in board controls and constants
- update board and backend types for new layout value
- add unit test verifying condensed node rendering

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest couldn't parse ESM modules)*
- `npm test --prefix ethos-backend` *(fails: missing dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685426fec300832f87859a2175ab48e3