### PR TITLE
Fix missing dark color for NavBar

### DIFF
--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -15,7 +15,8 @@ const NavBar: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const navClasses =
-    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-white dark:bg-card-dark border-gray-200 dark:border-gray-700';
+    // Use a valid dark mode color token instead of the removed `card-dark` variant
+    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700';
 
   return (
     <nav className={navClasses}>


### PR DESCRIPTION
## Summary
- use Tailwind gray-800 for NavBar dark mode

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest not found)*
- `npm test --prefix ethos-backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556219b6f8832fb334615c02cbd5d3