### PR TITLE
Update quest board post types

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -56,10 +56,10 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
   const allowedPostTypes: PostType[] =
     boardType === 'quest'
-      ? ['quest', 'task', 'log']
+      ? ['quest']
       : boardType === 'post'
       ? ['free_speech', 'request', 'commit', 'issue']
-      : POST_TYPES.map(p => p.value as PostType);
+      : POST_TYPES.map((p) => p.value as PostType);
 
   const renderQuestForm = type === 'quest';
 

--- a/ethos-frontend/tests/CreatePostBoardType.test.tsx
+++ b/ethos-frontend/tests/CreatePostBoardType.test.tsx
@@ -34,6 +34,6 @@ describe('CreatePost board type filtering', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Quest', 'Quest Task', 'Quest Log']);
+    expect(options).toEqual(['Quest']);
   });
 });


### PR DESCRIPTION
## Summary
- restrict allowed post types to just `quest` when board type is `quest`
- update tests for new post type restrictions

## Testing
- `npm test` *(fails: Test Suites: 9 failed, 7 passed, 16 total)*

------
https://chatgpt.com/codex/tasks/task_e_6855a454af84832fb255d6788d39b439