### PR TITLE
Add missing quest-post associations

### DIFF
--- a/ethos-backend/src/data/quests.json
+++ b/ethos-backend/src/data/quests.json
@@ -5,7 +5,64 @@
     "title": "Ethos",
     "description": "",
     "tags": [],
-    "linkedPosts": [],
+    "linkedPosts": [
+      {
+        "itemId": "2ccfcc93-65c3-4e6b-a2a1-fd2261d8d33e",
+        "itemType": "post"
+      },
+      {
+        "itemId": "7d619748-99fd-4182-b445-36f064ec5d34",
+        "itemType": "post"
+      },
+      {
+        "itemId": "c1fa9e19-08cb-4dca-bc6b-ef39ac2b0d4b",
+        "itemType": "post"
+      },
+      {
+        "itemId": "2c93a340-d89f-47bd-a146-530b4b4df5df",
+        "itemType": "post"
+      },
+      {
+        "itemId": "b925004c-ab1c-4893-aeac-ab4ea94eb0ca",
+        "itemType": "post"
+      },
+      {
+        "itemId": "6484f88a-1d54-4b42-a68b-901f336497de",
+        "itemType": "post"
+      },
+      {
+        "itemId": "c46d9061-03fd-4f41-bbd6-f0b65e282d34",
+        "itemType": "post"
+      },
+      {
+        "itemId": "bc9a97d0-3eef-4c2d-b4fc-18762740a0c3",
+        "itemType": "post"
+      },
+      {
+        "itemId": "c5d39daa-736b-40ae-b12b-56bfd284c2f2",
+        "itemType": "post"
+      },
+      {
+        "itemId": "dcc26e13-512b-4ab0-940c-8b764cc6e579",
+        "itemType": "post"
+      },
+      {
+        "itemId": "38943b72-45af-476f-8199-f40b792230c7",
+        "itemType": "post"
+      },
+      {
+        "itemId": "54f01d70-a5e7-4223-8c16-d28d9151d824",
+        "itemType": "post"
+      },
+      {
+        "itemId": "7de6e351-61c6-4ac5-a9f5-ea62542df40f",
+        "itemType": "post"
+      },
+      {
+        "itemId": "60175e71-58b0-4509-ab82-b75055d0f90c",
+        "itemType": "post"
+      }
+    ],
     "collaborators": [],
     "status": "active",
     "headPostId": "",
@@ -17,7 +74,16 @@
     "title": "Symbolcast",
     "description": "",
     "tags": [],
-    "linkedPosts": [],
+    "linkedPosts": [
+      {
+        "itemId": "25d83c49-4bcf-46af-96c5-8f0e68decf86",
+        "itemType": "post"
+      },
+      {
+        "itemId": "505a2608-de85-47bf-8783-264c069a6181",
+        "itemType": "post"
+      }
+    ],
     "collaborators": [],
     "status": "active",
     "headPostId": "",
@@ -55,6 +121,7 @@
     "tags": [],
     "linkedPosts": [
       {
+        "itemId": "820d027e-dcdc-4597-b806-cdadfa3832aa",
         "itemType": "post"
       }
     ],
@@ -69,7 +136,12 @@
     "title": "IDK Comic's",
     "description": "",
     "tags": [],
-    "linkedPosts": [],
+    "linkedPosts": [
+      {
+        "itemId": "0a2acb7c-2002-4926-88f1-85bc80916bbc",
+        "itemType": "post"
+      }
+    ],
     "collaborators": [],
     "status": "active",
     "headPostId": "",
@@ -83,6 +155,11 @@
     "tags": [],
     "linkedPosts": [
       {
+        "itemId": "188cbf3f-5962-48cd-976c-256866cec077",
+        "itemType": "post"
+      },
+      {
+        "itemId": "2256bf9f-6867-4de0-9804-e11bf0313de9",
         "itemType": "post"
       }
     ],
@@ -103,6 +180,11 @@
     ],
     "linkedPosts": [
       {
+        "itemId": "0daf8c76-5646-4100-8251-f119dcfcf66f",
+        "itemType": "post"
+      },
+      {
+        "itemId": "8e3393b1-a024-4c38-a4ba-9a2c5b8dbbfb",
         "itemType": "post"
       }
     ],
@@ -117,7 +199,112 @@
     "title": "Graduate Applications",
     "description": "(PRIVATE) this quest is to track my graduate applciations",
     "tags": [],
-    "linkedPosts": [],
+    "linkedPosts": [
+      {
+        "itemId": "f7a46bfb-8a6c-49c2-b461-9e2ac15f5ede",
+        "itemType": "post"
+      },
+      {
+        "itemId": "f9db4d56-fb24-41d3-a4e4-9c2aca829c8b",
+        "itemType": "post"
+      },
+      {
+        "itemId": "3f677892-1123-4dcd-88dd-332940d537df",
+        "itemType": "post"
+      },
+      {
+        "itemId": "b15cfb9a-09f3-4727-9657-c602d4896bfc",
+        "itemType": "post"
+      },
+      {
+        "itemId": "3051ab0d-fe7f-40f5-b4eb-61f9d6f54933",
+        "itemType": "post"
+      },
+      {
+        "itemId": "458c9af2-ac50-4399-b0fb-e5a004badc66",
+        "itemType": "post"
+      },
+      {
+        "itemId": "49e65a59-dc1f-4f3d-97f3-43bdddd0ed09",
+        "itemType": "post"
+      },
+      {
+        "itemId": "72f9fa71-ebb8-495f-9ab5-1dbbf7bac967",
+        "itemType": "post"
+      },
+      {
+        "itemId": "c692b73f-de0c-4228-837e-6932c6c314dd",
+        "itemType": "post"
+      },
+      {
+        "itemId": "1a382101-9a66-4c66-8865-2b7ef7197bee",
+        "itemType": "post"
+      },
+      {
+        "itemId": "8a4ae9ae-813c-4e7f-8687-bc8eb9438f9d",
+        "itemType": "post"
+      },
+      {
+        "itemId": "81fe4150-b189-47da-8030-c022b5ad81df",
+        "itemType": "post"
+      },
+      {
+        "itemId": "3dc7842b-b7a9-4976-81ed-b03f0bb90b0a",
+        "itemType": "post"
+      },
+      {
+        "itemId": "fa234807-543a-4a37-8a3b-36327755d570",
+        "itemType": "post"
+      },
+      {
+        "itemId": "d1cb4ba6-1717-4df4-bbb5-32a711b90b2b",
+        "itemType": "post"
+      },
+      {
+        "itemId": "f12eb902-a518-42ac-b40e-3513161a6e2b",
+        "itemType": "post"
+      },
+      {
+        "itemId": "eee8d106-38ad-48be-866b-96ceb4fe2840",
+        "itemType": "post"
+      },
+      {
+        "itemId": "39a2b6df-0673-4759-aeac-52951570bae6",
+        "itemType": "post"
+      },
+      {
+        "itemId": "593f1d91-7db2-40b8-a5b6-36212166c4d9",
+        "itemType": "post"
+      },
+      {
+        "itemId": "9ef2ea7e-9581-4f4b-b495-836de2da0bc6",
+        "itemType": "post"
+      },
+      {
+        "itemId": "926a4bcb-1203-44d9-854f-b829df7f5666",
+        "itemType": "post"
+      },
+      {
+        "itemId": "4beb7969-38f6-4ab3-91b8-a6e8840ec282",
+        "itemType": "post"
+      },
+      {
+        "itemId": "79e5dc33-24ac-4d7e-b8f8-b0035d8f4cb8",
+        "itemType": "post"
+      },
+      {
+        "itemId": "125efc2a-e98f-4590-ab6c-e0f33bfd18e5",
+        "itemType": "post"
+      },
+      {
+        "itemId": "d6c482f3-aad0-45a9-ab95-f25127f11746",
+        "itemType": "post"
+      },
+      {
+        "itemId": "cb71bf0a-7aa5-49f2-ad99-4e36c5b7a559",
+        "itemType": "post"
+      }
+    ],
     "collaborators": [],
     "status": "active",
     "headPostId": "",


### PR DESCRIPTION
## Summary
- populate `linkedPosts` in `quests.json` with post IDs
- keep empty arrays for quests without posts
- validate JSON and run backend tests

## Testing
- `npm install` (ethos-backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854852c8298832fa1877f6b927fa0f8