### PR TITLE
Add alert and button utilities

### DIFF
--- a/ethos-frontend/src/components/ui/AlertBox.tsx
+++ b/ethos-frontend/src/components/ui/AlertBox.tsx
@@ -26,10 +26,10 @@ const AlertBox: React.FC<AlertBoxProps> = ({
   const baseStyles =
     'rounded px-4 py-3 text-sm font-medium shadow-sm border-l-4';
   const typeStyles: Record<AlertType, string> = {
-    success: 'bg-green-50 text-green-800 border-green-400',
-    error: 'bg-red-50 text-red-800 border-red-400',
-    warning: 'bg-yellow-50 text-yellow-800 border-yellow-400',
-    info: 'bg-blue-50 text-blue-800 border-blue-400',
+    success: 'alert-success',
+    error: 'alert-error',
+    warning: 'alert-warning',
+    info: 'alert-info',
   };
 
   return (

--- a/ethos-frontend/src/components/ui/Button.tsx
+++ b/ethos-frontend/src/components/ui/Button.tsx
@@ -20,20 +20,14 @@ const Button: React.FC<ButtonProps> = ({
   disabled,
   ...props
 }) => {
-  const baseStyles =
-    'inline-flex items-center justify-center font-medium rounded-md focus:outline-none transition-colors duration-150';
+  const baseStyles = 'btn';
 
   const variantStyles: Record<ButtonVariant, string> = {
-    primary:
-      'bg-accent text-white hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-400 dark:bg-indigo-600 dark:hover:bg-indigo-500 dark:focus:ring-indigo-300',
-    secondary:
-      'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600 focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600',
-    ghost:
-      'bg-transparent text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:ring-2 focus:ring-gray-200 dark:focus:ring-gray-700',
-    danger:
-      'bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 dark:bg-red-500 dark:hover:bg-red-400 dark:focus:ring-red-300',
-    disabled:
-      'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed',
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    ghost: 'btn-ghost',
+    danger: 'btn-danger',
+    disabled: 'btn-disabled',
   };
 
   const sizeStyles: Record<ButtonSize, string> = {

--- a/ethos-frontend/src/components/ui/StatusBadge.tsx
+++ b/ethos-frontend/src/components/ui/StatusBadge.tsx
@@ -8,20 +8,14 @@ interface StatusBadgeProps {
 }
 
 const statusStyles: Record<string, string> = {
-  'To Do':
-    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
-  'In Progress':
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
-  Blocked:
-    'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-200',
-  Done:
-    'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
+  'To Do': 'badge-info',
+  'In Progress': 'badge-warning',
+  Blocked: 'badge-error',
+  Done: 'badge-success',
 };
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className }) => {
-  const style =
-    statusStyles[status] ||
-    'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+  const style = statusStyles[status] || 'badge-info';
   return (
     <span
       className={clsx(

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -9,6 +9,14 @@
   --text-primary: #1f2937;
   --accent: #4f46e5; /* indigo-600 */
   --info-background: #bfdbfe;
+  --success-bg: #ecfdf5;
+  --success-text: #047857;
+  --error-bg: #fef2f2;
+  --error-text: #b91c1c;
+  --warning-bg: #fffbeb;
+  --warning-text: #b45309;
+  --info-bg: #eff6ff;
+  --info-text: #1e40af;
 }
 
 .dark {
@@ -16,6 +24,14 @@
   --text-primary: #f9fafb; /* light gray */
   --accent: #818cf8; /* indigo-400 */
   --card-dark: #374151;
+  --success-bg: #064e3b;
+  --success-text: #ecfdf5;
+  --error-bg: #7f1d1d;
+  --error-text: #fef2f2;
+  --warning-bg: #78350f;
+  --warning-text: #fef3c7;
+  --info-bg: #1e40af;
+  --info-text: #dbeafe;
 }
 
 html, body {
@@ -57,4 +73,83 @@ a:hover {
   background-color: var(--info-background);
   transform: scale(1.05);
   transition: transform 0.15s ease;
+}
+
+.alert-success {
+  background-color: var(--success-bg);
+  color: var(--success-text);
+  border-left: 4px solid var(--success-text);
+}
+
+.alert-error {
+  background-color: var(--error-bg);
+  color: var(--error-text);
+  border-left: 4px solid var(--error-text);
+}
+
+.alert-warning {
+  background-color: var(--warning-bg);
+  color: var(--warning-text);
+  border-left: 4px solid var(--warning-text);
+}
+
+.alert-info {
+  background-color: var(--info-bg);
+  color: var(--info-text);
+  border-left: 4px solid var(--info-text);
+}
+
+.badge-success {
+  background-color: var(--success-bg);
+  color: var(--success-text);
+}
+
+.badge-error {
+  background-color: var(--error-bg);
+  color: var(--error-text);
+}
+
+.badge-warning {
+  background-color: var(--warning-bg);
+  color: var(--warning-text);
+}
+
+.badge-info {
+  background-color: var(--info-bg);
+  color: var(--info-text);
+}
+
+.btn {
+  @apply inline-flex items-center justify-center font-medium rounded-md focus:outline-none transition-colors duration-150;
+}
+
+.btn-primary {
+  background-color: var(--accent);
+  color: #fff;
+}
+
+.btn-secondary {
+  background-color: var(--bg-soft);
+  color: var(--text-primary);
+}
+
+.dark .btn-secondary {
+  background-color: var(--card-dark);
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: var(--text-primary);
+}
+
+.btn-danger {
+  background-color: var(--error-bg);
+  color: var(--error-text);
+}
+
+.btn-disabled {
+  background-color: var(--bg-soft);
+  color: var(--text-primary);
+  opacity: 0.6;
+  cursor: not-allowed;
 }

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -5,6 +5,14 @@ export const colors = {
   primaryDark: '#f9fafb',
   softDark: '#1f2937',
   infoBackground: '#bfdbfe',
+  success: '#047857',
+  successBg: '#ecfdf5',
+  error: '#b91c1c',
+  errorBg: '#fef2f2',
+  warning: '#b45309',
+  warningBg: '#fffbeb',
+  info: '#1e40af',
+  infoBg: '#eff6ff',
 };
 
 export default colors;


### PR DESCRIPTION
## Summary
- add success/error/warning/info colors to theme tokens
- define alert, badge, and button utility classes using CSS variables
- refactor AlertBox, StatusBadge and Button to use new utility classes

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm run lint --prefix ethos-frontend` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf716b10832f929bbbbb6e86121d