### PR TITLE
Add visual divider between quest map and logs

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -416,8 +416,10 @@ const QuestCard: React.FC<QuestCardProps> = ({
       </div>
       {expanded && (
         <div className="flex flex-col md:flex-row gap-4">
-          <div className="md:w-1/2 lg:w-1/3">{renderMap()}</div>
-          <div className="flex-1">{renderRightPanel()}</div>
+          <div className="md:w-1/2 lg:w-1/3 md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700">
+            {renderMap()}
+          </div>
+          <div className="flex-1 md:pl-4">{renderRightPanel()}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add subtle vertical divider between map canvas and log panel

## Testing
- `npm test` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6855c9c93d0c832f95f70b37c9ea2dec