### PR TITLE
Implement task status defaults

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -39,7 +39,10 @@ router.post(
       replyTo = null,
       linkedItems = [],
       collaborators = [],
+      status,
     } = req.body;
+
+    const finalStatus = status ?? (type === 'task' ? 'To Do' : undefined);
 
     const posts = postsStore.read();
     const quests = questsStore.read();
@@ -59,6 +62,7 @@ router.post(
       repostedFrom: null,
       linkedItems,
       questId,
+      status: finalStatus,
       nodeId: quest ? generateNodeId({ quest, posts, postType: type, parentPost: parent }) : undefined,
     };
 

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -33,6 +33,28 @@ describe('post routes', () => {
     expect(res.body.content).toBe('hello');
   });
 
+  it("POST /posts defaults task status to 'To Do'", async () => {
+    postsStore.read.mockReturnValue([]);
+    postsStore.write.mockClear();
+    const res = await request(app).post('/posts').send({ type: 'task' });
+    expect(res.status).toBe(201);
+    const written = postsStore.write.mock.calls[0][0][0];
+    expect(written.status).toBe('To Do');
+    expect(res.body.status).toBe('To Do');
+  });
+
+  it('POST /posts uses provided task status', async () => {
+    postsStore.read.mockReturnValue([]);
+    postsStore.write.mockClear();
+    const res = await request(app)
+      .post('/posts')
+      .send({ type: 'task', status: 'Blocked' });
+    expect(res.status).toBe(201);
+    const written = postsStore.write.mock.calls[0][0][0];
+    expect(written.status).toBe('Blocked');
+    expect(res.body.status).toBe('Blocked');
+  });
+
   it('PATCH /posts/:id regenerates nodeId on quest change for quest post', async () => {
     const posts = [
       {


### PR DESCRIPTION
## Summary
- allow POST /posts to set status and default tasks to "To Do"
- test that task posts get default or provided status

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854af5f61f4832f8da956b6ad39f7aa