### PR TITLE
Add theme colors file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ VITE_API_URL=http://localhost:3001/api
 VITE_SOCKET_URL=http://localhost:3001
 ```
 
+### Theme Tokens
+
+UI colors are centralized in `ethos-frontend/src/theme.ts` and mirrored in the
+Tailwind config. Use these variables instead of hard-coded color strings when
+styling components.
+
+| Token | Hex |
+| ----- | ---- |
+| `primary` | `#111827` |
+| `accent` | `#4F46E5` |
+| `soft` | `#F3F4F6` |
+| `primaryDark` | `#f9fafb` |
+| `softDark` | `#1f2937` |
+| `infoBackground` | `#bfdbfe` |
+
 ### 3. Setup Backend
 
 ```bash

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -8,6 +8,7 @@
   --bg-soft: #f9fafb;
   --text-primary: #1f2937;
   --accent: #4f46e5; /* indigo-600 */
+  --info-background: #bfdbfe;
 }
 
 .dark {
@@ -51,5 +52,5 @@ a:hover {
 }
 
 .droppable-over {
-  background-color: #bfdbfe;
+  background-color: var(--info-background);
 }

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -1,0 +1,10 @@
+export const colors = {
+  primary: '#111827',
+  accent: '#4F46E5',
+  soft: '#F3F4F6',
+  primaryDark: '#f9fafb',
+  softDark: '#1f2937',
+  infoBackground: '#bfdbfe',
+};
+
+export default colors;


### PR DESCRIPTION
## Summary
- centralize color variables in theme.ts
- document available theme tokens for contributors
- use CSS variable for drag drop highlight color

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546f44fb10832f90d73ae17faacdfc