### PR TITLE
Update graph layout container height

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -248,7 +248,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           'overflow-auto w-full h-full p-4 max-w-7xl mx-auto ' +
           (rootNodes.length === 1 ? 'flex justify-center' : '')
         }
-        style={{ minHeight: '50vh', position: 'relative' }}
+        style={{ minHeight: '60vh', maxHeight: '80vh', position: 'relative' }}
       >
         <svg
           className="absolute top-0 left-0 w-full h-full pointer-events-none"


### PR DESCRIPTION
## Summary
- use minHeight 60vh and maxHeight 80vh for GraphLayout container

## Testing
- `npm test -- -t GraphLayout` *(fails: useNavigate requires Router)*

------
https://chatgpt.com/codex/tasks/task_e_68555c12ddb8832fa5d13ac39aa62916