### PR TITLE
Add quest moderation and featured board

### DIFF
--- a/ethos-backend/src/data/quests.json
+++ b/ethos-backend/src/data/quests.json
@@ -31,7 +31,10 @@
         "to": "59687208-c91b-4562-9d39-5d7181c4623b"
       }
     ],
-    "helpRequest": false
+    "helpRequest": false,
+    "visibility": "public",
+    "approvalStatus": "approved",
+    "flagCount": 0
   },
   {
     "id": "41f1e562-2389-4717-a9c4-15abb17ded27",
@@ -44,6 +47,9 @@
     "status": "active",
     "headPostId": "5cfed02e-9695-4ccc-83a9-c57f06999e19",
     "taskGraph": [],
-    "helpRequest": false
+    "helpRequest": false,
+    "visibility": "public",
+    "approvalStatus": "approved",
+    "flagCount": 0
   }
 ]

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -6,7 +6,7 @@ import { boardsStore, questsStore, postsStore, usersStore } from '../models/stor
 import { enrichQuest, enrichPost } from '../utils/enrich';
 import { generateNodeId } from '../utils/nodeIdUtils';
 import { logQuest404 } from '../utils/errorTracker';
-import type { Quest, LinkedItem } from '../types/api';
+import type { Quest, LinkedItem, Visibility } from '../types/api';
 import type { DBQuest, DBPost } from '../types/db';
 
 const makeQuestNodeTitle = (content: string): string => {
@@ -24,6 +24,29 @@ interface AuthRequest<
 }
 
 const router = express.Router();
+
+// GET top 10 featured quests
+router.get('/featured', (req: Request, res: Response) => {
+  const quests = questsStore.read();
+  const posts = postsStore.read();
+
+  const popularity = (q: DBQuest) =>
+    posts.filter((p) => p.questId === q.id).length + (q.linkedPosts?.length || 0);
+
+  const featured = quests
+    .filter(
+      (q) => q.visibility === 'public' && q.approvalStatus === 'approved'
+    )
+    .sort((a, b) => popularity(b) - popularity(a))
+    .slice(0, 10)
+    .map((q) => ({
+      ...q,
+      popularity: popularity(q),
+      gitRepo: q.gitRepo ? { repoUrl: q.gitRepo.repoUrl ?? '', ...q.gitRepo } : undefined,
+    }));
+
+  res.json(featured);
+});
 
 // GET all quests
 router.get('/', (req: Request, res: Response) => {
@@ -56,6 +79,9 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     authorId,
     title,
     description,
+    visibility: 'public',
+    approvalStatus: 'approved',
+    flagCount: 0,
     tags,
     linkedPosts: fromPostId
       ? [{ itemId: fromPostId, itemType: 'post' } satisfies LinkedItem]
@@ -201,6 +227,44 @@ router.get(
     );
   }
 );
+
+// POST flag a quest for moderation
+router.post('/:id/flag', authMiddleware, (req: AuthRequest<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const quests = questsStore.read();
+  const posts = postsStore.read();
+  const quest = quests.find(q => q.id === id);
+  if (!quest) {
+    logQuest404(id, req.originalUrl);
+    res.status(404).json({ error: 'Quest not found' });
+    return;
+  }
+
+  quest.flagCount = (quest.flagCount || 0) + 1;
+
+  if (quest.flagCount >= 3 && quest.approvalStatus === 'approved') {
+    quest.approvalStatus = 'flagged';
+    const reviewPost: DBPost = {
+      id: uuidv4(),
+      authorId: req.user!.id,
+      type: 'meta_system',
+      subtype: 'mod_review',
+      content: `Quest ${quest.id} flagged for review`,
+      visibility: 'hidden',
+      timestamp: new Date().toISOString(),
+      tags: ['mod_review'],
+      collaborators: [],
+      replyTo: null,
+      repostedFrom: null,
+      linkedItems: [{ itemId: quest.id, itemType: 'quest' }],
+    };
+    posts.push(reviewPost);
+    postsStore.write(posts);
+  }
+
+  questsStore.write(quests);
+  res.json({ success: true, flags: quest.flagCount });
+});
 
 // GET task graph map for a quest
 router.get(
@@ -441,6 +505,36 @@ router.post(
     questsStore.write(quests);
     postsStore.write(posts);
 
+    res.json(quest);
+  }
+);
+
+// PATCH quest visibility or approval status by moderators
+router.patch(
+  '/:id/moderate',
+  authMiddleware,
+  (req: AuthRequest<{ id: string }, any, { visibility?: Visibility; approvalStatus?: 'approved' | 'flagged' | 'banned' }>, res: Response) => {
+    const { id } = req.params;
+    const { visibility, approvalStatus } = req.body;
+    const quests = questsStore.read();
+    const users = usersStore.read();
+    const quest = quests.find(q => q.id === id);
+    if (!quest) {
+      logQuest404(id, req.originalUrl);
+      res.status(404).json({ error: 'Quest not found' });
+      return;
+    }
+
+    const user = users.find(u => u.id === req.user!.id);
+    if (!user || (user.role !== 'moderator' && user.role !== 'admin')) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+
+    if (visibility) quest.visibility = visibility;
+    if (approvalStatus) quest.approvalStatus = approvalStatus as any;
+
+    questsStore.write(quests);
     res.json(quest);
   }
 );

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -14,6 +14,8 @@ export type UserRole = 'user' | 'admin' | 'moderator';
  */
 export type ReactionType = 'like' | 'heart' | 'repost';
 
+export type ApprovalStatus = 'approved' | 'flagged' | 'banned';
+
 export type AppItem = Post | Quest | Board | RenderableItem;
 
 /**
@@ -152,6 +154,9 @@ export interface Quest {
   title: string;
   description?: string;
   authorId: string;
+  visibility: Visibility;
+  approvalStatus: ApprovalStatus;
+  flagCount?: number;
   status: 'active' | 'completed' | 'archived';
   headPostId: string;
   createdAt?: string;

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -13,7 +13,8 @@ import type {
   BoardType,
   ReactionSet,
   ReactionCountMap,
-  ReviewTargetType
+  ReviewTargetType,
+  ApprovalStatus
 } from './api';
 
 // types/db.ts
@@ -62,6 +63,9 @@ export interface DBQuest {
   authorId: string;
   title: string;
   description?: string;
+  visibility: Visibility;
+  approvalStatus: ApprovalStatus;
+  flagCount?: number;
   status: 'active' | 'completed' | 'archived';
 
   headPostId: string;

--- a/ethos-backend/tests/questModeration.test.ts
+++ b/ethos-backend/tests/questModeration.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest';
+import express from 'express';
+
+import questRoutes from '../src/routes/questRoutes';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => { _req.user = { id: 'u1' }; next(); }
+}));
+
+jest.mock('../src/models/stores', () => ({
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
+  postsStore: { read: jest.fn(() => []), write: jest.fn() },
+  boardsStore: { read: jest.fn(() => []), write: jest.fn() },
+  usersStore: { read: jest.fn(() => [{ id: 'u1', role: 'moderator' }]), write: jest.fn() }
+}));
+
+const { questsStore, postsStore } = require('../src/models/stores');
+
+const app = express();
+app.use(express.json());
+app.use('/quests', questRoutes);
+
+describe('quest moderation routes', () => {
+  it('GET /quests/featured returns sorted quests', async () => {
+    questsStore.read.mockReturnValue([
+      { id: 'q1', authorId: 'u1', title: 'A', headPostId: '', linkedPosts: [], collaborators: [], status: 'active', visibility: 'public', approvalStatus: 'approved', flagCount: 0 },
+      { id: 'q2', authorId: 'u1', title: 'B', headPostId: '', linkedPosts: ['p1'], collaborators: [], status: 'active', visibility: 'public', approvalStatus: 'approved', flagCount: 0 }
+    ]);
+    postsStore.read.mockReturnValue([{ id: 'p1', questId: 'q2', authorId: 'u1', type: 'task', content: '', visibility: 'public', timestamp: '' }]);
+
+    const res = await request(app).get('/quests/featured');
+    expect(res.status).toBe(200);
+    expect(res.body[0].id).toBe('q2');
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('POST /quests/:id/flag increments flag count and creates review post', async () => {
+    questsStore.read.mockReturnValue([
+      { id: 'q1', authorId: 'u1', title: 'A', headPostId: '', linkedPosts: [], collaborators: [], status: 'active', visibility: 'public', approvalStatus: 'approved', flagCount: 2 }
+    ]);
+    postsStore.read.mockReturnValue([]);
+    postsStore.write.mockClear();
+
+    const res = await request(app).post('/quests/q1/flag');
+    expect(res.status).toBe(200);
+    const updated = questsStore.write.mock.calls[0][0][0];
+    expect(updated.flagCount).toBe(3);
+    expect(postsStore.write).toHaveBeenCalled();
+  });
+});

--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -27,6 +27,7 @@ const Board = lazy(() => import('./pages/board/[id]'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
+const FlaggedQuests = lazy(() => import('./pages/admin/FlaggedQuests'));
 
 /**
  * The root App component of the application.
@@ -65,6 +66,7 @@ const App: React.FC = () => {
                     <Route path={ROUTES.QUEST()} element={<Quest />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />
+                    <Route path={ROUTES.FLAGGED_QUESTS} element={<FlaggedQuests />} />
                   </Route>
 
                   {/* 🔁 Catch-all route for unmatched URLs */}

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -43,6 +43,11 @@ export const fetchAllQuests = async (): Promise<Quest[]> => {
   return res.data;
 };
 
+export const fetchFeaturedQuests = async (): Promise<Quest[]> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/featured`);
+  return res.data;
+};
+
 /**
  * Update a quest by ID  
  * @function updateQuestById  
@@ -129,6 +134,19 @@ export const fetchQuestsByBoardId = async (
   const res = await axiosWithAuth.get(
     `/boards/${boardId}/quests${params.toString() ? `?${params.toString()}` : ''}`
   );
+  return res.data;
+};
+
+export const flagQuest = async (id: string): Promise<{ success: boolean; flags: number }> => {
+  const res = await axiosWithAuth.post(`${BASE_URL}/${id}/flag`);
+  return res.data;
+};
+
+export const moderateQuest = async (
+  id: string,
+  updates: { visibility?: Quest['visibility']; approvalStatus?: Quest['approvalStatus'] }
+): Promise<Quest> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}/moderate`, updates);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/mod/ModReviewPanel.tsx
+++ b/ethos-frontend/src/components/mod/ModReviewPanel.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import type { Quest } from '../../types/questTypes';
+import { moderateQuest } from '../../api/quest';
+import { Select, Button } from '../ui';
+
+interface ModReviewPanelProps {
+  quest: Quest;
+  onUpdated?: (quest: Quest) => void;
+}
+
+const visibilityOptions = [
+  { value: 'public', label: 'Public' },
+  { value: 'private', label: 'Private' },
+  { value: 'hidden', label: 'Hidden' },
+];
+
+const approvalOptions = [
+  { value: 'approved', label: 'Approved' },
+  { value: 'flagged', label: 'Flagged' },
+  { value: 'banned', label: 'Banned' },
+];
+
+const ModReviewPanel: React.FC<ModReviewPanelProps> = ({ quest, onUpdated }) => {
+  const [visibility, setVisibility] = useState<Quest['visibility']>(quest.visibility);
+  const [approval, setApproval] = useState<Quest['approvalStatus']>(quest.approvalStatus);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const updated = await moderateQuest(quest.id, { visibility, approvalStatus: approval });
+      onUpdated?.(updated);
+    } catch (err) {
+      console.error('[ModReviewPanel] failed to update quest', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2 border p-3 rounded bg-surface dark:bg-background">
+      <div className="font-semibold">{quest.title}</div>
+      <div className="flex gap-2">
+        <Select value={visibility} onChange={e => setVisibility(e.target.value as Quest['visibility'])} options={visibilityOptions} />
+        <Select value={approval} onChange={e => setApproval(e.target.value as Quest['approvalStatus'])} options={approvalOptions} />
+        <Button onClick={handleSave} disabled={saving}>Save</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ModReviewPanel;

--- a/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { fetchFeaturedQuests } from '../../api/quest';
+import type { Quest } from '../../types/questTypes';
+import { Link } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
+import { Spinner } from '../ui';
+
+interface QuestWithScore extends Quest {
+  popularity?: number;
+}
+
+const FeaturedQuestBoard: React.FC = () => {
+  const [quests, setQuests] = useState<QuestWithScore[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchFeaturedQuests();
+        setQuests(data || []);
+      } catch (err) {
+        console.error('[FeaturedQuestBoard] Failed to load quests', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {quests.map(q => (
+        <div key={q.id} className="p-2 border rounded bg-surface dark:bg-background">
+          <Link to={ROUTES.QUEST(q.id)} className="font-semibold text-blue-600 underline">
+            {q.title}
+          </Link>
+          {typeof q.popularity === 'number' && (
+            <span className="ml-2 text-sm text-secondary">Score: {q.popularity}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FeaturedQuestBoard;

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -48,6 +48,8 @@ export const ROUTES = {
      * @returns A route string like `/boards/abc123`
      */
     BOARD: (id = ':id') => `/boards/${id}`,
+
+    FLAGGED_QUESTS: '/admin/flagged-quests',
   
     /** Wildcard route for handling 404 pages */
     NOT_FOUND: '*',

--- a/ethos-frontend/src/pages/admin/FlaggedQuests.tsx
+++ b/ethos-frontend/src/pages/admin/FlaggedQuests.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAllQuests } from '../../api/quest';
+import { useAuth } from '../../contexts/AuthContext';
+import ModReviewPanel from '../../components/mod/ModReviewPanel';
+import type { Quest } from '../../types/questTypes';
+import { Spinner } from '../../components/ui';
+
+const FlaggedQuestsPage: React.FC = () => {
+  const { user } = useAuth();
+  const [quests, setQuests] = useState<Quest[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchAllQuests();
+        setQuests(data.filter(q => q.approvalStatus === 'flagged'));
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (user?.role !== 'moderator' && user?.role !== 'admin') {
+    return <div>Forbidden</div>;
+  }
+
+  if (loading) return <Spinner />;
+
+  return (
+    <main className="container mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Flagged Quests</h1>
+      {quests.map(q => (
+        <ModReviewPanel key={q.id} quest={q} onUpdated={() => {}} />
+      ))}
+      {quests.length === 0 && <p>No flagged quests.</p>}
+    </main>
+  );
+};
+
+export default FlaggedQuestsPage;

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useBoardContext } from '../contexts/BoardContext';
 import Board from '../components/board/Board';
 import PostTypeFilter from '../components/board/PostTypeFilter';
+import FeaturedQuestBoard from '../components/quest/FeaturedQuestBoard';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
 import { Spinner } from '../components/ui';
@@ -46,19 +47,8 @@ const HomePage: React.FC = () => {
       </header>
 
       <section>
-        <Board
-          boardId="featured-quest"
-          title="✨ Featured Quest"
-          layout="grid"
-          gridLayout="horizontal"
-          user={user as User}
-          hideControls
-        />
-        <div className="text-right mt-1">
-          <Link to={ROUTES.BOARD('featured-quest')} className="text-blue-600 underline text-sm">
-            View Board Details
-          </Link>
-        </div>
+        <h2 className="text-xl font-semibold mb-2">✨ Featured Quests</h2>
+        <FeaturedQuestBoard />
       </section>
 
       <section className="space-y-4">

--- a/ethos-frontend/src/types/questTypes.ts
+++ b/ethos-frontend/src/types/questTypes.ts
@@ -9,6 +9,9 @@ export interface Quest {
   authorId: string;
   title: string;
   description?: string;
+  visibility: 'public' | 'private' | 'hidden' | 'system';
+  approvalStatus: 'approved' | 'flagged' | 'banned';
+  flagCount?: number;
   status: 'active' | 'completed' | 'archived';
   headPostId: string;
   createdAt?: string;


### PR DESCRIPTION
## Summary
- add approval status to API types and DB models
- default new quests to public, approved, and zero flags
- implement `/api/quests/featured` and moderation endpoints
- allow quests to be flagged for review
- create React components for featured quests and mod review
- expose flagged quests page
- add tests for featured quest endpoint and flagging

## Testing
- `npm test --silent` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6855c2c74ca4832fa324e335e4b4b5f4