### PR TITLE
Fix dark mode navbar color

### DIFF
--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -15,8 +15,8 @@ const NavBar: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const navClasses =
-    // Use a valid dark mode color token instead of the removed `card-dark` variant
-    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700';
+    // Use the surface color in dark mode so the navbar contrasts the page background
+    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-white dark:bg-surface border-gray-200 dark:border-gray-700';
 
   return (
     <nav className={navClasses}>


### PR DESCRIPTION
## Summary
- dark mode navbar now uses `bg-surface` so it contrasts the page background

## Testing
- `npm test --prefix ethos-backend` *(fails: jest not found)*
- `npm test --prefix ethos-frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685594efb380832f8e9d3151c60a2547