### PR TITLE
Improve color palette with soft tones

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,14 +6,14 @@ This guide documents the color tokens used throughout the Ethos application and 
 
 The palette is defined in `ethos-frontend/src/theme.ts` and mirrored in Tailwind and CSS variables. Each token represents a color that can be referenced in Tailwind classes or via `var(--token-name)`.
 
-| Token | Hex | Description |
-| ----- | --- | ----------- |
-| `primary` | `#111827` | Default text and interface color |
-| `accent` | `#4F46E5` | Primary brand accent |
-| `soft` | `#F3F4F6` | Light background or borders |
-| `primaryDark` | `#f9fafb` | Text color when dark mode is active |
-| `softDark` | `#1f2937` | Dark mode background |
-| `infoBackground` | `#bfdbfe` | Highlight color for drag/drop or info blocks |
+| Token | Light | Dark | Description |
+| ----- | ----- | ---- | ----------- |
+| `primary` | `#111827` | `#f9fafb` | Default text color |
+| `secondary` | `#4B5563` | `#D1D5DB` | Subtle text elements |
+| `accent` | `#4F46E5` | `#818cf8` | Brand accent and buttons |
+| `soft` | `#F3F4F6` | `#1f2937` | Application background |
+| `surface` | `#ffffff` | `#374151` | Cards and panels |
+| `infoBackground` | `#bfdbfe` | `#1e40af` | Highlight color for drag/drop or info blocks |
 
 ## Using Tokens in Components
 

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -12,9 +12,13 @@
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
+  --color-soft: #f3f4f6;
   --color-background: #f9fafb;
   --color-surface: #ffffff;
   --info-background: #bfdbfe;
+  --bg-soft: var(--color-soft);
+  --bg-soft-dark: #1f2937;
+  --text-primary: var(--color-primary);
   --success-bg: #ecfdf5;
   --success-text: #047857;
   --error-bg: #fef2f2;
@@ -32,9 +36,13 @@
   --color-success: #6ee7b7;
   --color-warning: #fde68a;
   --color-error: #fca5a5;
+  --color-soft-dark: #1f2937;
   --color-background: #1f2937;
   --color-surface: #374151;
   --info-background: #1e40af;
+  --bg-soft: var(--color-soft-dark);
+  --bg-soft-dark: var(--color-soft-dark);
+  --text-primary: var(--color-primary);
 }
 
 html, body {

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -8,6 +8,7 @@ export const colors: Record<string, Palette> = {
   primary: { light: '#111827', dark: '#f9fafb' },
   secondary: { light: '#4B5563', dark: '#D1D5DB' },
   accent: { light: '#4F46E5', dark: '#818cf8' },
+  soft: { light: '#F3F4F6', dark: '#1f2937' },
   success: { light: '#10B981', dark: '#6EE7B7' },
   warning: { light: '#F59E0B', dark: '#FDE68A' },
   error: { light: '#EF4444', dark: '#FCA5A5' },

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
           success: 'var(--color-success)',
           warning: 'var(--color-warning)',
           error: 'var(--color-error)',
+          soft: 'var(--color-soft)',
+          'soft-dark': 'var(--color-soft-dark)',
           background: 'var(--color-background)',
           surface: 'var(--color-surface)',
           'info-background': 'var(--info-background)',


### PR DESCRIPTION
## Summary
- expand design tokens with `soft` color
- register soft tokens in Tailwind
- expose CSS variables for `bg-soft` and text
- update design system docs to show the new palette

## Testing
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_6854c2e5e164832fbea59df617a55229