### PR TITLE
Improve README test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ git clone https://github.com/yourusername/ethos.git
 cd ethos
 ```
 
+Make sure you have **Node.js 16 or later** installed before proceeding.
+
 ### 2. Setup Frontend
 
 ```bash
@@ -138,7 +140,8 @@ For production builds, run `npm run build` and then start with `node dist/server
 
 ### Running Tests
 
-Execute the backend test suite after installing dependencies:
+Run `./setup.sh` first to install all dependencies before running tests.
+Execute the backend test suite after installing dependencies (tests require `supertest` to be installed):
 
 ```bash
 npm test --prefix ethos-backend
@@ -147,6 +150,7 @@ npm test --prefix ethos-backend
 This runs the Jest tests under `ethos-backend/tests`.
 
 To run the frontend test suite:
+Ensure `jest-environment-jsdom` is installed for the frontend tests.
 
 ```bash
 npm test --prefix ethos-frontend


### PR DESCRIPTION
## Summary
- clarify Node.js version requirement
- add instructions to run `./setup.sh` before tests
- mention `supertest` and `jest-environment-jsdom` prerequisites

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: useNavigate errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854c5ef27a4832f90ab0e6bbc5e0185