### PR TITLE
Implement optimistic status updates

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -60,6 +60,9 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value;
+    const optimistic = { ...post, status: newStatus };
+    if (selectedBoard) updateBoardItem(selectedBoard, optimistic);
+    onUpdate?.(optimistic);
     try {
       const updated = await updatePost(post.id, { status: newStatus });
       if (selectedBoard) updateBoardItem(selectedBoard, updated);


### PR DESCRIPTION
## Summary
- update task status dropdown logic to optimistically update board UI

## Testing
- `npm test --prefix ethos-backend` *(fails: jest not found)*
- `npm test --prefix ethos-frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8de0b14832fbe565567ff518e73