### PR TITLE
Improve theme-based text colors

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
         <TimelineProvider>
           <BoardProvider>
             <ThemeProvider>
-            <div className="min-h-screen flex flex-col bg-soft dark:bg-soft-dark text-gray-900 dark:text-gray-100">
+            <div className="min-h-screen flex flex-col bg-soft dark:bg-soft-dark text-primary">
               {/* Top-level navigation */}
               <NavBar />
 

--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -119,17 +119,17 @@ const Login: React.FC = () => {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4">
+    <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4 text-primary">
       <section className="w-full max-w-md bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <header className="mb-6 text-center">
-          <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">
+          <h1 className="text-3xl font-bold text-primary">
             {showReset
               ? 'Reset Password'
               : isRegistering
               ? 'Create an Account'
               : 'Welcome Back'}
           </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-100 mt-1">
+          <p className="text-sm text-secondary mt-1">
             {showReset
               ? 'Enter your email to receive a reset link.'
               : isRegistering
@@ -221,7 +221,7 @@ const Login: React.FC = () => {
           </div>
         )}
 
-        <footer className="mt-6 text-center text-sm text-gray-600 dark:text-gray-100">
+        <footer className="mt-6 text-center text-sm text-secondary">
           {showReset ? (
             <button
               type="button"

--- a/ethos-frontend/src/pages/NotFound.tsx
+++ b/ethos-frontend/src/pages/NotFound.tsx
@@ -31,13 +31,13 @@ const NotFound: React.FC = () => {
   const hasPosts = user && userPostBoard?.enrichedItems?.length;
 
   return (
-    <main className="min-h-screen bg-soft dark:bg-soft-dark px-4 py-12">
+    <main className="min-h-screen bg-soft dark:bg-soft-dark px-4 py-12 text-primary">
       <section className="text-center max-w-2xl mx-auto mb-12">
-        <h1 className="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-4">404</h1>
-        <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-200 mb-2">
+        <h1 className="text-6xl font-extrabold text-primary mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-secondary mb-2">
           You’ve wandered into the void 🌌
         </h2>
-        <p className="text-gray-500 dark:text-gray-400 mb-6">
+        <p className="text-secondary mb-6">
           The page you’re looking for doesn’t exist. No quests here, only echoes...
         </p>
         <Link to="/">
@@ -48,7 +48,7 @@ const NotFound: React.FC = () => {
       {/* 🧭 Suggested Quest Board */}
       {hasQuests && (
         <section className="mb-16">
-          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4 text-center">
+          <h3 className="text-xl font-semibold text-primary mb-4 text-center">
             Recent Quests
           </h3>
           <Board
@@ -64,7 +64,7 @@ const NotFound: React.FC = () => {
       {/* ✍️ Suggested Post Board */}
       {hasPosts && (
         <section>
-          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4 text-center">
+          <h3 className="text-xl font-semibold text-primary mb-4 text-center">
             Recent Posts
           </h3>
           <Board

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -46,13 +46,13 @@ const ProfilePage: React.FC = () => {
   const castUser = user as unknown as User;
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-6xl bg-soft dark:bg-soft-dark">
+    <main className="container mx-auto px-4 py-8 max-w-6xl bg-soft dark:bg-soft-dark text-primary">
       
       <Banner user={castUser} />
 
       {/* 📘 Your Quests */}
       <section className="mt-10 mb-12">
-        <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-4">📘 Your Quests</h2>
+        <h2 className="text-2xl font-semibold text-primary mb-4">📘 Your Quests</h2>
         {loadingQuests ? (
           <Spinner />
         ) : (
@@ -65,7 +65,7 @@ const ProfilePage: React.FC = () => {
               showCreate
             />
             {userQuestBoard?.enrichedItems?.length === 0 && (
-              <div className="text-gray-500 dark:text-gray-400 text-center py-8">
+              <div className="text-secondary text-center py-8">
                 You haven't created any quests yet.
               </div>
             )}
@@ -75,7 +75,7 @@ const ProfilePage: React.FC = () => {
 
       {/* 📝 Post History */}
       <section>
-        <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-4">📝 Your Post History</h2>
+        <h2 className="text-2xl font-semibold text-primary mb-4">📝 Your Post History</h2>
         {loadingPosts ? (
           <Spinner />
         ) : (
@@ -88,7 +88,7 @@ const ProfilePage: React.FC = () => {
               showCreate
             />
             {userPostBoard?.enrichedItems?.length === 0 && (
-              <div className="text-gray-500 dark:text-gray-400 text-center py-8">
+              <div className="text-secondary text-center py-8">
                 You haven't posted anything yet.
               </div>
             )}

--- a/ethos-frontend/src/pages/PublicProfile.tsx
+++ b/ethos-frontend/src/pages/PublicProfile.tsx
@@ -87,12 +87,12 @@ const PublicProfilePage: React.FC = () => {
   }
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-10 bg-soft dark:bg-soft-dark">
+    <main className="max-w-6xl mx-auto px-4 py-10 bg-soft dark:bg-soft-dark text-primary">
       <Banner user={profile} readOnly />
 
       {/* 📘 Public Quests */}
       <section className="mt-12">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-800 dark:text-gray-100">📘 Public Quests</h2>
+        <h2 className="text-2xl font-semibold mb-4 text-primary">📘 Public Quests</h2>
         {questBoard ? (
           questBoard.enrichedItems?.length ? (
             <Board
@@ -102,7 +102,7 @@ const PublicProfilePage: React.FC = () => {
               readOnly
             />
           ) : (
-            <div className="text-gray-500 dark:text-gray-400 text-center py-8">No public quests available.</div>
+            <div className="text-secondary text-center py-8">No public quests available.</div>
           )
         ) : (
           <Spinner />
@@ -111,7 +111,7 @@ const PublicProfilePage: React.FC = () => {
 
       {/* 🧭 Public Posts */}
       <section className="mt-12">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-800 dark:text-gray-100">🧭 Public Posts</h2>
+        <h2 className="text-2xl font-semibold mb-4 text-primary">🧭 Public Posts</h2>
         {postBoard ? (
           postBoard.enrichedItems?.length ? (
             <Board
@@ -121,7 +121,7 @@ const PublicProfilePage: React.FC = () => {
               readOnly
             />
           ) : (
-            <div className="text-gray-500 dark:text-gray-400 text-center py-8">No public posts found.</div>
+            <div className="text-secondary text-center py-8">No public posts found.</div>
           )
         ) : (
           <Spinner />
@@ -130,7 +130,7 @@ const PublicProfilePage: React.FC = () => {
 
       {/* ⭐ Review Section */}
       <section className="mt-12">
-        <h2 className="text-2xl font-semibold mb-4 text-gray-800 dark:text-gray-100">⭐ Leave a Review</h2>
+        <h2 className="text-2xl font-semibold mb-4 text-primary">⭐ Leave a Review</h2>
         <ReviewForm targetType="creator" modelId={profile.id} />
       </section>
     </main>

--- a/ethos-frontend/src/pages/ResetPassword.tsx
+++ b/ethos-frontend/src/pages/ResetPassword.tsx
@@ -101,10 +101,10 @@ const ResetPassword: React.FC = () => {
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4">
-      <section className="w-full max-w-md bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
+      <section className="w-full max-w-md bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg text-primary">
         <header className="mb-6 text-center">
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Reset Your Password</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-100 mt-1">Enter and confirm your new password.</p>
+          <h1 className="text-2xl font-bold text-primary">Reset Your Password</h1>
+          <p className="text-sm text-secondary mt-1">Enter and confirm your new password.</p>
         </header>
 
         {error && (

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -21,12 +21,12 @@ const HomePage: React.FC = () => {
   }
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-6xl space-y-12 bg-soft dark:bg-soft-dark">
+    <main className="container mx-auto px-4 py-8 max-w-6xl space-y-12 bg-soft dark:bg-soft-dark text-primary">
       <header className="mb-4">
-        <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-2">
+        <h1 className="text-4xl font-bold tracking-tight text-primary mb-2">
           Welcome to Ethos
         </h1>
-        <p className="text-lg text-gray-600 dark:text-gray-300">
+        <p className="text-lg text-secondary">
           A place to explore ideas, share quests, and collaborate.
         </p>
       </header>

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -103,9 +103,9 @@ const PostPage: React.FC = () => {
   if (!post) return <Spinner />;
 
   return (
-    <main className="container mx-auto max-w-3xl px-4 py-10 space-y-12">
+    <main className="container mx-auto max-w-3xl px-4 py-10 space-y-12 text-primary">
       {post.repostedFrom && (
-        <section className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4 text-sm text-gray-500 dark:text-gray-400">
+        <section className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4 text-sm text-secondary">
           ♻️ Reposted from @{post.repostedFrom.username}
         </section>
       )}

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -89,7 +89,7 @@ const QuestPage: React.FC = () => {
   }
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark">
+    <main className="max-w-6xl mx-auto px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark text-primary">
       {/* 🎯 Quest Summary Card */}
       <Banner quest={quest} />
       <Board
@@ -100,7 +100,7 @@ const QuestPage: React.FC = () => {
 
       {/* 🗺 Quest Map Section */}
       <section>
-        <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">🗺 Quest Map</h2>
+        <h2 className="text-xl font-semibold text-primary mb-4">🗺 Quest Map</h2>
         {mapBoard ? (
           <Board
             boardId={`map-${id}`}
@@ -112,7 +112,7 @@ const QuestPage: React.FC = () => {
             showCreate
           />
         ) : (
-          <div className="text-sm text-gray-500 dark:text-gray-400">
+          <div className="text-sm text-secondary">
             <p className="mb-2">No quest map defined yet.</p>
             {user?.id === quest.ownerId && !isMapLoading && (
               <Button variant="primary" onClick={handleCreateMapBoard}>
@@ -125,7 +125,7 @@ const QuestPage: React.FC = () => {
 
       {/* 📜 Quest Log Section */}
       <section>
-        <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">📜 Quest Log</h2>
+        <h2 className="text-xl font-semibold text-primary mb-4">📜 Quest Log</h2>
         {logBoard ? (
           <Board
             boardId={`log-${id}`}
@@ -140,7 +140,7 @@ const QuestPage: React.FC = () => {
             showCreate
           />
         ) : (
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-secondary">
             No quest logs yet. Start journaling progress.
           </p>
         )}
@@ -148,7 +148,7 @@ const QuestPage: React.FC = () => {
 
       {/* ⭐ Review Section */}
       <section>
-        <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">⭐ Leave a Review</h2>
+        <h2 className="text-xl font-semibold text-primary mb-4">⭐ Leave a Review</h2>
         <ReviewForm targetType="quest" questId={quest.id} />
       </section>
     </main>


### PR DESCRIPTION
## Summary
- ensure text colors use theme tokens
- apply `text-primary` and `text-secondary` across pages
- main layout uses token-based color

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855517d6910832f84097ddba0d03e47