### PR TITLE
Align connectors on scroll

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useLayoutEffect,
+  useCallback,
+} from 'react';
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { useGitDiff } from '../../hooks/useGit';
 import { Spinner } from '../ui';
@@ -30,6 +36,16 @@ interface NodeMap {
   [id: string]: Post & { children?: NodeChild[] };
 }
 
+const debounce = <T extends (...args: any[]) => void>(fn: T, delay: number) => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return (...args: Parameters<T>) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => fn(...args), delay);
+  };
+};
+
 const GraphLayout: React.FC<GraphLayoutProps> = ({
   items,
   edges,
@@ -55,7 +71,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
     commitId: selectedNode?.gitCommitSha,
   });
 
-  const computePaths = () => {
+  const computePaths = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
     const containerRect = container.getBoundingClientRect();
@@ -77,16 +93,22 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       }
     });
     setPaths(newPaths);
-  };
+  }, [edgeList]);
+
+  const debouncedComputePaths = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    debouncedComputePaths.current = debounce(computePaths, 50);
+  }, [computePaths]);
 
   useLayoutEffect(() => {
     computePaths();
-  }, [rootNodes, edgeList]);
+  }, [rootNodes, edgeList, computePaths]);
 
   useEffect(() => {
     window.addEventListener('resize', computePaths);
     return () => window.removeEventListener('resize', computePaths);
-  }, [edgeList]);
+  }, [computePaths]);
 
   useEffect(() => {
     const nodeMap: NodeMap = {};
@@ -130,17 +152,19 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   }, [edges]);
 
   useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
     const handleScroll = () => {
-      if (!containerRef.current || !onScrollEnd) return;
-      const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+      debouncedComputePaths.current();
+      if (!onScrollEnd) return;
+      const { scrollTop, scrollHeight, clientHeight } = el;
       if (scrollTop + clientHeight >= scrollHeight - 100) {
         onScrollEnd();
       }
     };
-
-    const el = containerRef.current;
-    if (el) el.addEventListener('scroll', handleScroll);
-    return () => el?.removeEventListener('scroll', handleScroll);
+    el.addEventListener('scroll', handleScroll);
+    return () => el.removeEventListener('scroll', handleScroll);
   }, [onScrollEnd]);
 
   const handleNodeClick = (n: Post) => {

--- a/ethos-frontend/tests/GraphLayoutScroll.test.js
+++ b/ethos-frontend/tests/GraphLayoutScroll.test.js
@@ -1,0 +1,51 @@
+const React = require('react');
+const { render, fireEvent, act } = require('@testing-library/react');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+jest.mock('../src/hooks/useGit', () => ({
+  __esModule: true,
+  useGitDiff: () => ({ data: null, isLoading: false })
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/components/layout/GraphNode', () => ({
+  __esModule: true,
+  default: ({ node, registerNode }) =>
+    React.createElement('div', {
+      'data-testid': node.id,
+      ref: (el) => registerNode(node.id, el),
+    }),
+}), { virtual: true });
+
+describe('GraphLayout scroll alignment', () => {
+  it('recomputes connector paths when scrolling', () => {
+    jest.useFakeTimers();
+    const posts = [
+      { id: 'p1', type: 'task', content: 'A', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'B', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+    const edges = [{ from: 'p1', to: 'p2' }];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, edges, questId: 'q1' }));
+
+    const root = container.firstElementChild;
+    const path = container.querySelector('path');
+    expect(path.getAttribute('d')).toBe('M 0 0 L 0 0');
+
+    root.scrollTop = 50;
+    fireEvent.scroll(root);
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+
+    const updatedPath = container.querySelector('path');
+    expect(updatedPath.getAttribute('d')).toBe('M 0 50 L 0 50');
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- debounce `computePaths` in `GraphLayout`
- recompute connector paths on scroll
- add regression test for scrolling alignment

## Testing
- `npm test --prefix ethos-frontend` *(fails: QuestLog permissions and others)*

------
https://chatgpt.com/codex/tasks/task_e_6854a85b169c832f87a54112098761cd