### PR TITLE
Use design token classes

### DIFF
--- a/ethos-frontend/src/components/ReviewList.tsx
+++ b/ethos-frontend/src/components/ReviewList.tsx
@@ -63,7 +63,7 @@ const ReviewList: React.FC<ReviewListProps> = ({ type, questId, postId, classNam
       ) : (
         <ul className="space-y-3">
           {reviews.map(review => (
-            <li key={review.id} className="border rounded bg-white dark:bg-gray-800 p-3">
+            <li key={review.id} className="border rounded bg-surface dark:bg-background p-3">
               <div className="flex justify-between items-center">
                 {renderStars(review.rating)}
                 <span className="text-xs text-gray-500 dark:text-gray-400">

--- a/ethos-frontend/src/components/controls/CollaberatorControls.tsx
+++ b/ethos-frontend/src/components/controls/CollaberatorControls.tsx
@@ -85,7 +85,7 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
               className={`px-3 py-1 rounded-full border text-sm ${
                 selectedRoles.includes(role)
                   ? 'bg-indigo-600 text-white border-indigo-600'
-                  : 'bg-white text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600'
+                  : 'bg-surface text-gray-700 border-gray-300 dark:bg-background dark:text-gray-200 dark:border-gray-600'
               }`}
             >
               {role}
@@ -102,7 +102,7 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
             {value.map((c, index) => (
               <li
                 key={index}
-                className="flex justify-between items-start bg-gray-50 dark:bg-gray-700 p-2 rounded-md border"
+                className="flex justify-between items-start bg-background dark:bg-surface p-2 rounded-md border"
               >
                 <div>
                   <strong>@{c.username}</strong>

--- a/ethos-frontend/src/components/ui/ActionMenu.tsx
+++ b/ethos-frontend/src/components/ui/ActionMenu.tsx
@@ -123,7 +123,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
         <FaEllipsisH />
       </button>
       {showMenu && (
-        <div className="absolute right-0 mt-1 w-48 z-10 border rounded bg-white dark:bg-gray-800 shadow text-sm">
+        <div className="absolute right-0 mt-1 w-48 z-10 border rounded bg-surface dark:bg-background shadow text-sm">
           {canEdit && (
             <>
               <button onClick={onEdit} className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700">

--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -30,7 +30,7 @@ const Banner: React.FC<BannerProps> = ({ user, quest }) => {
   const tags = user?.tags || quest?.collaborators || [];
 
   return (
-    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-white dark:bg-gray-800 p-4 sm:p-6 rounded-lg shadow mb-6">
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-surface dark:bg-background p-4 sm:p-6 rounded-lg shadow mb-6">
       {/* Left: Name + Description */}
       <div className="flex flex-col gap-1 text-left max-w-2xl">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">

--- a/ethos-frontend/src/components/ui/LinkViewer.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.tsx
@@ -48,7 +48,7 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items }) => {
   }, {});
 
   return (
-    <div className="text-xs text-gray-900 dark:text-gray-100">
+    <div className="text-xs text-primary dark:text-primary">
       <button
         onClick={() => setOpen((o) => !o)}
         className="text-blue-600 underline"
@@ -56,7 +56,7 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items }) => {
         {open ? 'Hide Links' : `Links (${items.length})`}
       </button>
       {open && (
-        <div className="mt-2 border rounded bg-gray-50 dark:bg-gray-700 p-2 space-y-1">
+        <div className="mt-2 border rounded bg-background dark:bg-surface p-2 space-y-1">
           {Object.entries(grouped).map(([type, list]) => (
             <div key={type}>
               <div className="font-semibold capitalize mb-1">{type}</div>

--- a/ethos-frontend/src/components/ui/TextArea.tsx
+++ b/ethos-frontend/src/components/ui/TextArea.tsx
@@ -43,7 +43,7 @@ const TextArea: React.FC<TextAreaProps> = ({
         readOnly={readOnly}
         onChange={onChange}
         className={clsx(
-          'w-full p-3 rounded-md border shadow-sm resize-y text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 focus:outline-none',
+          'w-full p-3 rounded-md border shadow-sm resize-y text-sm text-primary dark:text-primary bg-surface dark:bg-surface focus:outline-none',
           error
             ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
             : 'border-gray-300 dark:border-gray-600 focus:ring-accent focus:border-accent',


### PR DESCRIPTION
## Summary
- replace hard-coded gray classes in components with tokenized classes

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm test --prefix ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6854c5eeb850832f88e4745b7404276d