### PR TITLE
Add condense check and pulsing animation

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -84,6 +84,11 @@ const GraphNode: React.FC<GraphNodeProps> = ({
     };
   }, [isOver]);
 
+  const shouldCondenseChildren =
+    !focusedNodeId &&
+    node.children &&
+    node.children.length > MAX_CHILDREN_BEFORE_CONDENSE;
+
 
   if (condensed) {
     const colorKey = node.tags[0] || node.type;
@@ -152,7 +157,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
         setDropRef(el);
         registerNode?.(node.id, el);
       }}
-      className={`relative ${isOver ? 'ring-2 ring-blue-400' : ''}`}
+      className={`relative ${isOver ? 'ring-2 ring-blue-400' : ''} ${pulsing ? 'animate-pulse' : ''}`}
     >
       <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : ''}>
         <div


### PR DESCRIPTION
## Summary
- compute `shouldCondenseChildren` in `GraphNode`
- show pulsing animation when hovering over a node

## Testing
- `npm test --prefix ethos-frontend -- tests/GraphLayoutDragDrop.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685485557920832fbedf37c4e1f891ff