### PR TITLE
Update quest UI permissions

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -430,6 +430,7 @@ const Board: React.FC<BoardProps> = ({
           contributions={items}
           questId={quest?.id || ''}
           initialExpanded={initialExpanded}
+          editable={editable}
           {...(resolvedStructure === 'graph' ||
             resolvedStructure === 'graph-condensed' ||
             resolvedStructure === 'map-graph'

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -23,6 +23,7 @@ type GridLayoutProps = {
   user?: User;
   layout?: 'vertical' | 'horizontal' | 'kanban';
   compact?: boolean;
+  editable?: boolean;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
   onScrollEnd?: () => void;
@@ -82,6 +83,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   user,
   layout = 'vertical',
   compact = false,
+  editable = false,
   onEdit,
   onDelete,
   onScrollEnd,
@@ -196,9 +198,11 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               </DroppableColumn>
             </div>
           ))}
-          <div className="min-w-[280px] w-[320px] flex items-center justify-center text-accent hover:text-accent font-medium border border-secondary rounded-lg shadow-sm bg-surface cursor-pointer">
-            + Add Column
-          </div>
+          {editable && (
+            <div className="min-w-[280px] w-[320px] flex items-center justify-center text-accent hover:text-accent font-medium border border-secondary rounded-lg shadow-sm bg-surface cursor-pointer">
+              + Add Column
+            </div>
+          )}
         </div>
       </DndContext>
     );

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -52,6 +52,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   ];
 
   const isOwner = user?.id === questData.authorId;
+  const canEdit = isOwner || questData.collaborators?.some(c => c.userId === user?.id);
 
   const saveLinks = async () => {
     try {
@@ -199,15 +200,26 @@ const QuestCard: React.FC<QuestCardProps> = ({
               items={logs}
               user={user}
               layout="vertical"
+              editable={canEdit}
             />
             <div className="text-right mt-2">
-              <Button
-                size="sm"
-                variant="contrast"
-                onClick={() => setShowLogForm(true)}
-              >
-                + Add Item
-              </Button>
+              {canEdit ? (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => setShowLogForm(true)}
+                >
+                  + Add Item
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => onJoinToggle?.(questData)}
+                >
+                  Join Quest
+                </Button>
+              )}
             </div>
         </>
       );
@@ -233,15 +245,26 @@ const QuestCard: React.FC<QuestCardProps> = ({
               items={logs}
               user={user}
               layout="kanban"
+              editable={canEdit}
             />
             <div className="text-right mt-2">
-              <Button
-                size="sm"
-                variant="contrast"
-                onClick={() => setShowTaskForm(true)}
-              >
-                + Add Item
-              </Button>
+              {canEdit ? (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => setShowTaskForm(true)}
+                >
+                  + Add Item
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => onJoinToggle?.(questData)}
+                >
+                  Join Quest
+                </Button>
+              )}
             </div>
           </>
         );
@@ -263,13 +286,23 @@ const QuestCard: React.FC<QuestCardProps> = ({
               </div>
             )}
             <div className="text-right mb-2">
-              <Button
-                size="sm"
-                variant="contrast"
-                onClick={() => setShowTaskForm(true)}
-              >
-                + Add Item
-              </Button>
+              {canEdit ? (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => setShowTaskForm(true)}
+                >
+                  + Add Item
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => onJoinToggle?.(questData)}
+                >
+                  Join Quest
+                </Button>
+              )}
             </div>
             <GraphLayout
               items={logs as any}


### PR DESCRIPTION
## Summary
- show Join Quest button whenever Add Item is hidden
- hide Add Column when board is read-only

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Jest unable to handle ESM modules and network requests)*

------
https://chatgpt.com/codex/tasks/task_e_6855b2ce7838832fba5ce2528d8aa368