### PR TITLE
Compute dark-mode palette via color complements

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,14 +6,16 @@ This guide documents the color tokens used throughout the Ethos application and 
 
 The palette is defined in `ethos-frontend/src/theme.ts` and mirrored in Tailwind and CSS variables. Each token represents a color that can be referenced in Tailwind classes or via `var(--token-name)`.
 
-| Token | Light | Dark | Description |
-| ----- | ----- | ---- | ----------- |
-| `primary` | `#111827` | `#f9fafb` | Default text color |
-| `secondary` | `#4B5563` | `#D1D5DB` | Subtle text elements |
-| `accent` | `#4F46E5` | `#818cf8` | Brand accent and buttons |
-| `soft` | `#E5E7EB` | `#1f2937` | Application background |
-| `surface` | `#ffffff` | `#374151` | Cards and panels |
-| `infoBackground` | `#bfdbfe` | `#1e40af` | Highlight color for drag/drop or info blocks |
+| Token | Light | Description |
+| ----- | ----- | ----------- |
+| `primary` | `#111827` | Default text color |
+| `secondary` | `#4B5563` | Subtle text elements |
+| `accent` | `#4F46E5` | Brand accent and buttons |
+| `soft` | `#E5E7EB` | Application background |
+| `surface` | `#ffffff` | Cards and panels |
+| `infoBackground` | `#bfdbfe` | Highlight color for drag/drop or info blocks |
+
+Dark mode colors are automatically calculated as the complementary hex values of the light palette, except for the text colors `primary` and `secondary`, which retain their original light values for readability.
 
 `soft` now has a slightly darker light mode value. Use `surface` for most card backgrounds and reserve `soft` for overall page backgrounds.
 
@@ -45,7 +47,7 @@ for buttons and card backgrounds.
 }
 ```
 
-In dark mode the variables automatically switch to their `*-Dark` counterparts.
+In dark mode the variables automatically switch to the complementary colors.
 
 ## Adding or Updating Tokens
 

--- a/ethos-frontend/src/colorUtils.ts
+++ b/ethos-frontend/src/colorUtils.ts
@@ -1,0 +1,11 @@
+export function hexComplement(color: string): string {
+  const hex = color.replace('#', '');
+  if (hex.length !== 6 || /[^0-9a-fA-F]/.test(hex)) {
+    throw new Error(`Invalid hex color: ${color}`);
+  }
+  const r = 255 - parseInt(hex.slice(0, 2), 16);
+  const g = 255 - parseInt(hex.slice(2, 4), 16);
+  const b = 255 - parseInt(hex.slice(4, 6), 16);
+  const toHex = (v: number) => v.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -13,11 +13,11 @@
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-soft: #e5e7eb;
-  --color-background: #ffffff;
+  --color-background: #f9fafb;
   --color-surface: #ffffff;
   --info-background: #bfdbfe;
   --bg-soft: var(--color-soft);
-  --bg-soft-dark: #1f2937;
+  --bg-soft-dark: #1a1814;
   --text-primary: var(--color-primary);
   --success-bg: #ecfdf5;
   --success-text: #047857;
@@ -32,14 +32,14 @@
 .dark {
   --color-primary: #f9fafb;
   --color-secondary: #d1d5db;
-  --color-accent: #818cf8;
-  --color-success: #6ee7b7;
-  --color-warning: #fde68a;
-  --color-error: #fca5a5;
-  --color-soft-dark: #1f2937;
-  --color-background: #1f2937;
-  --color-surface: #374151;
-  --info-background: #1e40af;
+  --color-accent: #b0b91a;
+  --color-success: #ef467e;
+  --color-warning: #0a61f4;
+  --color-error: #10bbbb;
+  --color-soft-dark: #1a1814;
+  --color-background: #060504;
+  --color-surface: #000000;
+  --info-background: #402401;
   --bg-soft: var(--color-soft-dark);
   --bg-soft-dark: var(--color-soft-dark);
   --text-primary: var(--color-primary);

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -1,20 +1,33 @@
+import { hexComplement } from './colorUtils';
 
 export interface Palette {
   light: string;
   dark: string;
 }
 
-export const colors: Record<string, Palette> = {
-  primary: { light: '#111827', dark: '#f9fafb' },
-  secondary: { light: '#4B5563', dark: '#D1D5DB' },
-  accent: { light: '#4F46E5', dark: '#818cf8' },
-  soft: { light: '#E5E7EB', dark: '#1f2937' },
-  success: { light: '#10B981', dark: '#6EE7B7' },
-  warning: { light: '#F59E0B', dark: '#FDE68A' },
-  error: { light: '#EF4444', dark: '#FCA5A5' },
-  background: { light: '#f9fafb', dark: '#1f2937' },
-  surface: { light: '#ffffff', dark: '#374151' },
-  infoBackground: { light: '#bfdbfe', dark: '#1e40af' },
+export const lightColors: Record<string, string> = {
+  primary: '#111827',
+  secondary: '#4B5563',
+  accent: '#4F46E5',
+  soft: '#E5E7EB',
+  success: '#10B981',
+  warning: '#F59E0B',
+  error: '#EF4444',
+  background: '#f9fafb',
+  surface: '#ffffff',
+  infoBackground: '#bfdbfe',
 };
+
+const darkOverrides: Record<string, string> = {
+  primary: '#f9fafb',
+  secondary: '#d1d5db',
+};
+
+export const colors: Record<string, Palette> = Object.fromEntries(
+  Object.entries(lightColors).map(([name, light]) => [
+    name,
+    { light, dark: darkOverrides[name] ?? hexComplement(light) },
+  ])
+) as Record<string, Palette>;
 
 export default colors;


### PR DESCRIPTION
## Summary
- add `hexComplement` utility for color math
- compute dark palette by complementing light colors except for text colors
- update CSS variables to match derived dark colors
- document complementary dark-mode scheme

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68558a1423f8832fa2f92df8e83bf0dc