### PR TITLE
Add dark card color

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -206,7 +206,7 @@ const PostCard: React.FC<PostCardProps> = ({
   return (
     <div
       id={post.id}
-      className="relative border rounded bg-white dark:bg-gray-800 shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100 max-w-prose mx-auto"
+      className="relative border rounded bg-white dark:bg-card-dark shadow-sm p-4 space-y-3 text-gray-900 dark:text-gray-100 max-w-prose mx-auto"
     >
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-2">

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -272,7 +272,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   };
 
   return (
-    <div className="border rounded-lg shadow bg-white dark:bg-gray-800 p-6 text-gray-900 dark:text-gray-100">
+    <div className="border rounded-lg shadow bg-white dark:bg-card-dark p-6 text-gray-900 dark:text-gray-100">
       {renderHeader()}
       <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1 mb-2">
         <button

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -8,12 +8,14 @@
   --bg-soft: #f9fafb;
   --text-primary: #1f2937;
   --accent: #4f46e5; /* indigo-600 */
+  --card-dark: #ffffff;
 }
 
 .dark {
   --bg-soft: #1f2937; /* slate-800 */
   --text-primary: #f9fafb; /* light gray */
   --accent: #818cf8; /* indigo-400 */
+  --card-dark: #374151;
 }
 
 html, body {

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -17,6 +17,7 @@ module.exports = {
           soft: "#F3F4F6",
           "primary-dark": "#f9fafb",
           "soft-dark": "#1f2937",
+          "card-dark": "#374151",
         },
         borderRadius: {
           xl: "1rem",


### PR DESCRIPTION
## Summary
- define a `card-dark` palette entry
- expose CSS variable for `--card-dark`
- switch PostCard and QuestCard to use `dark:bg-card-dark`

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546f41b7e8832f88c11a5b528d285a