### PR TITLE
Move quest map above overview

### DIFF
--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -83,11 +83,6 @@ const QuestPage: React.FC = () => {
     <main className="max-w-6xl mx-auto px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark text-primary">
       {/* 🎯 Quest Summary Card */}
       <Banner quest={quest} />
-      <Board
-        board={createMockBoard(`quest-${quest.id}`, 'Quest Overview', [quest])}
-        editable={false}
-        compact={false}
-      />
 
       {/* 🗺 Quest Map Section */}
       <section>
@@ -106,6 +101,12 @@ const QuestPage: React.FC = () => {
           <Spinner />
         )}
       </section>
+
+      <Board
+        board={createMockBoard(`quest-${quest.id}`, 'Quest Overview', [quest])}
+        editable={false}
+        compact={false}
+      />
 
       {/* 📜 Quest Log Section */}
       <section>


### PR DESCRIPTION
## Summary
- reorder quest page sections so the map follows the banner
- keep board overview section after quest map

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test Suites: 9 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68555dce6814832fae738e8ccc0f7468