### PR TITLE
Update test suites with proper providers

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -1,9 +1,11 @@
 export default {
-  preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true, diagnostics: false }],
+  },
   moduleNameMapper: {
     'react-markdown': '<rootDir>/tests/__mocks__/react-markdown.tsx',
     'remark-gfm': '<rootDir>/tests/__mocks__/remark-gfm.ts',

--- a/ethos-frontend/src/components/post/PostCard.link.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.link.test.tsx
@@ -18,6 +18,10 @@ jest.mock('../../api/quest', () => ({
   linkPostToQuest: jest.fn(() => Promise.resolve({}))
 }));
 
+jest.mock('../../contexts/BoardContext', () => ({
+  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: jest.fn() }),
+}));
+
 const loadGraphMock = jest.fn();
 jest.mock('../../hooks/useGraph', () => ({
   useGraph: () => ({ loadGraph: loadGraphMock })

--- a/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import QuestPage from '../quest/[id]';
 
 jest.mock('../../contexts/AuthContext', () => ({
@@ -51,7 +52,11 @@ jest.mock('../../api/board', () => ({
 
 describe('QuestLog permissions', () => {
   it('hides editing controls for unauthorized users', async () => {
-    render(<QuestPage />);
+    render(
+      <BrowserRouter>
+        <QuestPage />
+      </BrowserRouter>
+    );
     await waitFor(() =>
       expect(screen.getByText('📜 Quest Log')).toBeInTheDocument()
     );


### PR DESCRIPTION
## Summary
- mock BoardContext in PostCard link tests
- wrap Quest log permission tests with `BrowserRouter`
- configure jest `transform` with `ts-jest`

## Testing
- `npm test --prefix ethos-frontend` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685557b4a734832fa25db108cf0e147d