### PR TITLE
Implement quest completion cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ The backend logger supports a `LOG_LEVEL` environment variable. Set it to
 `error`, `warn`, `info` (default), or `debug` to control the verbosity of
 console output. Each log line includes a timestamp for easier tracing.
 
+### API Routes
+
+- `POST /quests/:id/complete` – mark a quest as completed. Cascades the `solved` tag to linked posts when `cascadeSolution` is set and logs notifications for links with `notifyOnChange`.
+
 ---
 
 ## 🧠 Core Flow


### PR DESCRIPTION
## Summary
- add POST `/quests/:id/complete` endpoint to close quests
- cascade `solved` tag to linked posts and recursively complete linked quests
- log placeholder notifications for linked items with `notifyOnChange`
- document the new endpoint in the README

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854b0e0b718832f817162c545605dbf