### PR TITLE
Update task creation to link quest graph

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -78,6 +78,22 @@ router.post(
 
     posts.push(newPost);
     postsStore.write(posts);
+
+    if (questId && type === 'task') {
+      const quest = quests.find((q) => q.id === questId);
+      if (quest) {
+        quest.taskGraph = quest.taskGraph || [];
+        const from = quest.headPostId || '';
+        const exists = quest.taskGraph.some(
+          (e) => e.from === from && e.to === newPost.id
+        );
+        if (!exists) {
+          quest.taskGraph.push({ from, to: newPost.id });
+        }
+        questsStore.write(quests);
+      }
+    }
+
     const users = usersStore.read();
     res.status(201).json(enrichPost(newPost, { users }));
   }

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -55,6 +55,30 @@ describe('post routes', () => {
     expect(res.body.status).toBe('Blocked');
   });
 
+  it('POST /posts links task to quest taskGraph', async () => {
+    const quest: any = {
+      id: 'q1',
+      title: 'Quest',
+      status: 'active',
+      headPostId: '',
+      linkedPosts: [],
+      collaborators: [],
+      taskGraph: [] as any[],
+    };
+    postsStore.read.mockReturnValue([]);
+    questsStore.read.mockReturnValue([quest]);
+    postsStore.write.mockClear();
+    questsStore.write.mockClear();
+
+    const res = await request(app).post('/posts').send({ type: 'task', questId: 'q1' });
+
+    expect(res.status).toBe(201);
+    const newPost = postsStore.write.mock.calls[0][0][0];
+    expect(quest.taskGraph).toHaveLength(1);
+    expect(quest.taskGraph[0]).toEqual({ from: '', to: newPost.id });
+    expect(questsStore.write).toHaveBeenCalled();
+  });
+
   it('PATCH /posts/:id regenerates nodeId on quest change for quest post', async () => {
     const posts = [
       {


### PR DESCRIPTION
## Summary
- add quest task graph linking when creating tasks
- test the new behavior

## Testing
- `npx jest --runInBand --no-cache`

------
https://chatgpt.com/codex/tasks/task_e_6854bce50ff4832fa8059ba7c5353c47