### PR TITLE
Add boardType support across app

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -88,6 +88,7 @@ router.get(
     const board: BoardData = {
       id: `thread-${postId}`,
       title: 'Thread',
+      boardType: 'post',
       items: replies.map(r => r.id),
       layout: 'grid',
       createdAt: new Date().toISOString(),
@@ -289,6 +290,7 @@ router.post(
       featured = false,
       defaultFor = null,
       layout = "grid",
+      boardType = 'post',
       questId,
     } = req.body;
 
@@ -297,6 +299,7 @@ router.post(
       id: customId || uuidv4(),
       title,
       description,
+      boardType,
       items,
       filters,
       featured,
@@ -329,6 +332,7 @@ router.patch(
         id: req.params.id,
         title: req.body.title || 'Untitled Board',
         description: req.body.description || '',
+        boardType: req.body.boardType || 'post',
         layout: req.body.layout || 'grid',
         items: req.body.items ?? [],
         filters: req.body.filters ?? {},

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -109,6 +109,7 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     id: `map-${newQuest.id}`,
     title: `${newQuest.title} Map`,
     description: '',
+    boardType: 'map',
     layout: 'graph',
     items: newQuest.headPostId ? [newQuest.headPostId] : [],
     filters: {},

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -184,6 +184,7 @@ export interface Board {
   id: string;
   title: string;
   description?: string;
+  boardType: BoardType;
   layout: BoardLayout;
   items: (string | null)[];
   filters?: Record<string, any>;

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -87,6 +87,7 @@ export interface DBBoard {
   id: string;
   title: string;
   description?: string;
+  boardType: BoardType;
   layout: BoardLayout;
   items: (string | null)[];
   filters?: Record<string, any>;

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -14,8 +14,8 @@ jest.mock('../src/middleware/authMiddleware', () => ({
 jest.mock('../src/models/stores', () => ({
   boardsStore: {
     read: jest.fn(() => [
-      { id: 'b1', title: 'Board', description: '', layout: 'grid', items: [] },
-      { id: 'home', title: 'Home', description: '', layout: 'grid', items: [], defaultFor: 'home' },
+      { id: 'b1', title: 'Board', boardType: 'post', description: '', layout: 'grid', items: [] },
+      { id: 'home', title: 'Home', boardType: 'post', description: '', layout: 'grid', items: [], defaultFor: 'home' },
     ]),
     write: jest.fn(),
   },
@@ -283,7 +283,7 @@ describe('route handlers', () => {
   it('GET /boards/:id/quests returns quests from board', async () => {
     const { boardsStore, questsStore } = require('../src/models/stores');
     boardsStore.read.mockReturnValue([
-      { id: 'b1', title: 'Board', description: '', layout: 'grid', items: ['q1'] },
+      { id: 'b1', title: 'Board', boardType: 'post', description: '', layout: 'grid', items: ['q1'] },
     ]);
     questsStore.read.mockReturnValue([
       {
@@ -306,7 +306,7 @@ describe('route handlers', () => {
   it('GET /boards/:id/quests?enrich=true returns enriched quests', async () => {
     const { boardsStore, questsStore, usersStore } = require('../src/models/stores');
     boardsStore.read.mockReturnValue([
-      { id: 'b1', title: 'Board', description: '', layout: 'grid', items: ['q1'] },
+      { id: 'b1', title: 'Board', boardType: 'post', description: '', layout: 'grid', items: ['q1'] },
     ]);
     questsStore.read.mockReturnValue([
       {
@@ -348,7 +348,7 @@ describe('route handlers', () => {
     boardLogsStore.write.mockClear();
     await request(app)
       .post('/boards')
-      .send({ title: 'Board', items: [], layout: 'grid' });
+      .send({ title: 'Board', items: [], layout: 'grid', boardType: 'post' });
     expect(boardLogsStore.write).toHaveBeenCalled();
     const log = boardLogsStore.write.mock.calls[0][0][0];
     expect(log.action).toBe('create');
@@ -356,7 +356,7 @@ describe('route handlers', () => {
 
   it('PATCH /boards/:id logs update', async () => {
     const { boardsStore, boardLogsStore } = require('../src/models/stores');
-    boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', layout: 'grid', items: [] }]);
+    boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', boardType: 'post', layout: 'grid', items: [] }]);
     boardLogsStore.read.mockReturnValue([]);
     boardLogsStore.write.mockClear();
     await request(app).patch('/boards/b1').send({ title: 'New' });
@@ -367,7 +367,7 @@ describe('route handlers', () => {
 
   it('DELETE /boards/:id logs deletion', async () => {
     const { boardsStore, boardLogsStore } = require('../src/models/stores');
-    boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', layout: 'grid', items: [] }]);
+    boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', boardType: 'post', layout: 'grid', items: [] }]);
     boardLogsStore.read.mockReturnValue([]);
     boardLogsStore.write.mockClear();
     await request(app).delete('/boards/b1');

--- a/ethos-frontend/src/components/board/CreateBoard.tsx
+++ b/ethos-frontend/src/components/board/CreateBoard.tsx
@@ -7,8 +7,12 @@ import {
   Label,
   TextArea,
 } from '../ui';
-import { STRUCTURE_OPTIONS, VISIBILITY_OPTIONS } from '../../constants/options';
-import type { BoardLayout } from '../../types/boardTypes';
+import {
+  STRUCTURE_OPTIONS,
+  VISIBILITY_OPTIONS,
+  BOARD_TYPE_OPTIONS,
+} from '../../constants/options';
+import type { BoardLayout, BoardType } from '../../types/boardTypes';
 import { addBoard } from '../../api/board'; 
 
 const CreateBoard: React.FC<{
@@ -18,6 +22,7 @@ const CreateBoard: React.FC<{
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [layout, setStructure] = useState<BoardLayout>('grid');
+  const [boardType, setBoardType] = useState<BoardType>('post');
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
   const [category, setCategory] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -41,6 +46,7 @@ const CreateBoard: React.FC<{
     const boardData = {
       title: title.trim(),
       description: description.trim(),
+      boardType,
       layout,
       items: items.map(item => item.id),
       filters: { visibility },
@@ -80,6 +86,13 @@ const CreateBoard: React.FC<{
           value={layout}
           onChange={e => setStructure(e.target.value as BoardLayout)}
           options={STRUCTURE_OPTIONS.slice()}
+        />
+
+        <Label>Board Type</Label>
+        <Select
+          value={boardType}
+          onChange={e => setBoardType(e.target.value as BoardType)}
+          options={BOARD_TYPE_OPTIONS.slice()}
         />
 
         <Label>Visibility</Label>

--- a/ethos-frontend/src/components/board/EditBoard.tsx
+++ b/ethos-frontend/src/components/board/EditBoard.tsx
@@ -1,15 +1,24 @@
 import React, { useState } from 'react';
 import { Input, Select, TextArea, Button, Label, FormSection } from '../ui';
-import { STRUCTURE_OPTIONS, VISIBILITY_OPTIONS } from '../../constants/options';
+import {
+  STRUCTURE_OPTIONS,
+  VISIBILITY_OPTIONS,
+  BOARD_TYPE_OPTIONS,
+} from '../../constants/options';
 import { updateBoard, removeBoard } from '../../api/board';
-import type { BoardData, EditBoardProps } from '../../types/boardTypes';
-import type { BoardLayout } from '../../types/boardTypes';
+import type {
+  BoardData,
+  EditBoardProps,
+  BoardLayout,
+  BoardType,
+} from '../../types/boardTypes';
 import { getDisplayTitle } from '../../utils/displayUtils'; 
 
 const EditBoard: React.FC<EditBoardProps> = ({ board, onSave, onCancel, onDelete }) => {
   const [title, setTitle] = useState(board.title || '');
   const [description, setDescription] = useState(board.description || '');
   const [layout, setStructure] = useState(board.layout || 'grid');
+  const [boardType, setBoardType] = useState<BoardType>(board.boardType || 'post');
   const [visibility, setVisibility] = useState(board.filters?.visibility || 'public');
   const [category, setCategory] = useState(board.category || '');
   const [items, setItems] = useState<(string | null)[]>(board.items || []);
@@ -32,6 +41,7 @@ const EditBoard: React.FC<EditBoardProps> = ({ board, onSave, onCancel, onDelete
     const payload: Partial<BoardData> = {
       title: title.trim(),
       description: description.trim(),
+      boardType,
       layout,
       items,
       filters: { visibility },
@@ -80,6 +90,14 @@ const EditBoard: React.FC<EditBoardProps> = ({ board, onSave, onCancel, onDelete
           value={layout}
           onChange={(e) => setStructure(e.target.value as BoardLayout)}
           options={STRUCTURE_OPTIONS.slice()}
+        />
+
+        <Label htmlFor="board-type">Board Type</Label>
+        <Select
+          id="board-type"
+          value={boardType}
+          onChange={(e) => setBoardType(e.target.value as BoardType)}
+          options={BOARD_TYPE_OPTIONS.slice()}
         />
 
         <Label htmlFor="visibility">Visibility</Label>

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -6,6 +6,7 @@ import CollaberatorControls from '../controls/CollaberatorControls';
 import LinkControls from '../controls/LinkControls';
 import CreateQuest from '../quest/CreateQuest';
 import { useBoardContext } from '../../contexts/BoardContext';
+import type { BoardType } from '../../types/boardTypes';
 import { updateBoard } from '../../api/board';
 import type { Post, PostType, LinkedItem, CollaberatorRoles } from '../../types/postTypes';
 
@@ -48,7 +49,17 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
+const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
+
+  const boardType: BoardType | undefined =
+    boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
+
+  const allowedPostTypes: PostType[] =
+    boardType === 'quest'
+      ? ['quest', 'task', 'log']
+      : boardType === 'post'
+      ? ['free_speech', 'request', 'commit', 'issue']
+      : POST_TYPES.map(p => p.value as PostType);
 
   const renderQuestForm = type === 'quest';
 
@@ -142,7 +153,10 @@ const CreatePost: React.FC<CreatePostProps> = ({
               setType(val);
               if (val === 'task') setStatus('To Do');
             }}
-            options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
+            options={allowedPostTypes.map((t) => {
+              const opt = POST_TYPES.find((o) => o.value === t)!;
+              return { value: opt.value, label: opt.label };
+            })}
           />
         </FormSection>
         <CreateQuest onSave={(q) => onSave?.(q as any)} onCancel={onCancel} />
@@ -162,7 +176,10 @@ const CreatePost: React.FC<CreatePostProps> = ({
             setType(val);
             if (val === 'task') setStatus('To Do');
           }}
-          options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
+          options={allowedPostTypes.map((t) => {
+            const opt = POST_TYPES.find((o) => o.value === t)!;
+            return { value: opt.value, label: opt.label };
+          })}
         />
 
         {type === 'task' && (

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -1,5 +1,5 @@
 // options.ts
-import type { BoardLayout } from '../types/boardTypes';
+import type { BoardLayout, BoardType } from '../types/boardTypes';
 import type { PostType } from '../types/postTypes';
 
 export const STRUCTURE_OPTIONS: { value: BoardLayout; label: string }[] = [
@@ -15,6 +15,14 @@ export const VISIBILITY_OPTIONS = [
   { value: 'public', label: 'Public' },
   { value: 'private', label: 'Private' },
 ] as const;
+
+export const BOARD_TYPE_OPTIONS: { value: BoardType; label: string }[] = [
+  { value: 'post', label: 'Post' },
+  { value: 'quest', label: 'Quest' },
+  { value: 'map', label: 'Map' },
+  { value: 'log', label: 'Log' },
+  { value: 'custom', label: 'Custom' },
+];
 
 export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },

--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -187,6 +187,7 @@ export const useBoardContextEnhanced = () => {
     id: raw.id,
     title: raw.name || 'Untitled',
     createdAt: raw.createdAt || new Date().toISOString(),
+    boardType: raw.boardType || 'post',
     layout: raw.layout as BoardData['layout'],
     items: (raw.enrichedItems || []).map((item: any) => item?.id ?? null),
   });

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -3,11 +3,14 @@ import type { Post } from './postTypes';
 import type { Quest } from './questTypes';
 import type { Visibility, ItemType } from './common';
 
+export type BoardType = 'post' | 'quest' | 'map' | 'log' | 'custom';
+
 /** Generic board interface shared across profile, quests, etc. */
 export interface Board {
   id: string;
   title: string;
   description?: string;
+  boardType: BoardType;
   layout: BoardLayout;
   items: (string | null)[];
   filters?: Record<string, any>;
@@ -31,6 +34,7 @@ export interface CreateBoardPayload {
   id?: string;
   title: string;
   description?: string;
+  boardType: BoardType;
   layout: BoardLayout;
   items: string[];
   filters?: Record<string, any>;

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -15,7 +15,8 @@ import type { Quest } from '../types/questTypes';
 export const createMockBoard = (
   id: string,
   title: string,
-  items: Array<string | Post | Quest | null>
+  items: Array<string | Post | Quest | null>,
+  boardType: BoardData['boardType'] = 'post'
 ): BoardData => {
   const itemIds = items.map((item) => {
     if (item && typeof item === 'object') {
@@ -27,6 +28,7 @@ export const createMockBoard = (
   return {
     id,
     title,
+    boardType,
     layout: 'grid',
     items: itemIds,
     enrichedItems: items,

--- a/ethos-frontend/tests/Board.test.js
+++ b/ethos-frontend/tests/Board.test.js
@@ -36,6 +36,7 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
     fetchBoard.mockResolvedValue({
       id: 'b1',
       title: 'Board',
+      boardType: 'post',
       layout: 'graph',
       items: [],
       createdAt: new Date().toISOString(),
@@ -80,6 +81,7 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
       fetchBoard.mockResolvedValue({
         id: 'b1',
         title: 'Board',
+        boardType: 'quest',
         layout: 'graph',
         questId: 'q1',
         items: [],
@@ -136,6 +138,7 @@ const { fetchBoard, fetchBoardItems } = require('../src/api/board');
       fetchBoard.mockResolvedValue({
         id: 'b2',
         title: 'Board',
+        boardType: 'post',
         layout: 'grid',
         items: [],
         createdAt: new Date().toISOString(),

--- a/ethos-frontend/tests/CreatePostBoardType.test.tsx
+++ b/ethos-frontend/tests/CreatePostBoardType.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    boards: {
+      b1: { id: 'b1', title: 'Board', boardType: 'quest', layout: 'grid', items: [], createdAt: '' },
+    },
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+const CreatePost = require('../src/components/post/CreatePost').default;
+
+describe('CreatePost board type filtering', () => {
+  it('limits post type options for quest board', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} />
+      </BrowserRouter>
+    );
+    const select = screen.getByLabelText('Item Type');
+    const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Quest', 'Quest Task', 'Quest Log']);
+  });
+});

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -16,6 +16,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
     selectedBoard: 'b1',
     updateBoardItem: jest.fn(),
     appendToBoard: jest.fn(),
+    boards: { b1: { boardType: 'post' } },
   })
 }));
 

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -17,6 +17,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
     selectedBoard: 'b1',
     updateBoardItem: jest.fn(),
     removeItemFromBoard: jest.fn(),
+    boards: { b1: { boardType: 'post' } },
   }),
 }));
 

--- a/ethos-frontend/tests/GraphLayoutScroll.test.js
+++ b/ethos-frontend/tests/GraphLayoutScroll.test.js
@@ -24,6 +24,15 @@ jest.mock('../src/components/layout/GraphNode', () => ({
     }),
 }), { virtual: true });
 
+jest.mock('../src/contexts/BoardContext', () => ({
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    appendToBoard: jest.fn(),
+    updateBoardItem: jest.fn(),
+    boards: { b1: { boardType: 'post' } },
+  }),
+}));
+
 const GraphLayout = require('../src/components/layout/GraphLayout').default;
 
 describe('GraphLayout scroll alignment', () => {

--- a/ethos-frontend/tests/GridLayoutKanban.test.js
+++ b/ethos-frontend/tests/GridLayoutKanban.test.js
@@ -48,7 +48,8 @@ jest.mock('../src/contexts/BoardContext', () => ({
   useBoardContext: () => ({
     selectedBoard: 'b1',
     updateBoardItem: global.updateBoardItemMock,
-    removeItemFromBoard: global.removeItemFromBoardMock
+    removeItemFromBoard: global.removeItemFromBoardMock,
+    boards: { b1: { boardType: 'post' } }
   })
 }));
 

--- a/ethos-frontend/tests/TaskList.test.tsx
+++ b/ethos-frontend/tests/TaskList.test.tsx
@@ -27,7 +27,11 @@ jest.mock('../src/hooks/useGraph', () => ({
 
 jest.mock('../src/contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: jest.fn() }),
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    updateBoardItem: jest.fn(),
+    boards: { b1: { boardType: 'post' } },
+  }),
 }));
 
 jest.mock('react-router-dom', () => {


### PR DESCRIPTION
## Summary
- extend `Board` and related types with `boardType`
- persist `boardType` in backend routes
- update board forms to edit/select board type
- filter CreatePost options based on board type
- expose boardType through BoardContext
- adjust tests for new boardType logic

## Testing
- `npm test` within `ethos-backend`
- `npm test` within `ethos-frontend` *(fails: Jest could not run some suites)*

------
https://chatgpt.com/codex/tasks/task_e_68559881fe78832f86383903026f3c73