### PR TITLE
Render SVG edges in GraphLayout

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { useGitDiff } from '../../hooks/useGit';
 import { Spinner } from '../ui';
@@ -41,6 +41,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   loadingMore = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [paths, setPaths] = useState<{ key: string; d: string }[]>([]);
 
   const [rootNodes, setRootNodes] = useState<(Post & { children?: NodeChild[] })[]>([]);
   const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges || []);
@@ -51,6 +53,39 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     filePath: selectedNode?.gitFilePath,
     commitId: selectedNode?.gitCommitSha,
   });
+
+  const computePaths = () => {
+    const container = containerRef.current;
+    if (!container) return;
+    const containerRect = container.getBoundingClientRect();
+    const newPaths: { key: string; d: string }[] = [];
+    edgeList.forEach((edge) => {
+      const fromEl = nodeRefs.current[edge.from];
+      const toEl = nodeRefs.current[edge.to];
+      if (fromEl && toEl) {
+        const fromRect = fromEl.getBoundingClientRect();
+        const toRect = toEl.getBoundingClientRect();
+        const startX =
+          fromRect.left + fromRect.width / 2 - containerRect.left + container.scrollLeft;
+        const startY =
+          fromRect.bottom - containerRect.top + container.scrollTop;
+        const endX =
+          toRect.left + toRect.width / 2 - containerRect.left + container.scrollLeft;
+        const endY = toRect.top - containerRect.top + container.scrollTop;
+        newPaths.push({ key: `${edge.from}-${edge.to}`, d: `M ${startX} ${startY} L ${endX} ${endY}` });
+      }
+    });
+    setPaths(newPaths);
+  };
+
+  useLayoutEffect(() => {
+    computePaths();
+  }, [rootNodes, edgeList]);
+
+  useEffect(() => {
+    window.addEventListener('resize', computePaths);
+    return () => window.removeEventListener('resize', computePaths);
+  }, [edgeList]);
 
   useEffect(() => {
     const nodeMap: NodeMap = {};
@@ -143,8 +178,29 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           'overflow-auto w-full h-full p-4 max-w-7xl mx-auto ' +
           (rootNodes.length === 1 ? 'flex justify-center' : '')
         }
-        style={{ minHeight: '50vh' }}
+        style={{ minHeight: '50vh', position: 'relative' }}
       >
+        <svg
+          className="absolute top-0 left-0 w-full h-full pointer-events-none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <marker
+              id="arrow"
+              viewBox="0 0 10 10"
+              refX="10"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="#aaa" />
+            </marker>
+          </defs>
+          {paths.map((p) => (
+            <path key={p.key} d={p.d} stroke="#aaa" fill="none" markerEnd="url(#arrow)" />
+          ))}
+        </svg>
         {rootNodes.map((node) => (
           <GraphNode
             key={node.id}
@@ -157,6 +213,9 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
             onSelect={handleNodeClick}
             diffData={diffData}
             diffLoading={diffLoading}
+            registerNode={(id, el) => {
+              nodeRefs.current[id] = el;
+            }}
           />
         ))}
         {loadingMore && (

--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -33,6 +33,7 @@ interface GraphNodeProps {
   onSelect: (n: Post) => void;
   diffData?: { diffMarkdown?: string } | null;
   diffLoading: boolean;
+  registerNode?: (id: string, el: HTMLDivElement | null) => void;
 }
 
 const GraphNode: React.FC<GraphNodeProps> = ({
@@ -46,6 +47,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   onSelect,
   diffData,
   diffLoading,
+  registerNode,
 }) => {
   const isFolder = node.type === 'quest' || node.tags.includes('quest');
   const icon = isFolder ? '📁' : '📄';
@@ -60,7 +62,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
     const label = node.nodeId || node.id.slice(0, 6);
     const snippet = (node.content || '').slice(0, 30);
     return (
-      <div className="relative">
+      <div className="relative" ref={(el) => registerNode?.(node.id, el)}>
         <div
           className="mb-2 flex items-center cursor-pointer"
           style={{ marginLeft: depth * 16 }}
@@ -108,7 +110,13 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   }
 
   return (
-    <div ref={setDropRef} className={`relative ${isOver ? 'ring-2 ring-blue-400' : ''}`}>
+    <div
+      ref={(el) => {
+        setDropRef(el);
+        registerNode?.(node.id, el);
+      }}
+      className={`relative ${isOver ? 'ring-2 ring-blue-400' : ''}`}
+    >
       <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : ''}>
         <div
           className={`ml-${depth * 4} mb-6 flex items-start space-x-2 cursor-pointer`}

--- a/ethos-frontend/tests/GraphLayoutSvg.test.js
+++ b/ethos-frontend/tests/GraphLayoutSvg.test.js
@@ -1,0 +1,38 @@
+const React = require('react');
+const { render } = require('@testing-library/react');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+jest.mock('../src/hooks/useGit', () => ({
+  __esModule: true,
+  useGitDiff: () => ({ data: null, isLoading: false })
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/components/layout/GraphNode', () => ({
+  __esModule: true,
+  default: ({ node, registerNode }) =>
+    React.createElement('div', {
+      'data-testid': node.id,
+      ref: (el) => registerNode(node.id, el),
+    }),
+}), { virtual: true });
+
+describe('GraphLayout edges svg', () => {
+  it('renders a svg path when an edge exists', () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'A', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'B', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+    const edges = [{ from: 'p1', to: 'p2' }];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, edges, questId: 'q1' }));
+    const svg = container.querySelector('svg');
+    const path = container.querySelector('svg path');
+    expect(svg).not.toBeNull();
+    expect(path).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- compute node positions and draw lines in `GraphLayout`
- expose node refs from `GraphNode`
- test for SVG edge rendering when graph edges exist

## Testing
- `npm test --prefix ethos-frontend` *(fails: useNavigate requires Router context)*

------
https://chatgpt.com/codex/tasks/task_e_68547eaa96f4832f960dc0786370c38c