### PR TITLE
Allow jest to transform react-force-graph-2d

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -4,8 +4,11 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true, diagnostics: false }],
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true, diagnostics: false }],
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(react-force-graph-2d|react-force-graph|three|force-graph)(/|$))'
+  ],
   moduleNameMapper: {
     'react-markdown': '<rootDir>/tests/__mocks__/react-markdown.tsx',
     'remark-gfm': '<rootDir>/tests/__mocks__/remark-gfm.ts',


### PR DESCRIPTION
## Summary
- transform node modules needed for react-force-graph
- broaden ts-jest transform to cover JS/TS files

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test Suites: 14 failed, 5 passed, 19 total)*

------
https://chatgpt.com/codex/tasks/task_e_6855ccbe6ebc832f9d0bda7a0edb5d1b