### PR TITLE
Restore explicit color palette

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,16 +6,14 @@ This guide documents the color tokens used throughout the Ethos application and 
 
 The palette is defined in `ethos-frontend/src/theme.ts` and mirrored in Tailwind and CSS variables. Each token represents a color that can be referenced in Tailwind classes or via `var(--token-name)`.
 
-| Token | Light | Description |
-| ----- | ----- | ----------- |
-| `primary` | `#111827` | Default text color |
-| `secondary` | `#4B5563` | Subtle text elements |
-| `accent` | `#4F46E5` | Brand accent and buttons |
-| `soft` | `#E5E7EB` | Application background |
-| `surface` | `#ffffff` | Cards and panels |
-| `infoBackground` | `#bfdbfe` | Highlight color for drag/drop or info blocks |
-
-Dark mode colors are automatically calculated as the complementary hex values of the light palette, except for the text colors `primary` and `secondary`, which retain their original light values for readability.
+| Token | Light | Dark | Description |
+| ----- | ----- | ---- | ----------- |
+| `primary` | `#111827` | `#f9fafb` | Default text color |
+| `secondary` | `#4B5563` | `#D1D5DB` | Subtle text elements |
+| `accent` | `#4F46E5` | `#818cf8` | Brand accent and buttons |
+| `soft` | `#E5E7EB` | `#1f2937` | Application background |
+| `surface` | `#ffffff` | `#374151` | Cards and panels |
+| `infoBackground` | `#bfdbfe` | `#1e40af` | Highlight color for drag/drop or info blocks |
 
 `soft` now has a slightly darker light mode value. Use `surface` for most card backgrounds and reserve `soft` for overall page backgrounds.
 
@@ -47,7 +45,7 @@ for buttons and card backgrounds.
 }
 ```
 
-In dark mode the variables automatically switch to the complementary colors.
+In dark mode the variables automatically switch to their `*-Dark` counterparts.
 
 ## Adding or Updating Tokens
 

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -17,7 +17,7 @@
   --color-surface: #ffffff;
   --info-background: #bfdbfe;
   --bg-soft: var(--color-soft);
-  --bg-soft-dark: #1a1814;
+  --bg-soft-dark: #1f2937;
   --text-primary: var(--color-primary);
   --success-bg: #ecfdf5;
   --success-text: #047857;
@@ -32,14 +32,14 @@
 .dark {
   --color-primary: #f9fafb;
   --color-secondary: #d1d5db;
-  --color-accent: #b0b91a;
-  --color-success: #ef467e;
-  --color-warning: #0a61f4;
-  --color-error: #10bbbb;
-  --color-soft-dark: #1a1814;
-  --color-background: #060504;
-  --color-surface: #000000;
-  --info-background: #402401;
+  --color-accent: #818cf8;
+  --color-success: #6ee7b7;
+  --color-warning: #fde68a;
+  --color-error: #fca5a5;
+  --color-soft-dark: #1f2937;
+  --color-background: #1f2937;
+  --color-surface: #374151;
+  --info-background: #1e40af;
   --bg-soft: var(--color-soft-dark);
   --bg-soft-dark: var(--color-soft-dark);
   --text-primary: var(--color-primary);

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -1,33 +1,19 @@
-import { hexComplement } from './colorUtils';
-
 export interface Palette {
   light: string;
   dark: string;
 }
 
-export const lightColors: Record<string, string> = {
-  primary: '#111827',
-  secondary: '#4B5563',
-  accent: '#4F46E5',
-  soft: '#E5E7EB',
-  success: '#10B981',
-  warning: '#F59E0B',
-  error: '#EF4444',
-  background: '#f9fafb',
-  surface: '#ffffff',
-  infoBackground: '#bfdbfe',
+export const colors: Record<string, Palette> = {
+  primary: { light: '#111827', dark: '#f9fafb' },
+  secondary: { light: '#4B5563', dark: '#d1d5db' },
+  accent: { light: '#4F46E5', dark: '#818cf8' },
+  soft: { light: '#E5E7EB', dark: '#1f2937' },
+  success: { light: '#10B981', dark: '#6ee7b7' },
+  warning: { light: '#F59E0B', dark: '#fde68a' },
+  error: { light: '#EF4444', dark: '#fca5a5' },
+  background: { light: '#f9fafb', dark: '#1f2937' },
+  surface: { light: '#ffffff', dark: '#374151' },
+  infoBackground: { light: '#bfdbfe', dark: '#1e40af' },
 };
-
-const darkOverrides: Record<string, string> = {
-  primary: '#f9fafb',
-  secondary: '#d1d5db',
-};
-
-export const colors: Record<string, Palette> = Object.fromEntries(
-  Object.entries(lightColors).map(([name, light]) => [
-    name,
-    { light, dark: darkOverrides[name] ?? hexComplement(light) },
-  ])
-) as Record<string, Palette>;
 
 export default colors;


### PR DESCRIPTION
## Summary
- revert theme back to explicit light/dark hex values
- sync `index.css` variables with the palette
- document the full color table again
- keep `hexComplement` utility but remove palette usage
- ensure Tailwind config still references CSS variables

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855918cbbb4832f9b6d405e9f1daad8