### PR TITLE
Fix button color variables

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -31,6 +31,10 @@ The class `bg-accent` maps to the `accent` token defined above. The same applies
 
 Tokens are also exposed as CSS custom properties in `src/index.css`. Use them when writing custom styles or when Tailwind utility classes are not flexible enough.
 
+Each palette token is mirrored with a `--color-<token>` variable. For example,
+`--color-accent` and `--color-surface` provide the accent and surface colors used
+for buttons and card backgrounds.
+
 ```css
 .card {
   background-color: var(--bg-soft);

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -135,7 +135,7 @@ a:hover {
 }
 
 .btn-primary {
-  background-color: var(--accent);
+  background-color: var(--color-accent);
   color: #fff;
 }
 
@@ -145,7 +145,7 @@ a:hover {
 }
 
 .dark .btn-secondary {
-  background-color: var(--card-dark);
+  background-color: var(--color-surface);
 }
 
 .btn-ghost {


### PR DESCRIPTION
## Summary
- use `--color-accent` and `--color-surface` for button colors
- document new `--color-*` variables in the design system docs

## Testing
- `npx jest --runInBand` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c5edc608832f9a344ffbc3318bf3