### PR TITLE
Fix test wrappers and mocks

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import ReactionControls from './ReactionControls';
 import type { Post } from '../../types/postTypes';
 
 jest.mock('../../api/post', () => ({
+  __esModule: true,
   updateReaction: jest.fn(() => Promise.resolve()),
   addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
   removeRepost: jest.fn(() => Promise.resolve()),
@@ -11,10 +13,14 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
 
 describe('ReactionControls', () => {
   const basePost: Post = {
@@ -31,24 +37,40 @@ describe('ReactionControls', () => {
   } as any;
 
   it('shows Quest Log for task posts', async () => {
-    render(<ReactionControls post={basePost} user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <ReactionControls post={basePost} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
     expect(await screen.findByText('Quest Log')).toBeInTheDocument();
   });
 
   it('shows File Change View for commit posts', async () => {
     const commitPost = { ...basePost, type: 'commit' } as Post;
-    render(<ReactionControls post={commitPost} user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <ReactionControls post={commitPost} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
     expect(await screen.findByText('File Change View')).toBeInTheDocument();
   });
 
   it('defaults to Reply for other post types', async () => {
     const fsPost = { ...basePost, type: 'free_speech' } as Post;
-    render(<ReactionControls post={fsPost} user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <ReactionControls post={fsPost} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
     expect(await screen.findByText('Reply')).toBeInTheDocument();
   });
 
   it('toggles expanded view for tasks', async () => {
-    render(<ReactionControls post={basePost} user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <ReactionControls post={basePost} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
     const expand = await screen.findByText('Expand View');
     fireEvent.click(expand);
     expect(await screen.findByText(/Quest ID/)).toBeInTheDocument();

--- a/ethos-frontend/src/components/post/PostCard.link.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.link.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
 import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId } from '../../api/post';
 import { linkPostToQuest } from '../../api/quest';
 
 jest.mock('../../api/post', () => ({
+  __esModule: true,
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   updatePost: jest.fn((id, data) => Promise.resolve({ id, ...data })),
   fetchPostsByQuestId: jest.fn(() =>
@@ -15,6 +17,7 @@ jest.mock('../../api/post', () => ({
 }));
 
 jest.mock('../../api/quest', () => ({
+  __esModule: true,
   linkPostToQuest: jest.fn(() => Promise.resolve({}))
 }));
 
@@ -23,10 +26,19 @@ jest.mock('../../hooks/useGraph', () => ({
   useGraph: () => ({ loadGraph: loadGraphMock })
 }));
 
-jest.mock('react-router-dom', () => ({
+jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useNavigate: () => jest.fn(),
+  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: jest.fn(), appendToBoard: jest.fn() })
 }));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
 
 describe('PostCard task_edge linking', () => {
   const post: Post = {
@@ -42,7 +54,11 @@ describe('PostCard task_edge linking', () => {
   } as any;
 
   it('calls linkPostToQuest and refreshes graph on save', async () => {
-    render(<PostCard post={post} questId="q1" user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <PostCard post={post} questId="q1" user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
     fireEvent.click(screen.getByLabelText('More options'));
     fireEvent.click(screen.getByText(/Edit Links/i));
 

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
 import { requestHelpForTask } from '../../api/post';
 
 jest.mock('../../api/post', () => ({
+  __esModule: true,
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   requestHelpForTask: jest.fn(() =>
     Promise.resolve({
@@ -22,13 +24,18 @@ jest.mock('../../api/post', () => ({
 
 const appendMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
   useBoardContext: () => ({ appendToBoard: appendMock }),
 }));
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
 
 describe('PostCard request help', () => {
   const post: Post = {
@@ -44,7 +51,11 @@ describe('PostCard request help', () => {
   } as any;
 
   it('calls endpoint and appends to board', async () => {
-    render(<PostCard post={post} user={{ id: 'u1' }} />);
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
 
     fireEvent.click(screen.getByText(/Request Help/i));
 

--- a/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import QuestPage from '../quest/[id]';
 
 jest.mock('../../contexts/AuthContext', () => ({
@@ -38,7 +39,8 @@ jest.mock('../../hooks/useBoard', () => ({
 }));
 
 jest.mock('../../contexts/BoardContext', () => ({
-  useBoardContext: () => ({ refreshBoards: jest.fn() })
+  __esModule: true,
+  useBoardContext: () => ({ refreshBoards: jest.fn(), boards: {} })
 }));
 
 jest.mock('../../hooks/useSocket', () => ({
@@ -51,7 +53,11 @@ jest.mock('../../api/board', () => ({
 
 describe('QuestLog permissions', () => {
   it('hides editing controls for unauthorized users', async () => {
-    render(<QuestPage />);
+    render(
+      <BrowserRouter>
+        <QuestPage />
+      </BrowserRouter>
+    );
     await waitFor(() =>
       expect(screen.getByText('📜 Quest Log')).toBeInTheDocument()
     );

--- a/ethos-frontend/tests/Board.test.js
+++ b/ethos-frontend/tests/Board.test.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const { render, screen, waitFor } = require('@testing-library/react');
+const { BrowserRouter } = require('react-router-dom');
 const Board = require('../src/components/board/Board').default;
 
 jest.mock('../src/api/board', () => ({
@@ -23,6 +24,8 @@ jest.mock('../src/contexts/BoardContext', () => ({
   useBoardContext: () => ({
     setSelectedBoard: jest.fn(),
     appendToBoard: jest.fn(),
+    updateBoardItem: jest.fn(),
+    boards: {},
   }),
 }));
 
@@ -57,7 +60,11 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
 
     fetchBoardItems.mockResolvedValue(items);
 
-    render(React.createElement(Board, { boardId: 'b1', user: { id: 'u1' }, showCreate: false }));
+    render(
+      React.createElement(BrowserRouter, null,
+        React.createElement(Board, { boardId: 'b1', user: { id: 'u1' }, showCreate: false })
+      )
+    );
 
     await waitFor(() => {
       expect(screen.queryByText('Loading board...')).not.toBeInTheDocument();
@@ -110,7 +117,9 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
       fetchBoardItems.mockResolvedValue(items);
 
       render(
-        React.createElement(Board, { boardId: 'b1', user: { id: 'u1' }, showCreate: false })
+        React.createElement(BrowserRouter, null,
+          React.createElement(Board, { boardId: 'b1', user: { id: 'u1' }, showCreate: false })
+        )
       );
 
       await waitFor(() => {

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -3,10 +3,14 @@ const { render, act, within } = require('@testing-library/react');
 
 let isOverMock = false;
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
 
 jest.mock('../src/contexts/BoardContext', () => ({
   useBoardContext: () => ({
@@ -19,6 +23,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
 let dragHandler;
 
 jest.mock('@dnd-kit/core', () => ({
+  __esModule: true,
   DndContext: ({ onDragEnd, children }) => {
     dragHandler = onDragEnd;
     return React.createElement(React.Fragment, {}, children);

--- a/ethos-frontend/tests/GraphLayoutReorg.test.js
+++ b/ethos-frontend/tests/GraphLayoutReorg.test.js
@@ -1,11 +1,22 @@
 const React = require('react');
 const { render, within } = require('@testing-library/react');
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+const { BrowserRouter } = require('react-router-dom');
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
   useGitDiff: () => ({ data: null, isLoading: false })
 }));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 describe('GraphLayout task graph reorg', () => {
   it('nests child tasks when edges define hierarchy', () => {
@@ -15,7 +26,11 @@ describe('GraphLayout task graph reorg', () => {
     ];
     const edges = [{ from: 'p1', to: 'p2' }];
 
-    const { container } = render(React.createElement(GraphLayout, { items: posts, edges, questId: 'q1' }));
+    const { container } = render(
+      React.createElement(BrowserRouter, null,
+        React.createElement(GraphLayout, { items: posts, edges, questId: 'q1' })
+      )
+    );
     const rootNodes = container.querySelectorAll(':scope > div.relative');
     expect(rootNodes.length).toBe(1);
     const root = rootNodes[0];

--- a/ethos-frontend/tests/GraphLayoutScroll.test.js
+++ b/ethos-frontend/tests/GraphLayoutScroll.test.js
@@ -1,16 +1,19 @@
 const React = require('react');
 const { render, fireEvent, act } = require('@testing-library/react');
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
   useGitDiff: () => ({ data: null, isLoading: false })
 }));
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}), { virtual: true });
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+}, { virtual: true });
 
 jest.mock('../src/components/layout/GraphNode', () => ({
   __esModule: true,
@@ -20,6 +23,8 @@ jest.mock('../src/components/layout/GraphNode', () => ({
       ref: (el) => registerNode(node.id, el),
     }),
 }), { virtual: true });
+
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 describe('GraphLayout scroll alignment', () => {
   it('recomputes connector paths when scrolling', () => {

--- a/ethos-frontend/tests/GraphLayoutSvg.test.js
+++ b/ethos-frontend/tests/GraphLayoutSvg.test.js
@@ -1,16 +1,19 @@
 const React = require('react');
 const { render } = require('@testing-library/react');
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
   useGitDiff: () => ({ data: null, isLoading: false })
 }));
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}), { virtual: true });
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+}, { virtual: true });
 
 jest.mock('../src/components/layout/GraphNode', () => ({
   __esModule: true,
@@ -20,6 +23,8 @@ jest.mock('../src/components/layout/GraphNode', () => ({
       ref: (el) => registerNode(node.id, el),
     }),
 }), { virtual: true });
+
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 describe('GraphLayout edges svg', () => {
   it('renders a svg path when an edge exists', () => {

--- a/ethos-frontend/tests/GridLayoutKanban.test.js
+++ b/ethos-frontend/tests/GridLayoutKanban.test.js
@@ -55,31 +55,6 @@ jest.mock('../src/contexts/BoardContext', () => ({
 // Capture the drag handler to simulate drag end
 let dragHandler;
 
-jest.mock('@dnd-kit/core', () => {
-  const React = require('react');
-  return {
-    DndContext: ({ onDragEnd, children }) => {
-      dragHandler = onDragEnd;
-      return React.createElement('div', {}, children);
-    },
-    useDraggable: () => ({
-      attributes: {},
-      listeners: {},
-      setNodeRef: jest.fn(),
-      transform: null,
-      isDragging: false,
-    }),
-    useDroppable: () => ({
-      setNodeRef: jest.fn(),
-      isOver: false,
-    }),
-    useSensor: jest.fn(),
-    useSensors: (...s) => s,
-    PointerSensor: jest.fn(),
-    closestCenter: jest.fn(),
-  };
-}, { virtual: true });
-
 jest.mock('@dnd-kit/utilities', () => ({ CSS: { Translate: { toString: () => '' } } }), { virtual: true });
 
 const GridLayout = require('../src/components/layout/GridLayout').default;

--- a/ethos-frontend/tests/TaskList.test.tsx
+++ b/ethos-frontend/tests/TaskList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import PostCard from '../src/components/post/PostCard';
 
 jest.mock('../src/api/post', () => ({
@@ -7,6 +8,11 @@ jest.mock('../src/api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   updatePost: jest.fn((id, data) => Promise.resolve({ id, ...data })),
   fetchPostsByQuestId: jest.fn(() => Promise.resolve([])),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('../src/api/quest', () => ({
@@ -24,10 +30,14 @@ jest.mock('../src/contexts/BoardContext', () => ({
   useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: jest.fn() }),
 }));
 
-jest.mock('react-router-dom', () => ({
-  __esModule: true,
-  useNavigate: () => jest.fn(),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
 
 jest.mock(
   'react-markdown',
@@ -79,7 +89,11 @@ describe('task list checkbox', () => {
       return <PostCard post={p} user={{ id: 'u1' }} onUpdate={setP} />;
     }
 
-    render(<Wrapper />);
+    render(
+      <BrowserRouter>
+        <Wrapper />
+      </BrowserRouter>
+    );
     const boxes = screen.getAllByRole('checkbox');
     expect(boxes[0]).not.toBeChecked();
 


### PR DESCRIPTION
## Summary
- wrap test renders with BrowserRouter when components use useNavigate
- provide BoardContext mocks for tests needing board data
- reorder module mocks so they load before imports
- extend API mocks for ReactionControls

## Testing
- `npm test --silent` *(fails: Jest worker encountered errors)*

------
https://chatgpt.com/codex/tasks/task_e_685557b4a734832fa25db108cf0e147d