### PR TITLE
Fix quest map loading on login

### DIFF
--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -88,13 +88,22 @@ const Login: React.FC = () => {
         if (defaultBoard) {
           setSelectedBoard(defaultBoard.id);
           
-          await Promise.all([
+          const questMapId = defaultBoard.id.startsWith('map-')
+            ? defaultBoard.id.replace('map-', '')
+            : null;
+
+          const promises = [
             loadPermissions(defaultBoard.id),
-              fetchPostsForBoard(defaultBoard.id, user.id),
-              fetchQuestsForBoard(defaultBoard.id, user.id),
-              loadTimeline(defaultBoard.id, user.id),
-            loadGraph(defaultBoard.id),
-          ]);
+            fetchPostsForBoard(defaultBoard.id, user.id),
+            fetchQuestsForBoard(defaultBoard.id, user.id),
+            loadTimeline(defaultBoard.id, user.id),
+          ];
+
+          if (questMapId) {
+            promises.push(loadGraph(questMapId));
+          }
+
+          await Promise.all(promises);
         }
       
         navigate('/');


### PR DESCRIPTION
## Summary
- ensure login page only loads graph when board ID matches `map-${questId}`

## Testing
- `npm run lint` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555743ebdc832fb9fd9dde8403791e