### PR TITLE
Fix PostCard prop

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -32,7 +32,12 @@ interface PostCardProps {
 }
 
 const PostCard: React.FC<PostCardProps> = ({
-  post, user, onUpdate, onDelete, compact = false
+  post,
+  user,
+  onUpdate,
+  onDelete,
+  compact = false,
+  questId,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [replies, setReplies] = useState<Post[]>([]);


### PR DESCRIPTION
## Summary
- pass `questId` into `PostCard` by destructuring the prop

## Testing
- `npm test --prefix ethos-frontend` *(fails: No QueryClient set, use QueryClientProvider to set one)*

------
https://chatgpt.com/codex/tasks/task_e_68545aff7d5c832f96dbd3fbde79d53e