### PR TITLE
Enable interactive markdown tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It’s a new operating system for solving problems together.
 * **AI Content Reviews** – Rate and tag AI apps, quests, creators, or datasets.
 * **Quick Sharing** – Use the action menu to copy post quotes or grab a direct link.
 * **Visual Quest Maps** – Tree, grid, or list views of how solutions evolve.
+* **Interactive Task Lists** – Check off markdown tasks directly within posts.
 * **Freelancer-Oriented** – Designed to support real client work, solo projects, and peer-based micro-teams.
 * **Web3-Ready (Future)** – Enable decentralized contracts and token-based achievements.
 

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -116,6 +116,25 @@ const PostCard: React.FC<PostCardProps> = ({
     setShowReplies(prev => !prev);
   };
 
+  const handleToggleTask = async (index: number, checked: boolean) => {
+    const regex = /- \[[ xX]\]/g;
+    let i = -1;
+    const updatedContent = post.content.replace(regex, match => {
+      i += 1;
+      if (i === index) return `- [${checked ? 'x' : ' '}]`;
+      return match;
+    });
+
+    const optimistic = { ...post, content: updatedContent } as Post;
+    onUpdate?.(optimistic);
+    try {
+      const updated = await updatePost(post.id, { content: updatedContent });
+      onUpdate?.(updated);
+    } catch (err) {
+      console.error('[PostCard] Failed to toggle task:', err);
+    }
+  };
+
   const renderRepostInfo = () => {
     const quote = post.repostedFrom;
     if (!quote?.originalContent) return null;
@@ -262,7 +281,10 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="text-sm text-gray-800 dark:text-gray-200">
         {isLong ? (
           <>
-            <MarkdownRenderer content={content.slice(0, PREVIEW_LIMIT) + '…'} />
+            <MarkdownRenderer
+              content={content.slice(0, PREVIEW_LIMIT) + '…'}
+              onToggleTask={handleToggleTask}
+            />
             <button
               onClick={() => navigate(ROUTES.POST(post.id))}
               className="text-blue-600 underline text-xs ml-1"
@@ -271,7 +293,7 @@ const PostCard: React.FC<PostCardProps> = ({
             </button>
           </>
         ) : (
-          <MarkdownRenderer content={content} />
+          <MarkdownRenderer content={content} onToggleTask={handleToggleTask} />
         )}
         <MediaPreview media={post.mediaPreviews} />
       </div>

--- a/ethos-frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/ethos-frontend/src/components/ui/MarkdownRenderer.tsx
@@ -4,13 +4,30 @@ import remarkGfm from 'remark-gfm';
 
 interface MarkdownRendererProps {
   content: string;
+  onToggleTask?: (index: number, checked: boolean) => void;
 }
 
-const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onToggleTask }) => {
   if (!content) return null;
+  let checkboxIndex = -1;
+  const components = {
+    input: ({ checked, type, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => {
+      if (type === 'checkbox') {
+        checkboxIndex += 1;
+        return (
+          <input
+            type="checkbox"
+            defaultChecked={Boolean(checked)}
+            onChange={(e) => onToggleTask?.(checkboxIndex, e.target.checked)}
+          />
+        );
+      }
+      return <input type={type} {...props} />;
+    },
+  };
   return (
     <div className="prose prose-sm max-w-none">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{content}</ReactMarkdown>
     </div>
 
   );

--- a/ethos-frontend/tests/TaskList.test.tsx
+++ b/ethos-frontend/tests/TaskList.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PostCard from '../src/components/post/PostCard';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+  updatePost: jest.fn((id, data) => Promise.resolve({ id, ...data })),
+  fetchPostsByQuestId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../src/api/quest', () => ({
+  __esModule: true,
+  linkPostToQuest: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../src/hooks/useGraph', () => ({
+  __esModule: true,
+  useGraph: () => ({ loadGraph: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: jest.fn() }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock(
+  'react-markdown',
+  () => {
+    return function Mock({ children, components }) {
+      const lines = String(children).split(/\n/);
+      return (
+        <div>
+          {lines.map((line, idx) => {
+            const m = line.match(/- \[( |x)\] (.*)/);
+            if (m) {
+              const Input = components?.input || 'input';
+              return (
+                <label key={idx}>
+                  <Input type="checkbox" checked={m[1] === 'x'} />
+                  {m[2]}
+                </label>
+              );
+            }
+            return <span key={idx}>{line}</span>;
+          })}
+        </div>
+      );
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock('remark-gfm', () => () => ({}), { virtual: true });
+
+const { updatePost } = require('../src/api/post');
+
+describe('task list checkbox', () => {
+  it('toggles checkbox and updates post', async () => {
+    const post = {
+      id: 'p1',
+      authorId: 'u1',
+      type: 'task',
+      content: '- [ ] task one\n- [x] task two',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as any;
+
+    function Wrapper() {
+      const [p, setP] = React.useState(post);
+      return <PostCard post={p} user={{ id: 'u1' }} onUpdate={setP} />;
+    }
+
+    render(<Wrapper />);
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes[0]).not.toBeChecked();
+
+    fireEvent.change(boxes[0], { target: { checked: true } });
+    await waitFor(() => expect(updatePost).toHaveBeenCalled());
+    expect(updatePost).toHaveBeenCalledWith('p1', {
+      content: '- [x] task one\n- [x] task two',
+    });
+    expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary
- add onToggleTask prop and checkbox override in `MarkdownRenderer`
- handle checkbox toggling in `PostCard`
- test interactive task lists
- document interactive task list feature

## Testing
- `npm test --prefix ethos-frontend -- TaskList.test.tsx` *(fails: expect updatePost to have been called)*

------
https://chatgpt.com/codex/tasks/task_e_6854af4f3d68832f9f5e8a3b172706a8