### PR TITLE
Add dark mode styling to badges

### DIFF
--- a/ethos-frontend/src/components/ui/PostTypeBadge.tsx
+++ b/ethos-frontend/src/components/ui/PostTypeBadge.tsx
@@ -8,22 +8,57 @@ type PostTypeBadgeProps = {
 };
 
 const typeStyles: Record<PostType, { label: string; color: string }> = {
-  free_speech: { label: 'Free Speech', color: 'bg-gray-100 text-gray-700' },
-  request: { label: 'Request', color: 'bg-yellow-100 text-yellow-800' },
-  log: { label: 'Log', color: 'bg-blue-100 text-blue-800' },
-  task: { label: 'Task', color: 'bg-purple-100 text-purple-800' },
-  quest: { label: 'Quest', color: 'bg-green-100 text-green-800' },
-  meta_system: { label: 'System', color: 'bg-red-100 text-red-700' },
-  meta_announcement: { label: 'Announcement', color: 'bg-indigo-100 text-indigo-800' },
-  commit: { label: 'Commit', color: 'bg-pink-100 text-pink-800' },
-  issue: { label: 'Issue', color: 'bg-orange-100 text-orange-800' },
-  solved: { label: 'Solved', color: 'bg-lime-100 text-lime-800' },
+  free_speech: {
+    label: 'Free Speech',
+    color:
+      'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
+  },
+  request: {
+    label: 'Request',
+    color:
+      'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
+  },
+  log: {
+    label: 'Log',
+    color: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200',
+  },
+  task: {
+    label: 'Task',
+    color:
+      'bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-200',
+  },
+  quest: {
+    label: 'Quest',
+    color:
+      'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
+  },
+  meta_system: {
+    label: 'System',
+    color: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',
+  },
+  meta_announcement: {
+    label: 'Announcement',
+    color:
+      'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
+  },
+  commit: {
+    label: 'Commit',
+    color: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
+  },
+  issue: {
+    label: 'Issue',
+    color: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
+  },
+  solved: {
+    label: 'Solved',
+    color: 'bg-lime-100 text-lime-800 dark:bg-lime-800 dark:text-lime-200',
+  },
 };
 
 export const PostTypeBadge: React.FC<PostTypeBadgeProps> = ({ type, className }) => {
   const style = typeStyles[type] ?? {
     label: type,
-    color: 'bg-gray-200 text-gray-700',
+    color: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
   };
 
   return (

--- a/ethos-frontend/src/components/ui/StatusBadge.tsx
+++ b/ethos-frontend/src/components/ui/StatusBadge.tsx
@@ -8,14 +8,20 @@ interface StatusBadgeProps {
 }
 
 const statusStyles: Record<string, string> = {
-  'To Do': 'bg-gray-100 text-gray-700',
-  'In Progress': 'bg-yellow-100 text-yellow-800',
-  Blocked: 'bg-red-100 text-red-800',
-  Done: 'bg-green-100 text-green-800',
+  'To Do':
+    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
+  'In Progress':
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
+  Blocked:
+    'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-200',
+  Done:
+    'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
 };
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className }) => {
-  const style = statusStyles[status] || 'bg-gray-200 text-gray-700';
+  const style =
+    statusStyles[status] ||
+    'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
   return (
     <span
       className={clsx(


### PR DESCRIPTION
## Summary
- add dark mode styles for PostTypeBadge and StatusBadge

## Testing
- `npm test --silent` in `ethos-frontend` *(fails: No QueryClient, jsdom missing)*
- `npm test --silent` in `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68546f43ff60832fa7194ad3812be312