### PR TITLE
Hide Board controls with no items

### DIFF
--- a/ethos-frontend/tests/Board.test.js
+++ b/ethos-frontend/tests/Board.test.js
@@ -131,4 +131,29 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
       expect(layoutSelect.value).toBe('graph');
       expect(screen.getByText('Graph')).toBeInTheDocument();
     });
+
+    it('renders no controls when there are zero items', async () => {
+      fetchBoard.mockResolvedValue({
+        id: 'b2',
+        title: 'Board',
+        layout: 'grid',
+        items: [],
+        createdAt: new Date().toISOString(),
+        enrichedItems: [],
+      });
+
+      fetchBoardItems.mockResolvedValue([]);
+
+      render(
+        React.createElement(BrowserRouter, null,
+          React.createElement(Board, { boardId: 'b2', user: { id: 'u1' }, showCreate: false })
+        )
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText('Board not found.')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByPlaceholderText('Filter...')).toBeNull();
+    });
   });


### PR DESCRIPTION
## Summary
- hide sort/filter controls when board has no items
- derive item/post/link filter types from content
- add unit test for empty board view

## Testing
- `npm --prefix ethos-frontend run lint`
- `npm --prefix ethos-frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68558d132914832fb6678b0f5e0331d9