### PR TITLE
Fix hook order and import for map view

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -110,6 +110,12 @@ const GridLayout: React.FC<GridLayoutProps> = ({
     [items.length]
   );
 
+  /** Context for board updates is needed in several layouts. Call it here so
+   *  hook order stays consistent regardless of early returns.
+   */
+  const { selectedBoard, updateBoardItem, removeItemFromBoard } =
+    useBoardContext();
+
   useEffect(() => {
     if (layout === 'horizontal') {
       scrollToIndex(index);
@@ -146,7 +152,6 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   }, {} as Record<string, Post[]>);
 
   /** 📌 Kanban Layout */
-  const { selectedBoard, updateBoardItem, removeItemFromBoard } = useBoardContext();
 
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -7,6 +7,7 @@ import { Button, PostTypeBadge, Select } from '../ui';
 import { ROUTES } from '../../constants/routes';
 import GraphLayout from '../layout/GraphLayout';
 import GridLayout from '../layout/GridLayout';
+import MapGraphLayout from '../layout/MapGraphLayout';
 import CreatePost from '../post/CreatePost';
 import { fetchQuestById, updateQuestById } from '../../api/quest';
 import { fetchPostsByQuestId } from '../../api/post';


### PR DESCRIPTION
## Summary
- ensure `useBoardContext` is called before early returns in `GridLayout`
- import `MapGraphLayout` in `QuestCard` so map graph renders

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError when parsing react-force-graph-2d)*

------
https://chatgpt.com/codex/tasks/task_e_6855d4a11054832fbb3b59788e2651b3