### PR TITLE
Add optional task details field

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -39,6 +39,7 @@ router.post(
     const {
       type = 'free_speech',
       content = '',
+      details = '',
       visibility = 'public',
       tags = [],
       questId = null,
@@ -68,6 +69,7 @@ router.post(
       authorId: req.user!.id,
       type,
       content,
+      details,
       visibility,
       timestamp: new Date().toISOString(),
       tags,

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -91,6 +91,8 @@ export interface Post {
   type: PostType;
   subtype?: string;
   content: string;
+  /** Optional extra details for task posts */
+  details?: string;
   visibility: Visibility;
   timestamp: string;
   createdAt?: string;

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -23,6 +23,8 @@ export interface DBPost {
   type: PostType;
   subtype?: string;
   content: string;
+  /** Optional extra details for task posts */
+  details?: string;
   visibility: Visibility;
   timestamp: string;
 

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { addPost } from '../../api/post';
-import { Button, TextArea, Select, Label, FormSection } from '../ui';
+import { Button, TextArea, Select, Label, FormSection, Input } from '../ui';
 import CollaberatorControls from '../controls/CollaberatorControls';
 import LinkControls from '../controls/LinkControls';
 import CreateQuest from '../quest/CreateQuest';
@@ -51,6 +51,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const [type, setType] = useState<PostType>(initialType);
   const [status, setStatus] = useState<string>('To Do');
   const [content, setContent] = useState<string>('');
+  const [details, setDetails] = useState<string>('');
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -101,6 +102,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       const payload: Partial<Post> = {
         type,
         content,
+        ...(type === 'task' && details ? { details } : {}),
         visibility: 'public',
         linkedItems: autoLinkItems,
         helpRequest: type === 'request' || helpRequest || undefined,
@@ -208,20 +210,42 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           </>
         )}
 
-        <Label htmlFor="content">Content</Label>
-        <TextArea
-          id="content"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder={
-            replyTo
-              ? 'Reply to this post...'
-              : repostSource
-              ? 'Add a comment to your repost...'
-              : 'Share your thoughts or progress...'
-          }
-          required
-        />
+        {type === 'task' ? (
+          <>
+            <Label htmlFor="content">Task Title</Label>
+            <Input
+              id="content"
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              placeholder="Short task summary"
+              required
+            />
+            <Label htmlFor="details">Details</Label>
+            <TextArea
+              id="details"
+              value={details}
+              onChange={e => setDetails(e.target.value)}
+              placeholder="Additional information (optional)"
+            />
+          </>
+        ) : (
+          <>
+            <Label htmlFor="content">Content</Label>
+            <TextArea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={
+                replyTo
+                  ? 'Reply to this post...'
+                  : repostSource
+                  ? 'Add a comment to your repost...'
+                  : 'Share your thoughts or progress...'
+              }
+              required
+            />
+          </>
+        )}
       </FormSection>
 
       {showLinkControls(type) && !replyTo && (

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -9,7 +9,7 @@ import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
 import type { PostType, Post, CollaberatorRoles, LinkedItem } from '../../types/postTypes';
 
-import { TextArea, Select, Button, Label, FormSection } from '../ui';
+import { TextArea, Select, Button, Label, FormSection, Input } from '../ui';
 import LinkControls from '../controls/LinkControls';
 import CollaberatorControls from '../controls/CollaberatorControls';
 
@@ -23,6 +23,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
   const [type, setType] = useState<PostType>(post.type);
   const [status, setStatus] = useState<string>(post.status || 'To Do');
   const [content, setContent] = useState<string>(post.content || '');
+  const [details, setDetails] = useState<string>(post.details || '');
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>(post.collaborators || []);
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>(post.linkedItems || []);
   const [repostedFrom] = useState(post.repostedFrom || null);
@@ -46,6 +47,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
     const payload: Partial<Post> = {
       type,
       content,
+      ...(type === 'task' && details ? { details } : {}),
       ...(type === 'quest' && { collaborators }),
       ...(type === 'task' ? { status } : {}),
       linkedItems,
@@ -91,15 +93,38 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
           </>
         )}
 
-        <Label htmlFor="content">Content (Markdown supported)</Label>
-        <TextArea
-          id="content"
-          rows={8}
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Write your post..."
-          required
-        />
+        {type === 'task' ? (
+          <>
+            <Label htmlFor="content">Task Title</Label>
+            <Input
+              id="content"
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              placeholder="Short task summary"
+              required
+            />
+            <Label htmlFor="details">Details (Markdown supported)</Label>
+            <TextArea
+              id="details"
+              rows={8}
+              value={details}
+              onChange={e => setDetails(e.target.value)}
+              placeholder="Additional information"
+            />
+          </>
+        ) : (
+          <>
+            <Label htmlFor="content">Content (Markdown supported)</Label>
+            <TextArea
+              id="content"
+              rows={8}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Write your post..."
+              required
+            />
+          </>
+        )}
 
         <div className="mt-4">
           <button

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -96,8 +96,10 @@ const PostCard: React.FC<PostCardProps> = ({
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : 'Unknown time';
 
-  const content = post.renderedContent || post.content;
-  const isLong = content.length > PREVIEW_LIMIT;
+  const content = post.renderedContent || post.details || post.content;
+  const isLong = (post.type === 'task'
+    ? (post.details || '').length
+    : content.length) > PREVIEW_LIMIT;
 
   useEffect(() => {
     if (!post.replyTo) {
@@ -298,7 +300,32 @@ const PostCard: React.FC<PostCardProps> = ({
       {renderRepostInfo()}
 
       <div className="text-sm text-primary">
-        {isLong ? (
+        {post.type === 'task' ? (
+          <>
+            <div className="font-semibold">{post.content}</div>
+            {post.details && (
+              isLong ? (
+                <>
+                  <MarkdownRenderer
+                    content={post.details.slice(0, PREVIEW_LIMIT) + '…'}
+                    onToggleTask={handleToggleTask}
+                  />
+                  <button
+                    onClick={() => navigate(ROUTES.POST(post.id))}
+                    className="text-accent underline text-xs ml-1"
+                  >
+                    See more
+                  </button>
+                </>
+              ) : (
+                <MarkdownRenderer
+                  content={post.details}
+                  onToggleTask={handleToggleTask}
+                />
+              )
+            )}
+          </>
+        ) : isLong ? (
           <>
             <MarkdownRenderer
               content={content.slice(0, PREVIEW_LIMIT) + '…'}

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -15,6 +15,8 @@ export interface Post {
   type: PostType;
   subtype?: string;
   content: string;
+  /** Optional extra details for task posts */
+  details?: string;
   visibility: Visibility;
   timestamp: string;
   createdAt?: string;


### PR DESCRIPTION
## Summary
- add `details` field to Post types
- update backend to store optional task details
- allow entering task details when creating or editing tasks
- display task title with optional details in PostCard

## Testing
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bc9f537c832fa959579faa6cdf16