### PR TITLE
Fix hooks order in FeaturedQuestBoard

### DIFF
--- a/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
@@ -40,10 +40,6 @@ const FeaturedQuestBoard: React.FC = () => {
     return Array.from({ length: count }, (_, i) => start + i);
   }, [current, quests]);
 
-  if (loading) {
-    return <Spinner />;
-  }
-
   const scrollToIndex = (idx: number) => {
     const el = containerRef.current;
     if (!el) return;
@@ -52,8 +48,10 @@ const FeaturedQuestBoard: React.FC = () => {
   };
 
   useEffect(() => {
-    scrollToIndex(current);
-  }, [current]);
+    if (!loading) {
+      scrollToIndex(current);
+    }
+  }, [current, loading]);
 
   const handleScroll = () => {
     const el = containerRef.current;
@@ -61,6 +59,10 @@ const FeaturedQuestBoard: React.FC = () => {
     const idx = Math.round(el.scrollLeft / (CARD_WIDTH + GAP));
     if (idx !== current) setCurrent(idx);
   };
+
+  if (loading) {
+    return <Spinner />;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- ensure hooks in `FeaturedQuestBoard` are always called in the same order

## Testing
- `npm run lint` *(fails: 88 errors, 15 warnings)*
- `npm test` in `ethos-frontend` *(fails: 14 failed, 5 passed)*
- `npm test` in `ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6855ce63d570832fa4c8f0e60b203fb1