### PR TITLE
Add user profile API route

### DIFF
--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -1,0 +1,20 @@
+import express, { Request, Response } from 'express';
+import authOptional from '../middleware/authOptional';
+import { usersStore } from '../models/stores';
+
+const router = express.Router();
+
+// GET /api/users/:id - fetch public profile
+router.get('/:id', authOptional, (req: Request<{ id: string }>, res: Response): void => {
+  const user = usersStore.read().find(u => u.id === req.params.id);
+  if (!user) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  // Return only public fields
+  const { id, username, tags, bio, links, experienceTimeline } = user as any;
+  res.json({ id, username, tags, bio, links, experienceTimeline });
+});
+
+export default router;

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -13,6 +13,7 @@ import postRoutes from './routes/postRoutes';
 import questRoutes from './routes/questRoutes';
 import boardRoutes from './routes/boardRoutes';
 import reviewRoutes from './routes/reviewRoutes';
+import userRoutes from './routes/userRoutes';
 
 // Load environment variables from `.env` file
 dotenv.config();
@@ -59,6 +60,7 @@ app.use('/api/posts', postRoutes);    // 📝 Posts, reactions, replies
 app.use('/api/quests', questRoutes);  // 📦 Quests, task maps
 app.use('/api/boards', boardRoutes);  // 🧭 Boards and view layouts
 app.use('/api/reviews', reviewRoutes); // ⭐ Reviews
+app.use('/api/users', userRoutes);    // 👥 Public user profiles
 
 /**
  * Default server port


### PR DESCRIPTION
## Summary
- add `/api/users/:id` public profile endpoint
- expose user routes in the backend server

## Testing
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c09e36c8832f85edd47cb722696f