### PR TITLE
Auto-create quest head post

### DIFF
--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -4,9 +4,15 @@ import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
 import { questsStore, postsStore, usersStore } from '../models/stores';
 import { enrichQuest, enrichPost } from '../utils/enrich';
+import { generateNodeId } from '../utils/nodeIdUtils';
 import { logQuest404 } from '../utils/errorTracker';
 import type { Quest, LinkedItem } from '../types/api';
-import type { DBQuest } from '../types/db';
+import type { DBQuest, DBPost } from '../types/db';
+
+const makeQuestNodeTitle = (content: string): string => {
+  const text = content.trim();
+  return text.length <= 50 ? text : text.slice(0, 50) + '…';
+};
 
 interface AuthRequest<
   P = any,
@@ -35,6 +41,7 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     description = '',
     tags = [],
     fromPostId = '',
+    headType = 'log',
   } = req.body;
 
   const authorId = req.user?.id;
@@ -54,9 +61,32 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
       : [],
     collaborators: [],
     status: 'active',
-    headPostId: fromPostId || '',
+    headPostId: '',
     taskGraph: [],
   };
+
+  const posts = postsStore.read();
+  const rootContent = `${title}${description ? `\n\n${description}` : ''}`.trim();
+  const headPost: DBPost = {
+    id: uuidv4(),
+    authorId,
+    type: headType === 'task' ? 'task' : 'log',
+    content: rootContent,
+    visibility: 'public',
+    timestamp: new Date().toISOString(),
+    tags: [],
+    collaborators: [],
+    replyTo: null,
+    repostedFrom: null,
+    linkedItems: [],
+    questId: newQuest.id,
+    nodeId: generateNodeId({ quest: newQuest, posts, postType: headType === 'task' ? 'task' : 'log', parentPost: null }),
+    questNodeTitle: makeQuestNodeTitle(rootContent),
+  };
+  posts.push(headPost);
+  postsStore.write(posts);
+
+  newQuest.headPostId = headPost.id;
 
   const quests = questsStore.read();
   const dbQuest = {

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -63,6 +63,36 @@ describe('route handlers', () => {
     expect(res.body[0].id).toBe('q1');
   });
 
+  it('POST /quests creates quest with head post', async () => {
+    const { postsStore, questsStore } = require('../src/models/stores');
+    postsStore.read.mockReturnValue([]);
+    questsStore.read.mockReturnValue([]);
+    postsStore.write.mockClear();
+    questsStore.write.mockClear();
+
+    const res = await request(app)
+      .post('/quests')
+      .send({ title: 'New Quest', description: 'desc' });
+
+    expect(res.status).toBe(201);
+    const newPost = postsStore.write.mock.calls[0][0][0];
+    const newQuest = questsStore.write.mock.calls[0][0][0];
+    expect(newQuest.headPostId).toBe(newPost.id);
+    expect(newPost.questId).toBe(newQuest.id);
+    questsStore.read.mockReturnValue([
+      {
+        id: 'q1',
+        authorId: 'u1',
+        title: 'Quest',
+        status: 'active',
+        headPostId: '',
+        linkedPosts: [],
+        collaborators: [],
+        taskGraph: [],
+      },
+    ]);
+  });
+
   it('GET /boards/:id returns single board', async () => {
     const res = await request(app).get('/boards/b1');
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- generate a head post whenever a quest is created
- generate quest node ids for the head post
- store new head post id on the quest
- test quest creation

## Testing
- `npm test --silent --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_685555747a80832f93df285f87d4171d