### PR TITLE
Update graph map to use condensed nodes

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -268,7 +268,12 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 + Add Item
               </Button>
             </div>
-            <GraphLayout items={logs as any} user={user} edges={questData.taskGraph} />
+            <GraphLayout
+              items={logs as any}
+              user={user}
+              edges={questData.taskGraph}
+              condensed
+            />
           </>
         );
       default:


### PR DESCRIPTION
## Summary
- make quest map view use condensed GraphLayout nodes

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d18b65e8832f8cfb4e2f651196e4