### PR TITLE
Fix Add Item and nav bar colors

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -353,7 +353,7 @@ const Board: React.FC<BoardProps> = ({
             </Button>
           )}
           {showCreate && user && (
-            <Button variant="primary" onClick={() => setShowCreateForm(true)}>
+            <Button variant="contrast" onClick={() => setShowCreateForm(true)}>
               + Add Item
             </Button>
           )}

--- a/ethos-frontend/src/components/board/CreateBoard.tsx
+++ b/ethos-frontend/src/components/board/CreateBoard.tsx
@@ -107,7 +107,7 @@ const CreateBoard: React.FC<{
             placeholder={`Item ${index + 1}`}
           />
         ))}
-        <Button type="button" variant="secondary" onClick={handleAddItem}>
+        <Button type="button" variant="contrast" onClick={handleAddItem}>
           + Add Item
         </Button>
       </FormSection>

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -232,7 +232,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
         <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" variant="primary" disabled={isSubmitting}>
+        <Button type="submit" variant="contrast" disabled={isSubmitting}>
           {isSubmitting ? 'Posting...' : 'Create Post'}
         </Button>
       </div>

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -200,7 +200,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             <div className="text-right mt-2">
               <Button
                 size="sm"
-                variant="secondary"
+                variant="contrast"
                 onClick={() => setShowLogForm(true)}
               >
                 + Add Item
@@ -234,7 +234,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             <div className="text-right mt-2">
               <Button
                 size="sm"
-                variant="secondary"
+                variant="contrast"
                 onClick={() => setShowTaskForm(true)}
               >
                 + Add Item
@@ -262,7 +262,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             <div className="text-right mb-2">
               <Button
                 size="sm"
-                variant="secondary"
+                variant="contrast"
                 onClick={() => setShowTaskForm(true)}
               >
                 + Add Item

--- a/ethos-frontend/src/components/ui/Button.tsx
+++ b/ethos-frontend/src/components/ui/Button.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import clsx from 'clsx';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'disabled';
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'ghost'
+  | 'danger'
+  | 'disabled'
+  | 'contrast';
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'; // optional: 'md' is default
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -27,6 +33,8 @@ const Button: React.FC<ButtonProps> = ({
       'bg-accent text-white hover:bg-accent focus:ring-2 focus:ring-accent',
     secondary:
       'bg-soft text-primary hover:bg-surface focus:ring-2 focus:ring-secondary',
+    contrast:
+      'bg-primary text-surface dark:text-background hover:bg-primary focus:ring-2 focus:ring-primary',
     ghost:
       'bg-transparent text-secondary hover:bg-soft focus:ring-2 focus:ring-background',
     danger:

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -15,8 +15,7 @@ const NavBar: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const navClasses =
-    // Use a valid dark mode color token instead of the removed `card-dark` variant
-    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700';
+    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-surface dark:bg-soft-dark border-gray-200 dark:border-gray-700';
 
   return (
     <nav className={navClasses}>

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -144,6 +144,16 @@ a:hover {
   color: var(--text-primary);
 }
 
+.btn-contrast {
+  background-color: var(--color-primary);
+  color: var(--color-surface);
+}
+
+.dark .btn-contrast {
+  background-color: var(--color-primary);
+  color: var(--color-background);
+}
+
 .dark .btn-secondary {
   background-color: var(--color-surface);
 }


### PR DESCRIPTION
## Summary
- introduce new `contrast` button variant for light/dark theme contrast
- use the new variant for all **Add Item** and **Create Post** actions
- set nav bar background via theme tokens so it adapts to dark mode

## Testing
- `npm test` *(fails: Jest environment error)*

------
https://chatgpt.com/codex/tasks/task_e_68559463c58c832fabf4176337c9f10a