### PR TITLE
Add dark mode styling for form inputs

### DIFF
--- a/ethos-frontend/src/components/ui/Input.tsx
+++ b/ethos-frontend/src/components/ui/Input.tsx
@@ -17,20 +17,28 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <div className="w-full space-y-1">
         {srOnlyLabel && <label htmlFor={id} className="sr-only">{srOnlyLabel}</label>}
 
-        <div className="flex items-center border rounded-md shadow-sm focus-within:ring-2 focus-within:ring-accent focus-within:border-accent overflow-hidden">
-          {prefix && <span className="px-2 text-gray-500 bg-gray-100">{prefix}</span>}
+        <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus-within:ring-2 focus-within:ring-accent focus-within:border-accent overflow-hidden bg-white dark:bg-gray-700">
+          {prefix && (
+            <span className="px-2 text-gray-500 bg-gray-100 dark:text-gray-300 dark:bg-gray-600">
+              {prefix}
+            </span>
+          )}
           <input
             id={id}
             ref={ref}
             className={clsx(
-              'w-full px-3 py-2 text-sm',
-              error ? 'border-red-500' : 'border-gray-300',
+              'w-full px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100',
+              error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600',
               'focus:outline-none',
               className
             )}
             {...props} // only standard input attributes passed here
           />
-          {suffix && <span className="px-2 text-gray-500 bg-gray-100">{suffix}</span>}
+          {suffix && (
+            <span className="px-2 text-gray-500 bg-gray-100 dark:text-gray-300 dark:bg-gray-600">
+              {suffix}
+            </span>
+          )}
         </div>
 
         {helperText && (

--- a/ethos-frontend/src/components/ui/Select.tsx
+++ b/ethos-frontend/src/components/ui/Select.tsx
@@ -23,10 +23,10 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           value={value}
           onChange={onChange}
           className={clsx(
-            'w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:outline-none',
+            'w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100',
             error
               ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-              : 'border-gray-300 focus:ring-accent focus:border-accent',
+              : 'border-gray-300 dark:border-gray-600 focus:ring-accent focus:border-accent',
             'disabled:cursor-not-allowed disabled:opacity-50',
             className
           )}

--- a/ethos-frontend/src/components/ui/TextArea.tsx
+++ b/ethos-frontend/src/components/ui/TextArea.tsx
@@ -43,12 +43,12 @@ const TextArea: React.FC<TextAreaProps> = ({
         readOnly={readOnly}
         onChange={onChange}
         className={clsx(
-          'w-full p-3 rounded-md border shadow-sm resize-y text-sm text-gray-900 focus:outline-none',
+          'w-full p-3 rounded-md border shadow-sm resize-y text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 focus:outline-none',
           error
             ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-            : 'border-gray-300 focus:ring-accent focus:border-accent',
+            : 'border-gray-300 dark:border-gray-600 focus:ring-accent focus:border-accent',
           {
-            'bg-gray-100 cursor-not-allowed': disabled || readOnly,
+            'bg-gray-100 dark:bg-gray-600 cursor-not-allowed': disabled || readOnly,
           },
           className
         )}


### PR DESCRIPTION
## Summary
- add dark mode styles for `Input`, `TextArea`, and `Select`
- include dark borders, text, and backgrounds

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854651a3f50832f99b2dbf39eb5a6d3