### PR TITLE
Fix light theme contrast

### DIFF
--- a/ethos-frontend/src/components/ui/Button.tsx
+++ b/ethos-frontend/src/components/ui/Button.tsx
@@ -26,13 +26,13 @@ const Button: React.FC<ButtonProps> = ({
     primary:
       'bg-accent text-white hover:bg-accent focus:ring-2 focus:ring-accent',
     secondary:
-      'bg-background text-primary hover:bg-surface focus:ring-2 focus:ring-secondary',
+      'bg-soft text-primary hover:bg-surface focus:ring-2 focus:ring-secondary',
     ghost:
-      'bg-transparent text-secondary hover:bg-background focus:ring-2 focus:ring-background',
+      'bg-transparent text-secondary hover:bg-soft focus:ring-2 focus:ring-background',
     danger:
       'bg-error text-white hover:bg-error focus:ring-2 focus:ring-error',
     disabled:
-      'bg-background text-secondary cursor-not-allowed',
+      'bg-soft text-secondary cursor-not-allowed',
   };
 
   const sizeStyles: Record<ButtonSize, string> = {

--- a/ethos-frontend/src/components/ui/StatusBadge.tsx
+++ b/ethos-frontend/src/components/ui/StatusBadge.tsx
@@ -8,7 +8,7 @@ interface StatusBadgeProps {
 }
 
 const statusStyles: Record<string, string> = {
-  'To Do': 'bg-background text-secondary',
+  'To Do': 'bg-soft text-secondary',
   'In Progress': 'bg-warning text-warning',
   Blocked: 'bg-error text-error',
   Done: 'bg-success text-success',
@@ -16,7 +16,7 @@ const statusStyles: Record<string, string> = {
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className }) => {
   const style =
-    statusStyles[status] || 'bg-background text-secondary';
+    statusStyles[status] || 'bg-soft text-secondary';
   return (
     <span
       className={clsx(

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -13,7 +13,7 @@
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-soft: #e5e7eb;
-  --color-background: #f9fafb;
+  --color-background: #ffffff;
   --color-surface: #ffffff;
   --info-background: #bfdbfe;
   --bg-soft: var(--color-soft);


### PR DESCRIPTION
## Summary
- improve light theme readability by adjusting the button styles
- ensure status badges use `bg-soft` in light mode
- bump light theme background token to pure white

## Testing
- `npm test --prefix ethos-frontend` *(fails: useBoardContext must be used within a BoardProvider)*

------
https://chatgpt.com/codex/tasks/task_e_6854cb2e17b4832f9507f66b131b67ac