### PR TITLE
Add drag handle and reply button test

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -181,10 +181,14 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           style={{ marginLeft: depth * 16 }}
           className="mb-6 flex items-start space-x-2 cursor-pointer"
           onClick={() => onSelect(node)}
-          {...attributes}
-          {...listeners}
         >
-          <span className="text-xl select-none">{icon}</span>
+          <span
+            className="text-xl select-none cursor-grab"
+            {...attributes}
+            {...listeners}
+          >
+            {icon}
+          </span>
           <ContributionCard contribution={node} user={user} compact={compact} />
           {edge && (
             <span className="text-xs text-gray-500 ml-1 flex items-center">

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
@@ -10,9 +9,18 @@ jest.mock('../src/hooks/useGit', () => ({
 jest.mock('react-router-dom', () => ({
   __esModule: true,
   useNavigate: () => jest.fn()
+}), { virtual: true });
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    updateBoardItem: jest.fn(),
+    appendToBoard: jest.fn(),
+  })
 }));
 
 const { useGitDiff } = require('../src/hooks/useGit');
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 describe('GraphLayout node interaction', () => {
   it('loads git diff and dispatches event on node click', async () => {
@@ -37,7 +45,7 @@ describe('GraphLayout node interaction', () => {
 
     render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
 
-    fireEvent.click(screen.getByText('Task'));
+    fireEvent.click(screen.getAllByText('Task')[1]);
 
     await waitFor(() => {
       expect(useGitDiff).toHaveBeenCalledWith({
@@ -77,5 +85,28 @@ describe('GraphLayout node interaction', () => {
 
     expect(screen.getByText('N1')).toBeInTheDocument();
     expect(screen.queryByText('Some very long task content')).toBeNull();
+  });
+
+  it('shows reply form when clicking Reply on a node', () => {
+    const posts = [
+      {
+        id: 'p1',
+        type: 'task',
+        content: 'Task',
+        authorId: 'u1',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      },
+    ];
+
+    render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    fireEvent.click(screen.getAllByText('Task')[1]);
+    fireEvent.click(screen.getByText('Reply'));
+
+    expect(screen.getByText('Create Post')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- limit draggable area in GraphNode to an icon handle with `cursor-grab`
- add BoardContext mock and adjust click targets in GraphLayout tests
- test showing reply form when clicking Reply

## Testing
- `npx jest tests/GraphLayout.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6854b2fec5d8832f9257c96ad5e9f825