### PR TITLE
Implement quest completion cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ The backend logger supports a `LOG_LEVEL` environment variable. Set it to
 `error`, `warn`, `info` (default), or `debug` to control the verbosity of
 console output. Each log line includes a timestamp for easier tracing.
 
+## API Routes
+
+- `POST /api/quests/:id/complete` – mark a quest as completed. Linked posts with
+  `cascadeSolution` are tagged as `solved` and links with `notifyOnChange`
+  trigger a placeholder notification.
+
 ---
 
 ## 🧠 Core Flow

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -334,6 +334,61 @@ router.get(
   res.json(nodes);
 });
 
+// POST /quests/:id/complete – mark quest as completed
+router.post(
+  '/:id/complete',
+  authMiddleware,
+  (req: AuthRequest<{ id: string }>, res: Response): void => {
+    const { id } = req.params;
+    const quests = questsStore.read();
+    const posts = postsStore.read();
+    const quest = quests.find(q => q.id === id);
+    if (!quest) {
+      logQuest404(id, req.originalUrl);
+      res.status(404).json({ error: 'Quest not found' });
+      return;
+    }
+
+    const visited = new Set<string>();
+    const notify = (msg: string) => {
+      // Placeholder for notification logic
+      console.log(msg);
+    };
+
+    const completeQuest = (questId: string) => {
+      if (visited.has(questId)) return;
+      visited.add(questId);
+      const q = quests.find(x => x.id === questId);
+      if (!q) return;
+      q.status = 'completed';
+      q.linkedPosts?.forEach(link => {
+        if (link.itemType === 'post') {
+          if (link.cascadeSolution) {
+            const post = posts.find(p => p.id === link.itemId);
+            if (post) {
+              post.tags = [...(post.tags || []), 'solved'];
+            }
+          }
+          if (link.notifyOnChange) {
+            notify(`Notify post ${link.itemId} of quest ${questId} completion`);
+          }
+        } else if (link.itemType === 'quest') {
+          if (link.cascadeSolution) {
+            completeQuest(link.itemId);
+          } else if (link.notifyOnChange) {
+            notify(`Notify quest ${link.itemId} of quest ${questId} completion`);
+          }
+        }
+      });
+    };
+
+    completeQuest(id);
+    questsStore.write(quests);
+    postsStore.write(posts);
+    res.json({ success: true });
+  }
+);
+
 // DELETE quest
 router.delete(
   '/:id',

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -201,6 +201,53 @@ describe('route handlers', () => {
     expect(quest.taskGraph[0]).toEqual({ from: 't1', to: 't2', type: undefined, label: undefined });
   });
 
+  it('POST /quests/:id/complete cascades solution', async () => {
+    const { questsStore, postsStore } = require('../src/models/stores');
+    const quest: any = {
+      id: 'q1',
+      authorId: 'u1',
+      title: 'Quest',
+      status: 'active',
+      headPostId: '',
+      linkedPosts: [
+        { itemId: 'p1', itemType: 'post', cascadeSolution: true },
+        { itemId: 'qParent', itemType: 'quest', cascadeSolution: true },
+      ],
+      collaborators: [],
+      taskGraph: [] as any[],
+    };
+    const parent: any = {
+      id: 'qParent',
+      authorId: 'u1',
+      title: 'Parent',
+      status: 'active',
+      headPostId: '',
+      linkedPosts: [],
+      collaborators: [],
+      taskGraph: [] as any[],
+    };
+    questsStore.read.mockReturnValue([quest, parent]);
+    postsStore.read.mockReturnValue([
+      {
+        id: 'p1',
+        authorId: 'u1',
+        type: 'task',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+      },
+    ]);
+    postsStore.write.mockClear();
+
+    const res = await request(app).post('/quests/q1/complete');
+
+    expect(res.status).toBe(200);
+    expect(quest.status).toBe('completed');
+    expect(parent.status).toBe('completed');
+    expect(postsStore.write).toHaveBeenCalled();
+  });
+
   it('GET /boards/:id/quests returns quests from board', async () => {
     const { boardsStore, questsStore } = require('../src/models/stores');
     boardsStore.read.mockReturnValue([


### PR DESCRIPTION
## Summary
- add `POST /quests/:id/complete` endpoint
- cascade quest completion to linked posts and quests
- note completion route in README
- test quest completion cascade

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854ad741c80832f8166fcf9b21d2f56