### PR TITLE
Unify dark background color token

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -14,7 +14,6 @@ import GraphLayout from '../layout/GraphLayout';
 import ThreadLayout from '../layout/ThreadLayout';
 
 import { Button, Input, Select, Spinner } from '../ui';
-import { useTheme } from '../../contexts/ThemeContext';
 
 import type { BoardData, BoardProps, BoardLayout } from '../../types/boardTypes';
 import type { Post } from '../../types/postTypes';
@@ -50,7 +49,6 @@ const Board: React.FC<BoardProps> = ({
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const { theme } = useTheme();
 
   // Keep items state in sync with BoardContext updates
   useEffect(() => {
@@ -213,8 +211,8 @@ const Board: React.FC<BoardProps> = ({
     return <div className="text-red-500 p-4">Board not found.</div>;
   }
 
-  const containerBg = theme === 'dark' ? 'bg-gray-800' : 'bg-gray-50';
-  const panelBg = theme === 'dark' ? 'bg-gray-800' : 'bg-white';
+  const containerBg = 'bg-soft dark:bg-soft-dark';
+  const panelBg = 'bg-soft dark:bg-soft-dark';
 
   return (
     <div className={`space-y-4 p-6 rounded-xl shadow-lg max-w-5xl mx-auto ${containerBg}`}>

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -15,10 +15,7 @@ const NavBar: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const navClasses =
-    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b ' +
-    (theme === 'dark'
-      ? 'bg-gray-800 border-gray-700'
-      : 'bg-white border-gray-200');
+    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-soft dark:bg-soft-dark border-gray-200 dark:border-gray-700';
 
   return (
     <nav className={navClasses}>

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -90,7 +90,7 @@ const BoardPage: React.FC = () => {
 
   return (
     <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
-      <div className="bg-gray-100 dark:bg-gray-900 rounded-xl shadow-lg p-6 space-y-6">
+      <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
         <div className="flex justify-between items-center">
           <h1 className="text-3xl font-bold">{boardData.title}</h1>
           {editable && (

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -15,7 +15,6 @@ module.exports = {
           primary: "#111827",
           accent: "#4F46E5",
           soft: "#F3F4F6",
-          "primary-dark": "#f9fafb",
           "soft-dark": "#1f2937",
         },
         borderRadius: {


### PR DESCRIPTION
## Summary
- remove unused `primary-dark` color
- add `soft-dark` background in NavBar and boards
- use `bg-soft`/`dark:bg-soft-dark` across board container and Board component

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` in backend *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68546f4153f4832f92bd696875934ffd