### PR TITLE
Fix tests by removing duplicate state and updating mock

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -63,8 +63,6 @@ const PostCard: React.FC<PostCardProps> = ({
   const [createType, setCreateType] = useState<'log' | 'issue' | null>(null);
   const [asCommit, setAsCommit] = useState(false);
   const [showBrowser, setShowBrowser] = useState(false);
-  const [createType, setCreateType] = useState<PostType | null>(null);
-  const [asCommit, setAsCommit] = useState(false);
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();

--- a/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
@@ -40,7 +40,11 @@ jest.mock('../../hooks/useBoard', () => ({
 
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ refreshBoards: jest.fn(), boards: {} })
+  useBoardContext: () => ({
+    refreshBoards: jest.fn(),
+    boards: {},
+    setSelectedBoard: jest.fn(),
+  }),
 }));
 
 jest.mock('../../hooks/useSocket', () => ({


### PR DESCRIPTION
## Summary
- remove duplicate `createType` and `asCommit` declarations in `PostCard`
- include `setSelectedBoard` in BoardContext mock for QuestLogPermissions test

## Testing
- `npm test --prefix ethos-frontend -- --runInBand` *(fails: execution exceeded time)*

------
https://chatgpt.com/codex/tasks/task_e_68557c8667b0832f8c73f075d59628c3