### PR TITLE
Add Git file browser for tasks

### DIFF
--- a/ethos-frontend/src/components/git/GitFileBrowser.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowser.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { useGitFileTree } from '../../hooks/useGit';
+import { createRepoFile, updateRepoFile, fetchGitDiff } from '../../api/git';
+import { addPost } from '../../api/post';
+import type { GitFile } from '../../types/gitTypes';
+import { TextArea, Input, Button } from '../ui';
+
+interface GitFileBrowserProps {
+  questId: string;
+  onClose: () => void;
+}
+
+const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => {
+  const { data: tree, isLoading } = useGitFileTree(questId);
+  const [currentPath, setCurrentPath] = useState<string>('');
+  const [editingFile, setEditingFile] = useState<GitFile | null>(null);
+  const [content, setContent] = useState('');
+  const [message, setMessage] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const files = (tree || []).filter((f) => f.path.startsWith(currentPath));
+  const items = files
+    .filter((f) => {
+      const rest = f.path.slice(currentPath.length).split('/').filter(Boolean);
+      return rest.length === 1;
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  const handleOpen = (f: GitFile) => {
+    if (f.type === 'folder') {
+      setCurrentPath(f.path.endsWith('/') ? f.path : f.path + '/');
+    } else {
+      setEditingFile(f);
+      setContent('');
+      setMessage('');
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editingFile) return;
+    setSaving(true);
+    try {
+      const existing = tree?.some((f) => f.path === editingFile.path);
+      if (existing) {
+        await updateRepoFile(questId, editingFile.path, content);
+      } else {
+        await createRepoFile(questId, editingFile.path, content);
+      }
+      const diff = await fetchGitDiff(questId, editingFile.path);
+      await addPost({
+        type: 'commit',
+        questId,
+        content: message || `Update ${editingFile.path}`,
+        commitSummary: message || `Update ${editingFile.path}`,
+        gitDiff: diff.diffMarkdown,
+        linkedNodeId: editingFile.path,
+        visibility: 'public',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      });
+      setEditingFile(null);
+    } catch (err) {
+      console.error('[GitFileBrowser] save error', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-surface p-4 rounded w-96 max-h-full overflow-auto">
+        {editingFile ? (
+          <div className="space-y-2">
+            <div className="font-semibold">{editingFile.path}</div>
+            <Input
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Commit message"
+            />
+            <TextArea rows={10} value={content} onChange={(e) => setContent(e.target.value)} />
+            <div className="flex gap-2">
+              <Button onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving...' : 'Save'}
+              </Button>
+              <Button variant="ghost" onClick={() => setEditingFile(null)}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="mb-2 flex justify-between items-center">
+              <div className="font-semibold">{currentPath || 'root'}</div>
+              {currentPath && (
+                <button
+                  className="text-accent underline text-xs"
+                  onClick={() => setCurrentPath(currentPath.replace(/[^/]+\/?$/, ''))}
+                >
+                  Back
+                </button>
+              )}
+            </div>
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : (
+              <ul className="space-y-1">
+                {items.map((f) => (
+                  <li key={f.path}>
+                    <button
+                      className="text-accent underline text-sm"
+                      onClick={() => handleOpen(f)}
+                    >
+                      {f.type === 'folder' ? '📁' : '📄'} {f.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+        <div className="mt-4 flex justify-end">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GitFileBrowser;

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -19,6 +19,7 @@ import LinkViewer from '../ui/LinkViewer';
 import LinkControls from '../controls/LinkControls';
 import EditPost from './EditPost';
 import ActionMenu from '../ui/ActionMenu';
+import GitFileBrowser from '../git/GitFileBrowser';
 
 const PREVIEW_LIMIT = 240;
 const makeHeader = (content: string): string => {
@@ -58,6 +59,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const [edgeType, setEdgeType] = useState<'sub_problem' | 'solution_branch' | 'folder_split'>('sub_problem');
   const [edgeLabel, setEdgeLabel] = useState('');
   const [questPosts, setQuestPosts] = useState<Post[]>([]);
+  const [showBrowser, setShowBrowser] = useState(false);
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();
@@ -407,6 +409,23 @@ const PostCard: React.FC<PostCardProps> = ({
         user={user}
         onUpdate={onUpdate}
       />
+
+      {post.type === 'task' && post.linkedNodeId && post.questId && (
+        <>
+          <button
+            onClick={() => setShowBrowser(true)}
+            className="text-accent underline text-xs mt-1"
+          >
+            View File/Folder
+          </button>
+          {showBrowser && (
+            <GitFileBrowser
+              questId={post.questId}
+              onClose={() => setShowBrowser(false)}
+            />
+          )}
+        </>
+      )}
 
       {post.type === 'task' && (
         <button


### PR DESCRIPTION
## Summary
- add `GitFileBrowser` component for viewing and editing repository files
- open the browser from task cards via a new *View File/Folder* button

## Testing
- `npx jest --runInBand` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6855682babb0832f8e34257b34bfae94