### PR TITLE
Fix dark mode fallback style

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -65,7 +65,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   // 🛑 Fallback for unknown types
   console.warn("[ContributionCard] Unknown contribution type:", contribution);
   return (
-    <div className="p-4 border rounded text-sm text-gray-600 bg-gray-50">
+    <div className="p-4 border rounded text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-700">
       Unknown contribution type
     </div>
   );


### PR DESCRIPTION
## Summary
- update fallback styling in `ContributionCard` for better dark mode support

## Testing
- `npm test --prefix ethos-frontend` *(fails: 7 failed, 5 passed)*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854ad27f7b4832fad6b6f8ba4d9e828