### PR TITLE
Add line version thread component

### DIFF
--- a/ethos-frontend/src/components/quest/FileEditorPanel.tsx
+++ b/ethos-frontend/src/components/quest/FileEditorPanel.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import LineVersionThread from './LineVersionThread';
+
+interface FileEditorPanelProps {
+  questId: string;
+  filePath: string;
+  content: string;
+}
+
+const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, content }) => {
+  const [expandedLine, setExpandedLine] = useState<number | null>(null);
+  const lines = content.split('\n');
+
+  return (
+    <pre className="relative bg-background p-2 rounded border border-secondary text-sm font-mono overflow-x-auto">
+      {lines.map((line, idx) => (
+        <div key={idx} className="relative pl-8">
+          <span className="absolute left-0 w-6 text-right pr-1 text-secondary select-none">
+            {idx + 1}
+          </span>
+          {line}
+          <button
+            className="ml-2 text-accent underline text-xs"
+            onClick={() => setExpandedLine(expandedLine === idx + 1 ? null : idx + 1)}
+          >
+            {expandedLine === idx + 1 ? 'Hide' : 'History'}
+          </button>
+          {expandedLine === idx + 1 && (
+            <div className="mt-1">
+              <LineVersionThread
+                questId={questId}
+                filePath={filePath}
+                lineNumber={idx + 1}
+                onClose={() => setExpandedLine(null)}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+    </pre>
+  );
+};
+
+export default FileEditorPanel;

--- a/ethos-frontend/src/components/quest/LineVersionThread.tsx
+++ b/ethos-frontend/src/components/quest/LineVersionThread.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { fetchPostsByQuestId } from '../../api/post';
+import type { Post } from '../../types/postTypes';
+import GitDiffViewer from '../git/GitDiffViewer';
+import ReplyThread from '../post/ReplyThread';
+import { Spinner } from '../ui';
+
+interface LineVersionThreadProps {
+  questId: string;
+  filePath: string;
+  lineNumber: number;
+  onClose?: () => void;
+}
+
+const LineVersionThread: React.FC<LineVersionThreadProps> = ({
+  questId,
+  filePath,
+  lineNumber,
+  onClose,
+}) => {
+  const [commits, setCommits] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const posts = await fetchPostsByQuestId(questId);
+        const commitPosts = posts.filter(
+          (p) => p.type === 'commit' && p.gitFilePath === filePath
+        );
+        setCommits(commitPosts);
+      } catch (err) {
+        console.error('[LineVersionThread] Failed to fetch posts', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [questId, filePath]);
+
+  return (
+    <div className="bg-surface border border-secondary rounded p-2 mt-1 space-y-3 shadow-sm">
+      <div className="flex justify-between text-xs text-secondary">
+        <span>History for line {lineNumber}</span>
+        {onClose && (
+          <button onClick={onClose} className="underline">
+            Close
+          </button>
+        )}
+      </div>
+      {loading ? (
+        <Spinner />
+      ) : commits.length === 0 ? (
+        <div className="text-xs">No history found.</div>
+      ) : (
+        commits.map((commit) => (
+          <div key={commit.id} className="text-sm border-t border-secondary pt-2">
+            <div className="flex justify-between text-xs text-secondary mb-1">
+              <span>@{commit.author?.username || commit.authorId}</span>
+              <span>
+                {formatDistanceToNow(new Date(commit.timestamp), { addSuffix: true })}
+              </span>
+            </div>
+            {commit.commitSummary && (
+              <div className="font-semibold mb-1">{commit.commitSummary}</div>
+            )}
+            {commit.gitDiff && (
+              <GitDiffViewer markdown={commit.gitDiff} />
+            )}
+            <ReplyThread postId={commit.id} />
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default LineVersionThread;


### PR DESCRIPTION
## Summary
- add `LineVersionThread` component for showing commit history
- create basic `FileEditorPanel` to toggle line history view

## Testing
- `npm test --silent` *(fails: Jest environment and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855ccbd6ac8832f9a8c00a1c2c9f442