### PR TITLE
Improve dark mode label styling

### DIFF
--- a/ethos-frontend/src/components/controls/CollaberatorControls.tsx
+++ b/ethos-frontend/src/components/controls/CollaberatorControls.tsx
@@ -51,7 +51,7 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
       {/* Add Collaborator */}
       <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-end">
         <div className="flex-1">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
             Collaborator Username
           </label>
           <input
@@ -72,10 +72,10 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
       </div>
 
       {/* Select Roles */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Roles for this collaborator
-        </label>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Roles for this collaborator
+          </label>
         <div className="flex flex-wrap gap-2">
           {ALL_ROLES.map((role) => (
             <button
@@ -97,7 +97,7 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
       {/* Current Collaborators */}
       {value.length > 0 && (
         <div className="mt-4">
-          <p className="text-sm font-medium text-gray-700 mb-2">Assigned Collaborators:</p>
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Assigned Collaborators:</p>
           <ul className="space-y-2 text-sm">
             {value.map((c, index) => (
               <li
@@ -106,8 +106,8 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
               >
                 <div>
                   <strong>@{c.username}</strong>
-                  <div className="text-xs text-gray-600">
-                    Roles: {(c.roles || []).join(', ') || 'None'}
+                    <div className="text-xs text-gray-600 dark:text-gray-400">
+                      Roles: {(c.roles || []).join(', ') || 'None'}
                   </div>
                 </div>
                 <button

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -190,7 +190,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
             className="border rounded px-2 py-1 text-sm w-full"
           />
           <div className="flex items-center gap-2 my-1">
-            <label className="text-xs text-gray-600">Sort by:</label>
+            <label className="text-xs text-gray-600 dark:text-gray-400">Sort by:</label>
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as 'label' | 'node')}
@@ -255,7 +255,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
               </div>
 
               <div className="flex flex-wrap items-center gap-3 text-xs">
-                <label className="text-gray-600">Type:</label>
+                <label className="text-gray-600 dark:text-gray-400">Type:</label>
                 <select
                   value={item.linkType || 'related'}
                   onChange={(e) => handleUpdate(idx, 'linkType', e.target.value)}
@@ -268,7 +268,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
                   ))}
                 </select>
 
-                <label className="text-gray-600">Status:</label>
+                <label className="text-gray-600 dark:text-gray-400">Status:</label>
                 <select
                   value={item.linkStatus || 'active'}
                   onChange={(e) => handleUpdate(idx, 'linkStatus', e.target.value)}
@@ -279,7 +279,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
                   ))}
                 </select>
 
-                <label className="text-gray-600">
+                <label className="text-gray-600 dark:text-gray-400">
                   <input
                     type="checkbox"
                     checked={item.cascadeSolution || false}
@@ -287,7 +287,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
                   /> 🔁 Cascade
                 </label>
 
-                <label className="text-gray-600">
+                <label className="text-gray-600 dark:text-gray-400">
                   <input
                     type="checkbox"
                     checked={item.notifyOnChange || false}

--- a/ethos-frontend/src/components/ui/FormSection.tsx
+++ b/ethos-frontend/src/components/ui/FormSection.tsx
@@ -33,7 +33,7 @@ const FormSection: React.FC<FormSectionProps> = ({ title, className, children })
   return (
     <section className={clsx('mb-6', className)}>
       {/* Section Header */}
-      <h2 className="text-lg font-semibold text-gray-800 mb-3">{title}</h2>
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">{title}</h2>
 
       {/* Section Body */}
       <div className="space-y-4">{children}</div>

--- a/ethos-frontend/src/components/ui/Input.tsx
+++ b/ethos-frontend/src/components/ui/Input.tsx
@@ -41,11 +41,16 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           )}
         </div>
 
-        {helperText && (
-          <p className={clsx('text-xs', error ? 'text-red-600' : 'text-gray-500')}>
-            {helperText}
-          </p>
-        )}
+          {helperText && (
+            <p
+              className={clsx(
+                'text-xs',
+                error ? 'text-red-600' : 'text-gray-500 dark:text-gray-400'
+              )}
+            >
+              {helperText}
+            </p>
+          )}
       </div>
     );
   }

--- a/ethos-frontend/src/components/ui/Label.tsx
+++ b/ethos-frontend/src/components/ui/Label.tsx
@@ -34,10 +34,10 @@ const Label: React.FC<LabelProps> = ({ htmlFor, className, children, ...props })
   return (
     <label
       htmlFor={htmlFor}
-      className={clsx(
-        'block text-sm font-medium text-gray-700 mb-1',
-        className
-      )}
+        className={clsx(
+          'block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1',
+          className
+        )}
       {...props}
     >
       {children}

--- a/ethos-frontend/src/components/ui/Select.tsx
+++ b/ethos-frontend/src/components/ui/Select.tsx
@@ -38,11 +38,16 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             </option>
           ))}
         </select>
-        {helperText && (
-          <p className={clsx('text-xs', error ? 'text-red-600' : 'text-gray-500')}>
-            {helperText}
-          </p>
-        )}
+          {helperText && (
+            <p
+              className={clsx(
+                'text-xs',
+                error ? 'text-red-600' : 'text-gray-500 dark:text-gray-400'
+              )}
+            >
+              {helperText}
+            </p>
+          )}
       </div>
     );
   }

--- a/ethos-frontend/src/components/ui/TextArea.tsx
+++ b/ethos-frontend/src/components/ui/TextArea.tsx
@@ -53,11 +53,16 @@ const TextArea: React.FC<TextAreaProps> = ({
           className
         )}
       />
-      {helperText && (
-        <p className={clsx('text-xs', error ? 'text-red-600' : 'text-gray-500')}>
-          {helperText}
-        </p>
-      )}
+        {helperText && (
+          <p
+            className={clsx(
+              'text-xs',
+              error ? 'text-red-600' : 'text-gray-500 dark:text-gray-400'
+            )}
+          >
+            {helperText}
+          </p>
+        )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update label and form section components with dark mode text
- inherit dark text for input/select/textarea helper text
- tweak collaborator/linked controls to support dark mode
- adjust other form-related labels

## Testing
- `npm test` (fails: Board layout logic etc.)
- `npm test` in `ethos-backend` (fails: cannot find module 'supertest')

------
https://chatgpt.com/codex/tasks/task_e_68546f432ad0832f8669320a58593d04