### PR TITLE
Update link editing controls

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.link.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.link.test.tsx
@@ -23,6 +23,11 @@ jest.mock('../../hooks/useGraph', () => ({
   useGraph: () => ({ loadGraph: loadGraphMock })
 }));
 
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => jest.fn(),
+}));
+
 describe('PostCard task_edge linking', () => {
   const post: Post = {
     id: 'c1',
@@ -37,8 +42,9 @@ describe('PostCard task_edge linking', () => {
   } as any;
 
   it('calls linkPostToQuest and refreshes graph on save', async () => {
-    render(<PostCard post={post} questId="q1" />);
-    fireEvent.click(screen.getByText(/linked to/i));
+    render(<PostCard post={post} questId="q1" user={{ id: 'u1' }} />);
+    fireEvent.click(screen.getByLabelText('More options'));
+    fireEvent.click(screen.getByText(/Edit Links/i));
 
     await waitFor(() => expect(fetchPostsByQuestId).toHaveBeenCalled());
 

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -241,6 +241,7 @@ const PostCard: React.FC<PostCardProps> = ({
           type="post"
           canEdit={canEdit}
           onEdit={() => setEditMode(true)}
+          onEditLinks={() => setShowLinkEditor(true)}
           onDelete={() => onDelete?.(post.id)}
           content={post.content}
           permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
@@ -277,15 +278,6 @@ const PostCard: React.FC<PostCardProps> = ({
 
       {['request','quest','task','log','commit','issue', 'meta_system'].includes(post.type) && (
         <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
-          <button
-            type="button"
-            onClick={() => setShowLinkEditor((v) => !v)}
-            className="text-blue-600 underline"
-          >
-            {post.linkedItems && post.linkedItems.length > 0
-              ? `🔗 Linked to ${post.linkedItems.length} items`
-              : 'Link to item'}
-          </button>
           {showLinkEditor && (
             <div className="mt-2">
               <LinkControls

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -143,6 +143,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             id={quest.id}
             canEdit={true}
             onEdit={() => onEdit?.(questData)}
+            onEditLinks={() => setShowLinkEditor(true)}
             onDelete={() => onDelete?.(questData)}
             onArchived={() => {
               console.log(`[QuestCard] Quest ${quest.id} archived`);
@@ -275,15 +276,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
     <div className="border rounded-lg shadow bg-white dark:bg-card-dark p-6 text-gray-900 dark:text-gray-100">
       {renderHeader()}
       <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1 mb-2">
-        <button
-          type="button"
-          onClick={() => setShowLinkEditor((v) => !v)}
-          className="text-blue-600 underline"
-        >
-          {questData.linkedPosts && questData.linkedPosts.length > 0
-            ? `🔗 Linked to ${questData.linkedPosts.length} items`
-            : 'Link to item'}
-        </button>
         {showLinkEditor && (
           <div className="mt-2">
             <LinkControls

--- a/ethos-frontend/src/components/ui/ActionMenu.tsx
+++ b/ethos-frontend/src/components/ui/ActionMenu.tsx
@@ -16,6 +16,7 @@ interface ActionMenuProps {
   id: string;
   canEdit?: boolean;
   onEdit?: () => void;
+  onEditLinks?: () => void;
   onDelete?: () => void;
   onArchived?: () => void;
   permalink?: string;
@@ -36,6 +37,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   onEdit,
   onDelete,
   onArchived,
+  onEditLinks,
   permalink,
   content,
   boardId,
@@ -137,6 +139,17 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
               >
                 <FaArchive className="inline mr-2" /> {isArchiving ? 'Archiving…' : 'Archive'}
               </button>
+              {onEditLinks && (
+                <button
+                  onClick={() => {
+                    onEditLinks();
+                    setShowMenu(false);
+                  }}
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700"
+                >
+                  <FaLink className="inline mr-2" /> Edit Links
+                </button>
+              )}
             </>
           )}
           {content && (


### PR DESCRIPTION
## Summary
- remove inline "link to item" button from PostCard and QuestCard
- allow editing links via ActionMenu
- adjust tests for new Edit Links flow

## Testing
- `./setup.sh`
- `npm test` *(fails: BoardProvider and Router context errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854a83d4e88832fab679de746216d51