### PR TITLE
Fix username color on profile

### DIFF
--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -33,7 +33,7 @@ const Banner: React.FC<BannerProps> = ({ user, quest }) => {
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-surface dark:bg-background p-4 sm:p-6 rounded-lg shadow mb-6">
       {/* Left: Name + Description */}
       <div className="flex flex-col gap-1 text-left max-w-2xl">
-        <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
+        <h1 className="text-2xl font-bold text-primary">
           {user ? displayName : `📜 ${displayName}`}
         </h1>
         <p className="text-sm text-gray-600 dark:text-gray-300">{description}</p>


### PR DESCRIPTION
## Summary
- update banner username color to use theme-aware `text-primary`

## Testing
- `npm test` (fails: "jest-environment-jsdom" not found)
- `npm install` and `npm test` in `ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_68559ae62090832f80fabc174a473d30