### PR TITLE
Fix duplicate import in PostCard

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -19,7 +19,6 @@ import MediaPreview from '../ui/MediaPreview';
 import LinkViewer from '../ui/LinkViewer';
 import LinkControls from '../controls/LinkControls';
 import EditPost from './EditPost';
-import CreatePost from './CreatePost';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
 


### PR DESCRIPTION
## Summary
- remove redundant CreatePost import in PostCard

## Testing
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685576215a64832faa25919c87865277