### PR TITLE
Handle timeline board post types

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -55,11 +55,13 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
     boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
 
   const allowedPostTypes: PostType[] =
-    boardType === 'quest'
+    boardId === 'timeline-board'
+      ? ['quest', 'free_speech', 'request', 'review']
+      : boardType === 'quest'
       ? ['quest', 'task', 'log']
       : boardType === 'post'
       ? ['free_speech', 'request', 'commit', 'issue']
-      : POST_TYPES.map(p => p.value as PostType);
+      : POST_TYPES.map((p) => p.value as PostType);
 
   const renderQuestForm = type === 'quest';
 

--- a/ethos-frontend/src/components/ui/PostTypeBadge.tsx
+++ b/ethos-frontend/src/components/ui/PostTypeBadge.tsx
@@ -49,6 +49,10 @@ const typeStyles: Record<PostType, { label: string; color: string }> = {
     label: 'Issue',
     color: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
   },
+  review: {
+    label: 'Review',
+    color: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-200',
+  },
   solved: {
     label: 'Solved',
     color: 'bg-lime-100 text-lime-800 dark:bg-lime-800 dark:text-lime-200',

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -32,6 +32,7 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'log', label: 'Quest Log' },
   { value: 'commit', label: 'Commit' },
   { value: 'issue', label: 'Issue' },
+  { value: 'review', label: 'Review' },
 ];
 
 export const LINK_TYPES = ['solution', 'duplicate', 'citation'];

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -149,6 +149,7 @@ export type PostType =
   | 'meta_announcement'
   | 'commit'
   | 'issue'
+  | 'review'
   | 'solved';
   
 /**

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: null,
+    boards: {
+      'timeline-board': { id: 'timeline-board', title: 'Timeline', boardType: 'post', layout: 'grid', items: [], createdAt: '' },
+    },
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+const CreatePost = require('../src/components/post/CreatePost').default;
+
+describe('Timeline board post types', () => {
+  it('shows allowed options for timeline board', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} boardId="timeline-board" />
+      </BrowserRouter>
+    );
+    const select = screen.getByLabelText('Item Type');
+    const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Quest', 'Free Speech', 'Request', 'Review']);
+  });
+});


### PR DESCRIPTION
## Summary
- define a new `review` `PostType`
- surface `review` among selectable types
- add style for `review` badges
- filter types for `timeline-board`
- test that timeline board shows the right type options

## Testing
- `npm test --silent --prefix ethos-frontend` *(fails: Jest worker encountered child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_6855a456af38832fb5c047d54973d732