### PR TITLE
Enhance kanban dnd snapping

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -1,6 +1,15 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import ContributionCard from '../contribution/ContributionCard';
-import { DndContext, useDraggable, useDroppable, type DragEndEvent } from '@dnd-kit/core';
+import {
+  DndContext,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  closestCenter,
+} from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { updatePost, archivePost } from '../../api/post';
 import { useBoardContext } from '../../contexts/BoardContext';
@@ -80,6 +89,9 @@ const GridLayout: React.FC<GridLayoutProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [index, setIndex] = useState(0);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
   const scrollToIndex = useCallback((i: number) => {
     const el = containerRef.current;
     if (!el) return;
@@ -158,7 +170,11 @@ const GridLayout: React.FC<GridLayoutProps> = ({
 
   if (layout === 'kanban') {
     return (
-      <DndContext onDragEnd={handleDragEnd}>
+      <DndContext
+        onDragEnd={handleDragEnd}
+        sensors={sensors}
+        collisionDetection={closestCenter}
+      >
         <div className="flex overflow-auto space-x-4 pb-4 px-2">
           {defaultKanbanColumns.map((col) => (
             <div

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -50,8 +50,11 @@ a:hover {
 
 .dragging {
   opacity: 0.5;
+  transition: transform 0.15s ease;
 }
 
 .droppable-over {
   background-color: var(--info-background);
+  transform: scale(1.05);
+  transition: transform 0.15s ease;
 }

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -31,6 +31,10 @@ jest.mock('@dnd-kit/core', () => ({
     isDragging: false,
   }),
   useDroppable: () => ({ setNodeRef: jest.fn(), isOver: isOverMock }),
+  useSensor: jest.fn(),
+  useSensors: (...s) => s,
+  PointerSensor: jest.fn(),
+  closestCenter: jest.fn(),
 }), { virtual: true });
 
 jest.mock('../src/hooks/useGit', () => ({

--- a/ethos-frontend/tests/GridLayoutKanban.test.js
+++ b/ethos-frontend/tests/GridLayoutKanban.test.js
@@ -26,6 +26,10 @@ jest.mock('@dnd-kit/core', () => ({
     setNodeRef: jest.fn(),
     isOver: false,
   }),
+  useSensor: jest.fn(),
+  useSensors: (...s) => s,
+  PointerSensor: jest.fn(),
+  closestCenter: jest.fn(),
 }), { virtual: true });
 
 jest.mock('@dnd-kit/utilities', () => ({ __esModule: true, CSS: { Translate: { toString: () => '' } } }), { virtual: true });
@@ -69,6 +73,10 @@ jest.mock('@dnd-kit/core', () => {
       setNodeRef: jest.fn(),
       isOver: false,
     }),
+    useSensor: jest.fn(),
+    useSensors: (...s) => s,
+    PointerSensor: jest.fn(),
+    closestCenter: jest.fn(),
   };
 }, { virtual: true });
 


### PR DESCRIPTION
## Summary
- add `closestCenter` and pointer sensor to GridLayout
- tweak drag styling in index.css
- update Jest mocks with new exports

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854aedb4620832fab2f0b5cb6f74587