### PR TITLE
Fix GraphNode indentation

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -161,7 +161,8 @@ const GraphNode: React.FC<GraphNodeProps> = ({
     >
       <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : ''}>
         <div
-          className={`ml-${depth * 4} mb-6 flex items-start space-x-2 cursor-pointer`}
+          style={{ marginLeft: depth * 16 }}
+          className="mb-6 flex items-start space-x-2 cursor-pointer"
           onClick={() => onSelect(node)}
           {...attributes}
           {...listeners}


### PR DESCRIPTION
## Summary
- use inline `style={{ marginLeft: depth * 16 }}` instead of dynamic Tailwind classes

## Testing
- `npx jest --runInBand` *(fails: Cannot find module 'supertest')*
- `npx jest --runInBand` in frontend *(fails due to network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854a85ef7b8832f9368761be4707b1b