### PR TITLE
Switch quest map to condensed view

### DIFF
--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -96,7 +96,7 @@ const QuestPage: React.FC = () => {
           <Board
             boardId={`map-${id}`}
             board={mapBoard}
-            layout="graph"
+            layout="graph-condensed"
             editable={user?.id === quest.ownerId}
             quest={quest}
             user={user as User}


### PR DESCRIPTION
## Summary
- render quest map board using `graph-condensed` layout for a compact tree
- keep backend map board creation with `graph` layout

## Testing
- `./setup.sh` *(fails: blocked npm registry)*
- `npm test --prefix ethos-frontend` *(fails: jest not found)*
- `npm test --prefix ethos-backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555c0733f0832fa249c8c81648d62c