### PR TITLE
Add compact node card view

### DIFF
--- a/ethos-frontend/src/components/layout/CompactNodeCard.tsx
+++ b/ethos-frontend/src/components/layout/CompactNodeCard.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { Select } from '../ui';
+import { STATUS_OPTIONS } from '../../constants/options';
+import type { Post, QuestTaskStatus } from '../../types/postTypes';
+
+const makeHeader = (content: string): string => {
+  const text = content.trim();
+  return text.length <= 50 ? text : text.slice(0, 50) + '…';
+};
+
+interface CompactNodeCardProps {
+  post: Post;
+  onClick?: () => void;
+}
+
+const CompactNodeCard: React.FC<CompactNodeCardProps> = ({ post, onClick }) => {
+  const [status, setStatus] = useState<QuestTaskStatus>(post.status || 'To Do');
+  return (
+    <div
+      className="border border-secondary rounded bg-surface p-2 text-xs text-primary space-y-1 cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="font-semibold">{makeHeader(post.content || '')}</div>
+      {post.type === 'task' && (
+        <Select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as QuestTaskStatus)}
+          options={STATUS_OPTIONS.map(({ value, label }) => ({ value, label }))}
+          className="w-full text-xs"
+        />
+      )}
+    </div>
+  );
+};
+
+export default CompactNodeCard;

--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import ContributionCard from '../contribution/ContributionCard';
+import CompactNodeCard from './CompactNodeCard';
 import GitDiffViewer from '../git/GitDiffViewer';
 import { Spinner } from '../ui';
 import type { Post } from '../../types/postTypes';
@@ -9,15 +10,6 @@ import type { User } from '../../types/userTypes';
 import type { TaskEdge } from '../../types/questTypes';
 
 export const MAX_CHILDREN_BEFORE_CONDENSE = 5;
-
-const stringToColor = (str: string) => {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  const hue = Math.abs(hash) % 360;
-  return `hsl(${hue},70%,70%)`;
-};
 
 interface NodeChild {
   node: Post;
@@ -94,9 +86,6 @@ const GraphNode: React.FC<GraphNodeProps> = ({
 
 
   if (condensed && !expanded) {
-    const colorKey = node.tags[0] || node.type;
-    const color = stringToColor(colorKey);
-    const label = node.nodeId || node.id.slice(0, 6);
     const snippet = (node.content || '').slice(0, 30);
     return (
       <div
@@ -123,12 +112,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             }}
             title={snippet}
           >
-            <div
-              className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] text-white mr-2"
-              style={{ backgroundColor: color }}
-            >
-              {label}
-            </div>
+            <CompactNodeCard post={node} />
             {edge && (
               <span className="text-xs text-gray-500 dark:text-gray-400 ml-1 flex items-center">
                 {edge.label || edge.type}


### PR DESCRIPTION
## Summary
- show a lightweight CompactNodeCard when graph nodes are condensed
- include a short header and task status dropdown

## Testing
- `npm run lint --prefix ethos-frontend` *(fails: many existing lint errors)*
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: useNavigate errors and fetch issues)*

------
https://chatgpt.com/codex/tasks/task_e_6855680d3d28832fbe5b9e9cae6960fe