### PR TITLE
Fix preview background in EditPost

### DIFF
--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -110,11 +110,11 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
             {showPreview ? 'Hide Markdown Preview' : 'Show Markdown Preview'}
           </button>
 
-          {showPreview && (
-            <div className="mt-2 border rounded p-3 bg-gray-50 text-sm prose max-w-none">
-              <MarkdownRenderer content={content} />
-            </div>
-          )}
+            {showPreview && (
+              <div className="mt-2 border rounded p-3 bg-gray-50 dark:bg-gray-800 text-sm prose max-w-none">
+                <MarkdownRenderer content={content} />
+              </div>
+            )}
         </div>
       </FormSection>
 


### PR DESCRIPTION
## Summary
- tweak preview background colors for EditPost

## Testing
- `npm test --prefix ethos-frontend` *(fails: GraphLayout and other component tests fail)*
- `npm test --prefix ethos-backend` *(fails: cannot find modules like 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_6854ad26ec00832f8fc12778f036e436