### PR TITLE
Add draggable condensed nodes with expand/collapse

### DIFF
--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -87,6 +87,43 @@ describe('GraphLayout node interaction', () => {
     expect(screen.queryByText('Some very long task content')).toBeNull();
   });
 
+  it('expands condensed node on click', () => {
+    const posts = [
+      {
+        id: 'p1',
+        nodeId: 'N1',
+        type: 'task',
+        content: 'Some very long task content that should be trimmed',
+        authorId: 'u1',
+        visibility: 'public',
+        timestamp: '',
+        tags: ['task'],
+        collaborators: [],
+        linkedItems: [],
+      },
+    ];
+
+    render(
+      React.createElement(GraphLayout, {
+        items: posts,
+        questId: 'q1',
+        condensed: true,
+      })
+    );
+
+    fireEvent.click(screen.getByText('N1'));
+
+    expect(
+      screen.getByText('Some very long task content that should be trimmed')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Collapse'));
+
+    expect(
+      screen.queryByText('Some very long task content that should be trimmed')
+    ).toBeNull();
+  });
+
   it('shows reply form when clicking Reply on a node', () => {
     const posts = [
       {


### PR DESCRIPTION
## Summary
- enable condensed graph nodes to expand into full cards
- add collapse button for expanded condensed nodes
- make condensed nodes draggable for linking
- cover expansion logic in GraphLayout tests

## Testing
- `./setup.sh`
- `npm test --prefix ethos-frontend` *(fails: useNavigate hook outside router)*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854d3d3ebd4832fa3540498afb86533