### PR TITLE
Fix edge duplication in GraphLayout drag/drop

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -122,10 +122,13 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
         postId: active.id as string,
         parentId: over.id as string,
       });
-      setEdgeList((prev) => [
-        ...prev,
-        { from: over.id as string, to: active.id as string },
-      ]);
+      setEdgeList((prev) => {
+        const exists = prev.some(
+          (e) => e.from === (over.id as string) && e.to === (active.id as string)
+        );
+        if (exists) return prev;
+        return [...prev, { from: over.id as string, to: active.id as string }];
+      });
     } catch (err) {
       console.error('[GraphLayout] failed to link post:', err);
     }

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -50,4 +50,28 @@ describe('GraphLayout drag and drop', () => {
     expect(within(root).getByText('Parent')).toBeInTheDocument();
     expect(within(root).getByText('Child')).toBeInTheDocument();
   });
+
+  it('does not duplicate edges on repeated drags', async () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'Parent', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'Child', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    await act(async () => {
+      await dragHandler({ active: { id: 'p2' }, over: { id: 'p1' } });
+    });
+
+    await act(async () => {
+      await dragHandler({ active: { id: 'p2' }, over: { id: 'p1' } });
+    });
+
+    const rootNodes = container.querySelectorAll(':scope > div.relative');
+    expect(rootNodes.length).toBe(1);
+    const root = rootNodes[0];
+    expect(within(root).getByText('Parent')).toBeInTheDocument();
+    const children = within(root).getAllByText('Child');
+    expect(children.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent duplicate edges when dropping a node on the same parent
- test repeated drags to ensure graph edges aren't duplicated

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_685474d6f254832faeaa3d428f8ff39f