### PR TITLE
Update quest post type options based on view

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -240,6 +240,16 @@ const Board: React.FC<BoardProps> = ({
     return board?.id ? canEditBoard(board.id) : false;
   }, [readOnly, forcedEditable, board?.id, canEditBoard]);
 
+  const activeView = useMemo<'map' | 'log' | 'file-change'>(() => {
+    if (['map-graph', 'graph', 'graph-condensed'].includes(resolvedStructure)) {
+      return 'map';
+    }
+    const hasCommit = renderableItems.some(
+      (it) => 'type' in it && (it as Post).type === 'commit'
+    );
+    return hasCommit ? 'file-change' : 'log';
+  }, [resolvedStructure, renderableItems]);
+
   const Layout = {
     grid: GridLayout,
     horizontal: GridLayout,
@@ -372,6 +382,7 @@ const Board: React.FC<BoardProps> = ({
             onSave={handleAdd}
             onCancel={() => setShowCreateForm(false)}
             boardId={board.id}
+            currentView={activeView}
           />
         </div>
       )}

--- a/ethos-frontend/tests/CreatePostView.test.tsx
+++ b/ethos-frontend/tests/CreatePostView.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    boards: {
+      b1: { id: 'b1', title: 'Board', boardType: 'quest', layout: 'grid', items: [], createdAt: '' },
+    },
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+const CreatePost = require('../src/components/post/CreatePost').default;
+
+describe('CreatePost view filtering', () => {
+  const getOptions = () => {
+    const select = screen.getByLabelText('Item Type');
+    return Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+  };
+
+  it('allows only task posts in map view', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} currentView="map" />
+      </BrowserRouter>
+    );
+    expect(getOptions()).toEqual(['Quest Task']);
+  });
+
+  it('allows log posts in log view', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} currentView="log" />
+      </BrowserRouter>
+    );
+    expect(getOptions()).toEqual(['Quest Log']);
+  });
+
+  it('allows commit and log posts in file-change view', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} currentView="file-change" />
+      </BrowserRouter>
+    );
+    expect(getOptions()).toEqual(['Commit', 'Quest Log']);
+  });
+});


### PR DESCRIPTION
## Summary
- compute active view in `Board` and pass to `CreatePost`
- restrict allowed post types in `CreatePost` when board type is quest
- add tests verifying post type filtering for map, log and file-change views

## Testing
- `npm test -- -w=1` *(fails: cannot find jest-environment-jsdom)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*
- `npm test -- -w=1` in backend *(fails: cannot find module 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_6855a4595258832fa2a632e650b32a56