### PR TITLE
Fix indentation style in GraphLayout

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -211,7 +211,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       >
         <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : ''}>
           <div
-            className={`ml-${depth * 4} mb-6 flex items-start space-x-2 cursor-pointer`}
+            className="mb-6 flex items-start space-x-2 cursor-pointer"
+            style={{ marginLeft: depth * 16 }}
             onClick={() => handleNodeClick(node)}
             {...attributes}
             {...listeners}


### PR DESCRIPTION
## Summary
- remove dynamic margin class from graph nodes
- use inline style to offset nodes by depth

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6854656c5bec832f82ac0d36ebc81b5c