### PR TITLE
Update join quest behavior

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -44,7 +44,22 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const [showLogForm, setShowLogForm] = useState(false);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
   const [linkDraft, setLinkDraft] = useState(quest.linkedPosts || []);
+  const [joinRequested, setJoinRequested] = useState(false);
   const navigate = useNavigate();
+
+  const handleJoinRequest = () => {
+    if (!user?.id) {
+      navigate(ROUTES.LOGIN);
+      return;
+    }
+    if (joinRequested) {
+      alert('Request already sent. Awaiting approval.');
+      return;
+    }
+    onJoinToggle?.(questData);
+    setJoinRequested(true);
+    alert('Join request sent.');
+  };
   const viewOptions = [
     { value: 'map', label: 'Map - Graph' },
     { value: 'timeline', label: 'Log' },
@@ -133,8 +148,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
           onArchived={isOwner ? () => {
             console.log(`[QuestCard] Quest ${quest.id} archived`);
           } : undefined}
-          onJoin={!isOwner ? () => onJoinToggle?.(questData) : undefined}
-          joinLabel="Join Quest"
+          onJoin={!isOwner ? handleJoinRequest : undefined}
+          joinLabel="Request to Join"
           permalink={`${window.location.origin}${ROUTES.QUEST(quest.id)}`}
         />
   
@@ -196,9 +211,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 <Button
                   size="sm"
                   variant="contrast"
-                  onClick={() => onJoinToggle?.(questData)}
+                  onClick={handleJoinRequest}
                 >
-                  Join Quest
+                  Request to Join
                 </Button>
               )}
             </div>
@@ -241,9 +256,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 <Button
                   size="sm"
                   variant="contrast"
-                  onClick={() => onJoinToggle?.(questData)}
+                  onClick={handleJoinRequest}
                 >
-                  Join Quest
+                  Request to Join
                 </Button>
               )}
             </div>
@@ -279,9 +294,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 <Button
                   size="sm"
                   variant="contrast"
-                  onClick={() => onJoinToggle?.(questData)}
+                  onClick={handleJoinRequest}
                 >
-                  Join Quest
+                  Request to Join
                 </Button>
               )}
             </div>

--- a/ethos-frontend/src/components/ui/ActionMenu.tsx
+++ b/ethos-frontend/src/components/ui/ActionMenu.tsx
@@ -46,7 +46,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   boardId,
   className = '',
   onJoin,
-  joinLabel = 'Join Quest',
+  joinLabel = 'Request to Join',
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);


### PR DESCRIPTION
## Summary
- update ActionMenu to show 'Request to Join'
- implement join request flow in QuestCard
- redirect to login if user isn't logged in
- notify users when a request was sent or already sent

## Testing
- `npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom missing)*
- `npm --prefix ethos-backend test` *(fails: unable to find supertest modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855b8e680e4832fa5523bdbb671035d