### PR TITLE
Add dark mode color for commit summaries

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -209,7 +209,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       {expanded && post.type === 'commit' && (
         <div className="mt-3 text-sm">
           {post.commitSummary && (
-            <div className="mb-1 text-gray-700 italic">{post.commitSummary}</div>
+            <div className="mb-1 italic text-secondary dark:text-secondary">{post.commitSummary}</div>
           )}
           {post.gitDiff && (
             <pre className="whitespace-pre-wrap overflow-x-auto bg-gray-50 p-2 border text-xs">


### PR DESCRIPTION
## Summary
- ensure commit summaries match design-system tokens

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm run lint --prefix ethos-frontend` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_685557b708b4832f86a31063a1e24389