### PR TITLE
Add dynamic reply labels & expand view

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ReactionControls from './ReactionControls';
+import type { Post } from '../../types/postTypes';
+
+jest.mock('../../api/post', () => ({
+  updateReaction: jest.fn(() => Promise.resolve()),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: () => jest.fn(),
+}));
+
+describe('ReactionControls', () => {
+  const basePost: Post = {
+    id: 'p1',
+    authorId: 'u1',
+    type: 'task',
+    content: 'hello',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+    questId: 'q1',
+  } as any;
+
+  it('shows Quest Log for task posts', async () => {
+    render(<ReactionControls post={basePost} user={{ id: 'u1' }} />);
+    expect(await screen.findByText('Quest Log')).toBeInTheDocument();
+  });
+
+  it('shows File Change View for commit posts', async () => {
+    const commitPost = { ...basePost, type: 'commit' } as Post;
+    render(<ReactionControls post={commitPost} user={{ id: 'u1' }} />);
+    expect(await screen.findByText('File Change View')).toBeInTheDocument();
+  });
+
+  it('defaults to Reply for other post types', async () => {
+    const fsPost = { ...basePost, type: 'free_speech' } as Post;
+    render(<ReactionControls post={fsPost} user={{ id: 'u1' }} />);
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+  });
+
+  it('toggles expanded view for tasks', async () => {
+    render(<ReactionControls post={basePost} user={{ id: 'u1' }} />);
+    const expand = await screen.findByText('Expand View');
+    fireEvent.click(expand);
+    expect(await screen.findByText(/Quest ID/)).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
 import {
   FaThumbsUp,
   FaRegThumbsUp,
@@ -6,6 +8,8 @@ import {
   FaRegHeart,
   FaReply,
   FaRetweet,
+  FaExpand,
+  FaCompress,
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
@@ -44,6 +48,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
   const [showReplyPanel, setShowReplyPanel] = useState(false);
   const [repostLoading, setRepostLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -148,11 +154,35 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </button>
 
         <button
-          className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-          onClick={() => setShowReplyPanel(prev => !prev)}
+          className={clsx(
+            'flex items-center gap-1',
+            post.type !== 'task' && post.type !== 'commit' && showReplyPanel && 'text-green-600'
+          )}
+          onClick={() => {
+            if (post.type === 'task' && post.questId) {
+              navigate(ROUTES.BOARD(`log-${post.questId}`));
+            } else if (post.type === 'commit') {
+              navigate(ROUTES.POST(post.id));
+            } else {
+              setShowReplyPanel(prev => !prev);
+            }
+          }}
         >
-          <FaReply /> {showReplyPanel ? 'Cancel' : 'Reply'}
+          <FaReply />{' '}
+          {post.type === 'task'
+            ? 'Quest Log'
+            : post.type === 'commit'
+            ? 'File Change View'
+            : showReplyPanel
+            ? 'Cancel'
+            : 'Reply'}
         </button>
+
+        {(post.type === 'task' || post.type === 'commit') && (
+          <button className="flex items-center gap-1" onClick={() => setExpanded(prev => !prev)}>
+            {expanded ? <FaCompress /> : <FaExpand />} {expanded ? 'Collapse View' : 'Expand View'}
+          </button>
+        )}
 
       </div>
 
@@ -166,6 +196,26 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
             }}
             onCancel={() => setShowReplyPanel(false)}
           />
+        </div>
+      )}
+
+      {expanded && post.type === 'task' && (
+        <div className="mt-3 text-sm text-gray-600">
+          {post.questId && <div>Quest ID: {post.questId}</div>}
+          {post.status && <div>Status: {post.status}</div>}
+        </div>
+      )}
+
+      {expanded && post.type === 'commit' && (
+        <div className="mt-3 text-sm">
+          {post.commitSummary && (
+            <div className="mb-1 text-gray-700 italic">{post.commitSummary}</div>
+          )}
+          {post.gitDiff && (
+            <pre className="whitespace-pre-wrap overflow-x-auto bg-gray-50 p-2 border text-xs">
+              {post.gitDiff}
+            </pre>
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- update ReactionControls to recognize post types and provide an expand view
- add ReactionControls unit tests for new behavior

## Testing
- `npm test --prefix ethos-frontend` *(fails: useBoardContext must be used within a BoardProvider, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854b00b178c832f9f1b322859ec3065