### PR TITLE
Add quest node inspector

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -9,6 +9,7 @@ import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import { useGitDiff } from "../../hooks/useGit";
 import { Spinner } from "../ui";
 import GraphNode from "./GraphNode";
+import QuestNodeInspector from "../quest/QuestNodeInspector";
 import type { User } from "../../types/userTypes";
 import type { Post } from "../../types/postTypes";
 
@@ -72,6 +73,10 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges || []);
   const [selectedNode, setSelectedNode] = useState<Post | null>(null);
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
+  const activeNode = activeNodeId
+    ? localItems.find((it) => it.id === activeNodeId) || null
+    : null;
 
   useEffect(() => {
     setLocalItems(items);
@@ -190,6 +195,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
 
   const handleNodeClick = (n: Post) => {
     setSelectedNode(n);
+    setActiveNodeId((prev) => (prev === n.id ? null : n.id));
     onSelectNode?.(n);
     window.dispatchEvent(
       new CustomEvent("questTaskSelect", { detail: { taskId: n.id } }),
@@ -335,6 +341,21 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           <div className="flex justify-center py-4">
             <Spinner />
           </div>
+        )}
+      </div>
+      <div
+        className={
+          'fixed top-0 right-0 h-full w-80 bg-surface dark:bg-background shadow-lg transform transition-transform duration-300 ' +
+          (activeNodeId ? 'translate-x-0' : 'translate-x-full')
+        }
+        data-testid="quest-node-inspector"
+      >
+        {activeNode && (
+          <QuestNodeInspector
+            node={activeNode}
+            user={user}
+            onClose={() => setActiveNodeId(null)}
+          />
         )}
       </div>
     </DndContext>

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { Post } from '../../types/postTypes';
+
+interface QuestNodeInspectorProps {
+  node: Post;
+  onClose: () => void;
+}
+
+const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({ node, onClose }) => {
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold">Node Details</h2>
+        <button onClick={onClose} className="text-xl leading-none">&times;</button>
+      </div>
+      <p className="text-sm whitespace-pre-wrap">{node.content}</p>
+    </div>
+  );
+};
+
+export default QuestNodeInspector;


### PR DESCRIPTION
## Summary
- show quest node inspector with slide-in animation
- toggle inspector panel by clicking graph nodes

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest tests due to network and module issues)*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6855ccb8e8b8832fa5d26f030197987e