### PR TITLE
Fix profile banner text color

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -264,7 +264,7 @@ const Board: React.FC<BoardProps> = ({
     <div className={`space-y-4 p-6 rounded-xl shadow-lg max-w-5xl mx-auto ${containerBg}`}>
       {/* Board Header */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
-        <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100">
+        <h2 className="text-xl font-semibold text-primary dark:text-primary">
           {forcedTitle || board.title || 'Board'}
         </h2>
 

--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -33,7 +33,7 @@ const Banner: React.FC<BannerProps> = ({ user, quest }) => {
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-surface dark:bg-background p-4 sm:p-6 rounded-lg shadow mb-6">
       {/* Left: Name + Description */}
       <div className="flex flex-col gap-1 text-left max-w-2xl">
-        <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
+        <h1 className="text-2xl font-bold text-primary dark:text-primary">
           {user ? displayName : `📜 ${displayName}`}
         </h1>
         <p className="text-sm text-gray-600 dark:text-gray-300">{description}</p>

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -114,7 +114,7 @@ const BoardPage: React.FC = () => {
     <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
       <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
         <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold">{boardData.title}</h1>
+          <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
           {editable && (
             <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
               Edit Board


### PR DESCRIPTION
## Summary
- ensure banner username color uses theme token so it's light in dark mode
- update board titles to use theme color tokens

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559ae62090832f80fabc174a473d30