### PR TITLE
Add dark mode styles for LinkViewer

### DIFF
--- a/ethos-frontend/src/components/ui/LinkViewer.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.tsx
@@ -48,7 +48,7 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items }) => {
   }, {});
 
   return (
-    <div className="text-xs">
+    <div className="text-xs text-gray-900 dark:text-gray-100">
       <button
         onClick={() => setOpen((o) => !o)}
         className="text-blue-600 underline"
@@ -56,7 +56,7 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items }) => {
         {open ? 'Hide Links' : `Links (${items.length})`}
       </button>
       {open && (
-        <div className="mt-2 border rounded bg-gray-50 p-2 space-y-1">
+        <div className="mt-2 border rounded bg-gray-50 dark:bg-gray-700 p-2 space-y-1">
           {Object.entries(grouped).map(([type, list]) => (
             <div key={type}>
               <div className="font-semibold capitalize mb-1">{type}</div>


### PR DESCRIPTION
## Summary
- improve text visibility in LinkViewer
- support dark mode background for LinkViewer dropdown

## Testing
- `npm test --silent` *(fails: useNavigate() may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_6854ad252380832fb1d39521d9f64437