### PR TITLE
Add graph node focus condensation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ npm install --prefix ethos-frontend @dnd-kit/core
 
 Drag nodes on top of other nodes in the graph view to create parent/child links. Nodes with a type or tag of `quest` appear as folder icons (📁) so you can visually organize quests. This drag-and-drop behavior uses the same `@dnd-kit/core` dependency as the Kanban board.
 
+When a node has more than five children, the graph condenses those children into small circle icons. Clicking a condensed node sets it as the focus and expands its subtree while siblings stay collapsed.
+
 
 ---
 

--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -45,6 +45,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   const [rootNodes, setRootNodes] = useState<(Post & { children?: NodeChild[] })[]>([]);
   const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges || []);
   const [selectedNode, setSelectedNode] = useState<Post | null>(null);
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
 
   const { data: diffData, isLoading: diffLoading } = useGitDiff({
     questId,
@@ -114,6 +115,10 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     );
   };
 
+  const handleNodeFocus = (id: string) => {
+    setFocusedNodeId(id);
+  };
+
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -153,6 +158,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
             user={user}
             compact={compact}
             condensed={condensed}
+            focusedNodeId={focusedNodeId}
+            onFocus={handleNodeFocus}
             selectedNode={selectedNode}
             onSelect={handleNodeClick}
             diffData={diffData}


### PR DESCRIPTION
## Summary
- add `MAX_CHILDREN_BEFORE_CONDENSE` constant
- show condensed child nodes when not focused and there are many children
- allow focusing a condensed node to expand it
- track `focusedNodeId` in `GraphLayout`
- document condensing logic in **Graph View Linking** section of README

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: useNavigate may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_68547eac4d3c832f9e0be173dbe10f7e