### PR TITLE
Add Jest mocks and config mapping

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -3,6 +3,13 @@ export default {
   testEnvironment: 'jest-environment-jsdom',
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    'react-markdown': '<rootDir>/tests/__mocks__/react-markdown.tsx',
+    'remark-gfm': '<rootDir>/tests/__mocks__/remark-gfm.ts',
+    '.*/hooks/usePermissions$': '<rootDir>/tests/__mocks__/usePermissions.ts',
+    '.*/hooks/useGit$': '<rootDir>/tests/__mocks__/useGit.ts'
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.test.json',

--- a/ethos-frontend/jest.setup.ts
+++ b/ethos-frontend/jest.setup.ts
@@ -17,13 +17,4 @@ if (typeof global.TextDecoder === 'undefined') {
 // Provide a default API base for modules that read from import.meta.env
 process.env.VITE_API_URL = 'http://localhost:3001/api';
 
-// Mock ESM modules not handled by ts-jest
-jest.mock('react-markdown', () => {
-  const React = require('react');
-  return {
-    __esModule: true,
-    default: (props: any) => React.createElement('div', null, props.children),
-  };
-});
-jest.mock('remark-gfm', () => ({}));
 

--- a/ethos-frontend/tests/__mocks__/react-markdown.tsx
+++ b/ethos-frontend/tests/__mocks__/react-markdown.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function ReactMarkdownMock(props: any) {
+  return <div>{props.children}</div>;
+}

--- a/ethos-frontend/tests/__mocks__/remark-gfm.ts
+++ b/ethos-frontend/tests/__mocks__/remark-gfm.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/ethos-frontend/tests/__mocks__/useGit.ts
+++ b/ethos-frontend/tests/__mocks__/useGit.ts
@@ -1,0 +1,2 @@
+export const useGitDiff = jest.fn(() => ({ data: { diffMarkdown: '' }, isLoading: false }));
+export default { useGitDiff };

--- a/ethos-frontend/tests/__mocks__/usePermissions.ts
+++ b/ethos-frontend/tests/__mocks__/usePermissions.ts
@@ -1,0 +1,4 @@
+export const usePermissions = () => ({
+  canEditBoard: () => false
+});
+export default { usePermissions };


### PR DESCRIPTION
## Summary
- create mock modules for `react-markdown`, `remark-gfm`, and helper hooks
- map modules to mocks and enable esm extensions in Jest config
- simplify `jest.setup.ts`

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test Suites: 8 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6854774ce2d8832fa8af1c06692891be