### PR TITLE
Add horizontal and kanban board layouts

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -24,7 +24,13 @@ export type ReactionCountMap = Record<ReactionType, number>;
 //
 // 🧭 BOARD
 //
-export type BoardLayout = 'grid' | 'graph' | 'graph-condensed' | 'thread';
+export type BoardLayout =
+  | 'grid'
+  | 'horizontal'
+  | 'kanban'
+  | 'graph'
+  | 'graph-condensed'
+  | 'thread';
   
 /**
  * Supported tags for labeling and filtering posts.

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -198,6 +198,8 @@ const Board: React.FC<BoardProps> = ({
 
   const Layout = {
     grid: GridLayout,
+    horizontal: GridLayout,
+    kanban: GridLayout,
     graph: GraphLayout,
     'graph-condensed': GraphLayout,
     thread: ThreadLayout,
@@ -252,6 +254,8 @@ const Board: React.FC<BoardProps> = ({
                 onChange={(e) => setViewMode(e.target.value as BoardLayout)}
                 options={[
                   { value: 'grid', label: 'Grid' },
+                  { value: 'horizontal', label: 'Horizontal' },
+                  { value: 'kanban', label: 'Kanban' },
                   ...(graphEligible
                     ? [
                         { value: 'graph', label: 'Graph' },
@@ -328,7 +332,9 @@ const Board: React.FC<BoardProps> = ({
             ? { edges: quest?.taskGraph }
             : {})}
           {...(resolvedStructure === 'graph-condensed' ? { condensed: true } : {})}
-          {...(resolvedStructure === 'grid' ? { layout: gridLayout } : {})}
+          {...(['grid', 'horizontal', 'kanban'].includes(resolvedStructure)
+            ? { layout: resolvedStructure === 'grid' ? gridLayout : resolvedStructure }
+            : {})}
         />
       )}
     </div>

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -4,6 +4,8 @@ import type { PostType } from '../types/postTypes';
 
 export const STRUCTURE_OPTIONS: { value: BoardLayout; label: string }[] = [
   { value: 'grid', label: 'Grid' },
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'kanban', label: 'Kanban' },
   { value: 'graph', label: 'Graph' },
   { value: 'graph-condensed', label: 'Graph (Condensed)' },
   { value: 'thread', label: 'Thread' },

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -55,7 +55,13 @@ export interface RenderableItem {
 
 export type BoardItem = RenderableItem | Post | Quest | Board ;
 
-export type BoardLayout = 'grid' | 'graph' | 'graph-condensed' | 'thread';
+export type BoardLayout =
+  | 'grid'
+  | 'horizontal'
+  | 'kanban'
+  | 'graph'
+  | 'graph-condensed'
+  | 'thread';
 
 
 /** Props passed to the Board component */


### PR DESCRIPTION
## Summary
- support `horizontal` and `kanban` as board layouts
- expose new layout options in constants and board view selector
- map new layouts to `GridLayout` component

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a85a6294832fbbb574fc97fe0e03