### PR TITLE
Add review list component

### DIFF
--- a/ethos-frontend/src/api/review.ts
+++ b/ethos-frontend/src/api/review.ts
@@ -1,0 +1,25 @@
+import { axiosWithAuth } from '../utils/authUtils';
+import type { Review, ReviewTargetType } from '../types/reviewTypes';
+
+export interface FetchReviewsOptions {
+  type?: ReviewTargetType;
+  questId?: string;
+  postId?: string;
+  sort?: 'highest' | 'recent';
+  search?: string;
+}
+
+export const fetchReviews = async (
+  options: FetchReviewsOptions = {}
+): Promise<Review[]> => {
+  const params = new URLSearchParams();
+  if (options.type) params.set('type', options.type);
+  if (options.questId) params.set('questId', options.questId);
+  if (options.postId) params.set('postId', options.postId);
+  if (options.sort) params.set('sort', options.sort);
+  if (options.search) params.set('search', options.search);
+
+  const url = `/reviews${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};

--- a/ethos-frontend/src/components/ReviewList.tsx
+++ b/ethos-frontend/src/components/ReviewList.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { fetchReviews } from '../api/review';
+import type { Review, ReviewTargetType } from '../types/reviewTypes';
+import { Select, Spinner } from './ui';
+
+interface ReviewListProps {
+  type: ReviewTargetType;
+  questId?: string;
+  postId?: string;
+  className?: string;
+}
+
+const ReviewList: React.FC<ReviewListProps> = ({ type, questId, postId, className }) => {
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [sort, setSort] = useState<'recent' | 'highest'>('recent');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchReviews({ type, questId, postId, sort });
+        setReviews(data || []);
+      } catch (err) {
+        console.error('[ReviewList] Failed to fetch reviews:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [type, questId, postId, sort]);
+
+  const renderStars = (count: number) => {
+    return (
+      <span className="text-yellow-500">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <span key={i}>{i < count ? '★' : '☆'}</span>
+        ))}
+      </span>
+    );
+  };
+
+  return (
+    <div className={className}>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">Reviews</h3>
+        <div className="w-32">
+          <Select
+            value={sort}
+            onChange={e => setSort(e.target.value as 'recent' | 'highest')}
+            options={[
+              { value: 'recent', label: 'Most Recent' },
+              { value: 'highest', label: 'Highest Rated' },
+            ]}
+          />
+        </div>
+      </div>
+      {loading ? (
+        <Spinner />
+      ) : reviews.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {reviews.map(review => (
+            <li key={review.id} className="border rounded bg-white dark:bg-gray-800 p-3">
+              <div className="flex justify-between items-center">
+                {renderStars(review.rating)}
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {new Date(review.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+              {review.tags && review.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {review.tags.map(tag => (
+                    <span
+                      key={tag}
+                      className="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded text-gray-700 dark:text-gray-200"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {review.feedback && (
+                <p className="text-sm mt-2 text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+                  {review.feedback}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ReviewList;

--- a/ethos-frontend/src/pages/PublicProfile.tsx
+++ b/ethos-frontend/src/pages/PublicProfile.tsx
@@ -9,6 +9,7 @@ import { usePost } from '../hooks/usePost';
 import Banner from '../components/ui/Banner';
 import Board from '../components/board/Board';
 import { Spinner } from '../components/ui';
+import ReviewList from '../components/ReviewList';
 
 import type { EnrichedQuest, Quest } from '../types/questTypes';
 import type { EnrichedPost, Post } from '../types/postTypes';
@@ -125,6 +126,12 @@ const PublicProfilePage: React.FC = () => {
         ) : (
           <Spinner />
         )}
+      </section>
+
+      {/* ⭐ Reviews */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold mb-4 text-gray-800">⭐ Reviews</h2>
+        <ReviewList type="creator" />
       </section>
     </main>
   );

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -11,6 +11,7 @@ import { useSocketListener } from '../../hooks/useSocket';
 import Banner from '../../components/ui/Banner';
 import Board from '../../components/board/Board';
 import { Button, Spinner } from '../../components/ui';
+import ReviewList from '../../components/ReviewList';
 import { createMockBoard } from '../../utils/boardUtils';
 
 import type { User } from '../../types/userTypes';
@@ -143,6 +144,12 @@ const QuestPage: React.FC = () => {
             No quest logs yet. Start journaling progress.
           </p>
         )}
+      </section>
+
+      {/* ⭐ Reviews Section */}
+      <section>
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">⭐ Reviews</h2>
+        <ReviewList type="quest" questId={quest.id} />
       </section>
     </main>
   );

--- a/ethos-frontend/src/types/api.ts
+++ b/ethos-frontend/src/types/api.ts
@@ -10,6 +10,7 @@ export * from './postTypes';
 export * from './userTypes';
 export * from './gitTypes';
 export * from './common';
+export * from './reviewTypes';
 
 export type UUID = string;
 export type Timestamp = string;

--- a/ethos-frontend/src/types/reviewTypes.ts
+++ b/ethos-frontend/src/types/reviewTypes.ts
@@ -1,0 +1,15 @@
+export type ReviewTargetType = 'ai_app' | 'quest' | 'creator' | 'dataset';
+
+export interface Review {
+  id: string;
+  reviewerId: string;
+  targetType: ReviewTargetType;
+  rating: number;
+  tags?: string[];
+  feedback?: string;
+  repoUrl?: string;
+  modelId?: string;
+  questId?: string;
+  postId?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add new `ReviewList` to show ratings and feedback
- support fetching reviews via new API utility
- export review types
- display review lists on quest and creator pages

## Testing
- `npm test` *(fails: cannot find supertest)*
- `npm run lint` *(fails: eslint plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854aa41e950832fa34878c229a34500