### PR TITLE
Add infinite activity feed

### DIFF
--- a/ethos-frontend/src/components/feed/ActivityFeed.tsx
+++ b/ethos-frontend/src/components/feed/ActivityFeed.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState } from 'react';
+import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
+import { useAuth } from '../../contexts/AuthContext';
+import { useBoard } from '../../hooks/useBoard';
+import { fetchBoard } from '../../api/board';
+import Board from '../board/Board';
+import { Spinner } from '../ui';
+
+import type { BoardData } from '../../types/boardTypes';
+
+interface ActivityFeedProps {
+  boardId?: string;
+}
+
+const ActivityFeed: React.FC<ActivityFeedProps> = ({ boardId = 'timeline-board' }) => {
+  const { user } = useAuth();
+  const { board, setBoard } = useBoard(boardId);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadMore = useCallback(async () => {
+    if (!boardId || loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const nextPage = page + 1;
+      const more: BoardData = await fetchBoard(boardId, {
+        page: nextPage,
+        limit: DEFAULT_PAGE_SIZE,
+        enrich: true,
+        userId: user?.id,
+      });
+      if (more.items?.length) {
+        setBoard(prev =>
+          prev
+            ? {
+                ...prev,
+                items: [...prev.items, ...more.items],
+                enrichedItems: [
+                  ...(prev.enrichedItems || []),
+                  ...(more.enrichedItems || []),
+                ],
+              }
+            : more
+        );
+        setPage(nextPage);
+      } else {
+        setHasMore(false);
+      }
+    } catch (err) {
+      console.warn('[ActivityFeed] Pagination error:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [boardId, page, loading, hasMore, user?.id, setBoard]);
+
+  if (!board) return <Spinner />;
+
+  return (
+    <Board
+      boardId={boardId}
+      board={board}
+      layout="grid"
+      hideControls
+      onScrollEnd={loadMore}
+      loading={loading}
+    />
+  );
+};
+
+export default ActivityFeed;

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -7,6 +7,7 @@ import FeaturedQuestBoard from '../components/quest/FeaturedQuestBoard';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
 import { Spinner } from '../components/ui';
+import ActivityFeed from '../components/feed/ActivityFeed';
 import { getRenderableBoardItems } from '../utils/boardUtils';
 
 import type { User } from '../types/userTypes';
@@ -71,13 +72,8 @@ const HomePage: React.FC = () => {
       </section>
 
       <section>
-        <Board
-          boardId="timeline-board"
-          title="⏳ Recent Activity"
-          layout="grid"
-          user={user as User}
-          hideControls
-        />
+        <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>
+        <ActivityFeed />
       </section>
 
     </main>


### PR DESCRIPTION
## Summary
- create `ActivityFeed` component that lazily loads additional pages from a board
- update home page to render the activity feed instead of a static board

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5c2bdc4832fbd104989828c3107