### PR TITLE
Add drag anchors and subtree movement

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -54,6 +54,16 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   const icon = isFolder ? '📁' : '📄';
 
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: node.id });
+  const {
+    attributes: anchorAttributes,
+    listeners: anchorListeners,
+    setNodeRef: setAnchorRef,
+  } = useDraggable({ id: `anchor-${node.id}` });
+  const {
+    attributes: subtreeAttributes,
+    listeners: subtreeListeners,
+    setNodeRef: setSubtreeRef,
+  } = useDraggable({ id: `move-${node.id}` });
   const { setNodeRef: setDropRef, isOver } = useDroppable({ id: node.id });
   const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
 
@@ -230,6 +240,24 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             {icon}
           </span>
           <ContributionCard contribution={node} user={user} compact={compact} />
+          <span
+            data-testid={`move-${node.id}`}
+            ref={setSubtreeRef}
+            {...subtreeAttributes}
+            {...subtreeListeners}
+            className="cursor-move text-xs ml-1"
+            title="Move subtree"
+          >
+            ↕
+          </span>
+          <span
+            data-testid={`anchor-${node.id}`}
+            ref={setAnchorRef}
+            {...anchorAttributes}
+            {...anchorListeners}
+            className="ml-1 w-3 h-3 bg-blue-400 rounded-full inline-block cursor-grab"
+            title="Create child"
+          />
           {expanded && !editing && (
             <button
               className="text-xs underline ml-1"

--- a/ethos-frontend/tests/GraphNodeAnchor.test.js
+++ b/ethos-frontend/tests/GraphNodeAnchor.test.js
@@ -1,0 +1,74 @@
+const React = require('react');
+const { render, act, within } = require('@testing-library/react');
+
+let dragHandler;
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+jest.mock('@dnd-kit/core', () => ({
+  __esModule: true,
+  DndContext: ({ onDragEnd, children }) => {
+    dragHandler = onDragEnd;
+    return React.createElement(React.Fragment, {}, children);
+  },
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({ setNodeRef: jest.fn(), isOver: false }),
+  useSensor: jest.fn(),
+  useSensors: (...s) => s,
+  PointerSensor: jest.fn(),
+  closestCenter: jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/hooks/useGit', () => ({
+  useGitDiff: () => ({ data: null, isLoading: false })
+}));
+
+const GraphLayout = require('../src/components/layout/GraphLayout').default;
+
+describe('GraphLayout anchor interaction', () => {
+  it('creates a new child when dragging from anchor', async () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'Parent', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    await act(async () => {
+      await dragHandler({ active: { id: 'anchor-p1' }, over: null });
+    });
+
+    const root = container.querySelector('div.relative');
+    expect(within(root).getByText('Parent')).toBeInTheDocument();
+    expect(within(root).getByText('New Task')).toBeInTheDocument();
+  });
+
+  it('moves subtree when using move handle', async () => {
+    const posts = [
+      { id: 'p1', type: 'task', content: 'A', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] },
+      { id: 'p2', type: 'task', content: 'B', authorId: 'u1', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+    ];
+
+    const { container } = render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
+
+    await act(async () => {
+      await dragHandler({ active: { id: 'move-p2' }, over: { id: 'p1' } });
+    });
+
+    const root = container.firstElementChild.querySelector('div.relative');
+    expect(within(root).getByText('A')).toBeInTheDocument();
+    expect(within(root).getByText('B')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add draggable anchors to GraphNode for creating children
- allow dragging node subtree via a new handle
- extend GraphLayout state for dynamic nodes
- handle anchor and subtree drag logic
- test anchor-based child creation and subtree move

## Testing
- `npm test --silent --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a459d068832f9407b5e206b262c9