### PR TITLE
Fix PostCSS plugin and API duplication

### DIFF
--- a/ethos-frontend/postcss.config.cjs
+++ b/ethos-frontend/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -176,22 +176,3 @@ export const enrichQuestWithData = async (quest: Quest): Promise<EnrichedQuest> 
     isNew: false,
   };
 };
-
-/**
- * Link a post to a quest and optionally specify a parent task
- * @function linkPostToQuest
- * @param questId - Quest ID
- * @param data - Link details { postId, parentId?, edgeType?, edgeLabel? }
- */
-export const linkPostToQuest = async (
-  questId: string,
-  data: {
-    postId: string;
-    parentId?: string;
-    edgeType?: 'sub_problem' | 'solution_branch' | 'folder_split';
-    edgeLabel?: string;
-  }
-): Promise<Quest> => {
-  const res = await axiosWithAuth.post(`${BASE_URL}/${questId}/link`, data);
-  return res.data;
-};


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin in PostCSS config
- remove duplicate `linkPostToQuest` definition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685455b9dea4832fbcdce91f2bc1dcaf