### PR TITLE
Update dark mode style for filter buttons

### DIFF
--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -171,7 +171,11 @@ const LinkControls: React.FC<LinkControlsProps> = ({
                   key={t}
                   type="button"
                   onClick={() => setPostTypeFilter(t as any)}
-                  className={`text-xs px-2 py-0.5 rounded ${postTypeFilter===t ? 'bg-indigo-600 text-white' : 'bg-gray-100'}`}
+                  className={`text-xs px-2 py-0.5 rounded ${
+                    postTypeFilter === t
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-700 dark:text-gray-200'
+                  }`}
                 >
                   {t}
                 </button>


### PR DESCRIPTION
## Summary
- make post type filter buttons adapt to dark theme

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6854651da0ac832fb0a23dccb372cc06