### PR TITLE
Implement random username generation

### DIFF
--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -16,6 +16,7 @@ import type { User } from '../types/api';
 
 import { asyncHandler } from '../utils/asyncHandler';
 import { error } from '../utils/logger';
+import { generateRandomUsername } from '../utils/usernameUtils';
 
 import type { AuthenticatedRequest } from '../types/express';
 
@@ -127,9 +128,14 @@ router.post('/register', asyncHandler(async (req: Request, res: Response) => {
       return res.status(409).json({ error: 'Email already registered' });
     }
 
+    let newUsername = username || generateRandomUsername();
+    while (users.find(u => u.username === newUsername)) {
+      newUsername = generateRandomUsername();
+    }
+
     const newUser: User = {
       id: `u_${uuidv4()}`,
-      username: username || email.split('@')[0],
+      username: newUsername,
       email,
       password: await hashPassword(password),
       role: 'user',

--- a/ethos-backend/src/utils/usernameUtils.ts
+++ b/ethos-backend/src/utils/usernameUtils.ts
@@ -1,0 +1,29 @@
+export const adjectives = [
+  'brave',
+  'curious',
+  'mighty',
+  'noble',
+  'swift',
+  'cunning',
+  'wise',
+  'eager',
+  'wild',
+];
+
+export const nouns = [
+  'lion',
+  'dragon',
+  'falcon',
+  'tiger',
+  'phoenix',
+  'wizard',
+  'ranger',
+  'druid',
+];
+
+export const generateRandomUsername = (): string => {
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const noun = nouns[Math.floor(Math.random() * nouns.length)];
+  const number = Math.floor(1000 + Math.random() * 9000); // 4-digit suffix
+  return `${adj}_${noun}_${number}`;
+};

--- a/ethos-backend/tests/usernameUtils.test.ts
+++ b/ethos-backend/tests/usernameUtils.test.ts
@@ -1,0 +1,14 @@
+import { generateRandomUsername } from '../src/utils/usernameUtils';
+
+describe('generateRandomUsername', () => {
+  it('returns a string with pattern adjective_noun_number', () => {
+    const name = generateRandomUsername();
+    expect(name).toMatch(/^[a-z]+_[a-z]+_\d{4}$/);
+  });
+
+  it('generates unique values on successive calls', () => {
+    const first = generateRandomUsername();
+    const second = generateRandomUsername();
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary
- generate random usernames using new `usernameUtils`
- ensure unique username on register
- test username generator

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_68558b4bea2c832fb6a4a5677bb09f08