### PR TITLE
Enable drag-and-drop linking in GraphLayout

### DIFF
--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -158,3 +158,22 @@ export const enrichQuestWithData = async (quest: Quest): Promise<EnrichedQuest> 
     isNew: false,
   };
 };
+
+/**
+ * Link a post to a quest and optionally specify a parent task
+ * @function linkPostToQuest
+ * @param questId - Quest ID
+ * @param data - Link details { postId, parentId?, edgeType?, edgeLabel? }
+ */
+export const linkPostToQuest = async (
+  questId: string,
+  data: {
+    postId: string;
+    parentId?: string;
+    edgeType?: 'sub_problem' | 'solution_branch' | 'folder_split';
+    edgeLabel?: string;
+  }
+): Promise<Quest> => {
+  const res = await axiosWithAuth.post(`${BASE_URL}/${questId}/link`, data);
+  return res.data;
+};

--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { DndContext, useDraggable, useDroppable, type DragEndEvent } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
 import { useGitDiff } from '../../hooks/useGit';
 import GitDiffViewer from '../git/GitDiffViewer';
 import { Spinner } from '../ui';
 import ContributionCard from '../contribution/ContributionCard';
+import { linkPostToQuest } from '../../api/quest';
 import type { User } from '../../types/userTypes';
 import type { Post } from '../../types/postTypes';
 
@@ -39,6 +42,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [rootNodes, setRootNodes] = useState<(Post & { children?: NodeChild[] })[]>([]);
+  const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges || []);
   const [selectedNode, setSelectedNode] = useState<Post | null>(null);
 
   const { data: diffData, isLoading: diffLoading } = useGitDiff({
@@ -55,9 +59,9 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       nodeMap[item.id] = { ...item, children: [] };
     });
 
-    if (edges && edges.length > 0) {
-      const toIds = new Set(edges.map((e) => e.to));
-      edges.forEach((edge) => {
+    if (edgeList && edgeList.length > 0) {
+      const toIds = new Set(edgeList.map((e) => e.to));
+      edgeList.forEach((edge) => {
         const fromNode = nodeMap[edge.from];
         const toNode = nodeMap[edge.to];
         if (fromNode && toNode) {
@@ -82,7 +86,11 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     }
 
     setRootNodes(roots);
-  }, [items, edges]);
+  }, [items, edgeList]);
+
+  useEffect(() => {
+    setEdgeList(edges || []);
+  }, [edges]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -105,6 +113,23 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     );
   };
 
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    try {
+      await linkPostToQuest(questId, {
+        postId: active.id as string,
+        parentId: over.id as string,
+      });
+      setEdgeList((prev) => [
+        ...prev,
+        { from: over.id as string, to: active.id as string },
+      ]);
+    } catch (err) {
+      console.error('[GraphLayout] failed to link post:', err);
+    }
+  };
+
   const renderNode = (
     node: Post & { children?: NodeChild[] },
     depth: number = 0,
@@ -113,54 +138,74 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     const isFolder = node.type === 'quest' || node.tags.includes('quest');
     const icon = isFolder ? '📁' : '📄';
 
+    const {
+      attributes,
+      listeners,
+      setNodeRef,
+      transform,
+      isDragging,
+    } = useDraggable({ id: node.id });
+    const { setNodeRef: setDropRef, isOver } = useDroppable({ id: node.id });
+    const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
+
     return (
-      <div key={node.id} className="relative">
-        <div
-          className={`ml-${depth * 4} mb-6 flex items-start space-x-2 cursor-pointer`}
-          onClick={() => handleNodeClick(node)}
-        >
-          <span className="text-xl select-none">{icon}</span>
-          <ContributionCard contribution={node} user={user} compact={compact} />
-          {edge && (
-            <span className="text-xs text-gray-500 ml-1">
-              {edge.label || edge.type}
-            </span>
+      <div
+        key={node.id}
+        ref={setDropRef}
+        className={`relative ${isOver ? 'ring-2 ring-blue-400' : ''}`}
+      >
+        <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : ''}>
+          <div
+            className={`ml-${depth * 4} mb-6 flex items-start space-x-2 cursor-pointer`}
+            onClick={() => handleNodeClick(node)}
+            {...attributes}
+            {...listeners}
+          >
+            <span className="text-xl select-none">{icon}</span>
+            <ContributionCard contribution={node} user={user} compact={compact} />
+            {edge && (
+              <span className="text-xs text-gray-500 ml-1">
+                {edge.label || edge.type}
+              </span>
+            )}
+          </div>
+          {selectedNode?.id === node.id && (
+            <div className="ml-8 mb-4">
+              {diffLoading ? <Spinner /> : diffData?.diffMarkdown && (
+                <GitDiffViewer markdown={diffData.diffMarkdown} />
+              )}
+            </div>
+          )}
+          {node.children && node.children.length > 0 && (
+            <div className="ml-8 border-l border-gray-300 pl-4">
+              {node.children.map((child) =>
+                renderNode(child.node, depth + 1, child.edge)
+              )}
+            </div>
           )}
         </div>
-        {selectedNode?.id === node.id && (
-          <div className="ml-8 mb-4">
-            {diffLoading ? <Spinner /> : diffData?.diffMarkdown && (
-              <GitDiffViewer markdown={diffData.diffMarkdown} />
-            )}
-          </div>
-        )}
-        {node.children && node.children.length > 0 && (
-          <div className="ml-8 border-l border-gray-300 pl-4">
-            {node.children.map((child) =>
-              renderNode(child.node, depth + 1, child.edge)
-            )}
-          </div>
-        )}
       </div>
     );
   };
 
   return (
-    <div
-      ref={containerRef}
-      className={
-        'overflow-auto w-full h-full p-4 max-w-7xl mx-auto ' +
-        (rootNodes.length === 1 ? 'flex justify-center' : '')
-      }
-      style={{ minHeight: '50vh' }}
-    >
-      {rootNodes.map((node) => renderNode(node))}
-      {loadingMore && (
-        <div className="flex justify-center py-4">
-          <Spinner />
-        </div>
-      )}
-    </div>
+    <DndContext onDragEnd={handleDragEnd}>
+      <div
+        ref={containerRef}
+        className={
+          'overflow-auto w-full h-full p-4 max-w-7xl mx-auto ' +
+          (rootNodes.length === 1 ? 'flex justify-center' : '')
+        }
+        style={{ minHeight: '50vh' }}
+      >
+        {rootNodes.map((node) => renderNode(node))}
+        {loadingMore && (
+          <div className="flex justify-center py-4">
+            <Spinner />
+          </div>
+        )}
+      </div>
+    </DndContext>
   );
 };
 

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -1,0 +1,53 @@
+const React = require('react');
+const { render, act, within } = require('@testing-library/react');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+let dragHandler;
+
+jest.mock('@dnd-kit/core', () => ({
+  DndContext: ({ onDragEnd, children }) => {
+    dragHandler = onDragEnd;
+    return React.createElement('div', {}, children);
+  },
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({ setNodeRef: jest.fn(), isOver: false }),
+}), { virtual: true });
+
+jest.mock('../src/hooks/useGit', () => ({
+  useGitDiff: () => ({ data: null, isLoading: false })
+}));
+
+jest.mock('../src/api/quest', () => ({
+  linkPostToQuest: jest.fn(() => Promise.resolve({}))
+}));
+
+const { linkPostToQuest } = require('../src/api/quest');
+
+describe('GraphLayout drag and drop', () => {
+  it('links tasks on drop and updates hierarchy', async () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'Parent', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'Child', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    await act(async () => {
+      await dragHandler({ active: { id: 'p2' }, over: { id: 'p1' } });
+    });
+
+    expect(linkPostToQuest).toHaveBeenCalledWith('q1', { postId: 'p2', parentId: 'p1' });
+
+    const rootNodes = container.querySelectorAll(':scope > div.relative');
+    expect(rootNodes.length).toBe(1);
+    const root = rootNodes[0];
+    expect(within(root).getByText('Parent')).toBeInTheDocument();
+    expect(within(root).getByText('Child')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate `@dnd-kit/core` in `GraphLayout` so tasks can be dragged onto other tasks
- update task graph state on drop and call `linkPostToQuest`
- expose API helper for linking posts to quests
- show visual feedback during drag
- test drag-and-drop hierarchy updates

## Testing
- `npm test --silent` *(fails: Jest couldn't parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_685426fffa40832fabfb3dfad15356db