### PR TITLE
Add createType and asCommit states

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import { formatDistanceToNow } from 'date-fns';
 
-import type { Post } from '../../types/postTypes';
+import type { Post, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
 import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelpForTask } from '../../api/post';
@@ -61,6 +61,8 @@ const PostCard: React.FC<PostCardProps> = ({
   const [edgeLabel, setEdgeLabel] = useState('');
   const [questPosts, setQuestPosts] = useState<Post[]>([]);
   const [showBrowser, setShowBrowser] = useState(false);
+  const [createType, setCreateType] = useState<PostType | null>(null);
+  const [asCommit, setAsCommit] = useState(false);
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- add PostType to imports
- define `createType` and `asCommit` state in `PostCard`

## Testing
- `npm test` *(fails: useBoardContext must be used within a BoardProvider, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68557c84e358832fb0f03c0563eb2ecd