### PR TITLE
Darken soft palette color

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -11,9 +11,11 @@ The palette is defined in `ethos-frontend/src/theme.ts` and mirrored in Tailwind
 | `primary` | `#111827` | `#f9fafb` | Default text color |
 | `secondary` | `#4B5563` | `#D1D5DB` | Subtle text elements |
 | `accent` | `#4F46E5` | `#818cf8` | Brand accent and buttons |
-| `soft` | `#F3F4F6` | `#1f2937` | Application background |
+| `soft` | `#E5E7EB` | `#1f2937` | Application background |
 | `surface` | `#ffffff` | `#374151` | Cards and panels |
 | `infoBackground` | `#bfdbfe` | `#1e40af` | Highlight color for drag/drop or info blocks |
+
+`soft` now has a slightly darker light mode value. Use `surface` for most card backgrounds and reserve `soft` for overall page backgrounds.
 
 ## Using Tokens in Components
 
@@ -25,7 +27,7 @@ Color tokens are registered as Tailwind colors so you can use them directly in c
 <button className="bg-accent text-white hover:bg-accent/80">Click me</button>
 ```
 
-The class `bg-accent` maps to the `accent` token defined above. The same applies to `text-primary`, `bg-soft`, and other tokens.
+The class `bg-accent` maps to the `accent` token defined above. The same applies to `text-primary`, `bg-soft`, `bg-surface`, and other tokens.
 
 ### CSS Variables
 

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -12,7 +12,7 @@
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
-  --color-soft: #f3f4f6;
+  --color-soft: #e5e7eb;
   --color-background: #f9fafb;
   --color-surface: #ffffff;
   --info-background: #bfdbfe;

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -8,7 +8,7 @@ export const colors: Record<string, Palette> = {
   primary: { light: '#111827', dark: '#f9fafb' },
   secondary: { light: '#4B5563', dark: '#D1D5DB' },
   accent: { light: '#4F46E5', dark: '#818cf8' },
-  soft: { light: '#F3F4F6', dark: '#1f2937' },
+  soft: { light: '#E5E7EB', dark: '#1f2937' },
   success: { light: '#10B981', dark: '#6EE7B7' },
   warning: { light: '#F59E0B', dark: '#FDE68A' },
   error: { light: '#EF4444', dark: '#FCA5A5' },


### PR DESCRIPTION
## Summary
- darken the `soft` color token
- document the change in the design system guide
- rebuild Tailwind CSS so `bg-soft` matches the new value

## Testing
- `npx --prefix ethos-frontend tailwindcss -i ethos-frontend/src/index.css -o ethos-frontend/src/tailwind.css`
- `npm test --prefix ethos-frontend` *(fails: Cannot log after tests are done, useNavigate errors)*
- `npm test --prefix ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6854c5f03150832fbd71df31581eef23