### PR TITLE
Refactor Request Board to Quest Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Current build includes:
 - Boards to visualize posts and quests in grid, graph or timeline views
 - Thread replies endpoint now supports pagination via `page` and `limit` query options
 - Tasks now include a **Request Help** action using `/api/posts/tasks/:id/request-help`,
-  automatically adding the new request to the `request-board`
+  automatically adding the new request to the `quest-board`
 - Inline linking of quests and posts
 - Link dropdowns support node ID search and sorting
 - Review system for AI apps, quests and creators

--- a/ethos-backend/src/data/boardLogs.json
+++ b/ethos-backend/src/data/boardLogs.json
@@ -407,42 +407,42 @@
   },
   {
     "id": "6fdfdd88-88ee-4602-a263-003d056377ce",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:57.907Z"
   },
   {
     "id": "980f8c48-ec0e-422e-aebc-2f6f7323f750",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:57.930Z"
   },
   {
     "id": "2773094e-8e95-405a-9d49-5b792e809698",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:58.589Z"
   },
   {
     "id": "5ea50a21-9aca-4ee0-abc6-86295f85d08f",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:58.620Z"
   },
   {
     "id": "4f718840-6c14-482d-9ef4-b7e9eff9f7e0",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:59.490Z"
   },
   {
     "id": "577434fc-6e36-4c29-a5f9-d0c75757f735",
-    "boardId": "request-board",
+    "boardId": "quest-board",
     "action": "update",
     "userId": "u_41eb992a-b0ee-48ce-ad06-c08d3b766732",
     "timestamp": "2025-06-20T18:44:59.519Z"

--- a/ethos-backend/src/data/boards.json
+++ b/ethos-backend/src/data/boards.json
@@ -74,8 +74,8 @@
     "category": "quest"
   },
   {
-    "id": "request-board",
-    "title": "Request Board",
+    "id": "quest-board",
+    "title": "Quest Board",
     "description": "Posts seeking help",
     "boardType": "post",
     "layout": "grid",

--- a/ethos-backend/src/data/quests.json
+++ b/ethos-backend/src/data/quests.json
@@ -36,6 +36,7 @@
       }
     ],
     "helpRequest": false,
+    "displayOnBoard": true,
     "visibility": "public",
     "approvalStatus": "approved",
     "flagCount": 0
@@ -52,6 +53,7 @@
     "headPostId": "f116d807-dd25-447e-b965-1abd3969676d",
     "taskGraph": [],
     "helpRequest": false,
+    "displayOnBoard": true,
     "visibility": "public",
     "approvalStatus": "approved",
     "flagCount": 0

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -9,6 +9,25 @@ import type { BoardData } from '../types/api';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
+const getQuestBoardItems = (
+  posts: ReturnType<typeof postsStore.read>,
+  quests: ReturnType<typeof questsStore.read>
+) => {
+  const questIds = quests
+    .filter((q) => (q as any).displayOnBoard)
+    .map((q) => q.id);
+  const requestIds = posts
+    .filter(
+      (p) =>
+        p.type === 'request' &&
+        (p.visibility === 'public' ||
+          p.visibility === 'request_board' ||
+          p.helpRequest)
+    )
+    .map((p) => p.id);
+  return [...questIds, ...requestIds];
+};
+
 const router = express.Router();
 
 //
@@ -38,6 +57,11 @@ router.get(
           .filter(q => q.authorId === userId)
           .map(q => q.id);
         return { ...board, items: filtered };
+      }
+
+      if (board.id === 'quest-board') {
+        const items = getQuestBoardItems(posts, quests);
+        return { ...board, items };
       }
 
       return board;
@@ -167,7 +191,9 @@ router.get(
     const start = (pageNum - 1) * pageSize;
     const end = start + pageSize;
     let boardItems = board.items;
-    if (userId && board.id === 'my-posts') {
+    if (board.id === 'quest-board') {
+      boardItems = getQuestBoardItems(posts, quests);
+    } else if (userId && board.id === 'my-posts') {
       boardItems = posts.filter(p => p.authorId === userId).map(p => p.id);
     } else if (userId && board.id === 'my-quests') {
       boardItems = quests.filter(q => q.authorId === userId).map(q => q.id);
@@ -210,7 +236,9 @@ router.get(
     }
 
     let boardItems = board.items;
-    if (userId && board.id === 'my-posts') {
+    if (board.id === 'quest-board') {
+      boardItems = getQuestBoardItems(posts, quests);
+    } else if (userId && board.id === 'my-posts') {
       boardItems = posts.filter(p => p.authorId === userId).map(p => p.id);
     } else if (userId && board.id === 'my-quests') {
       boardItems = quests.filter(q => q.authorId === userId).map(q => q.id);
@@ -253,7 +281,11 @@ router.get(
     }
 
     let boardItems = board.items;
-    if (userId && board.id === 'my-quests') {
+    if (board.id === 'quest-board') {
+      boardItems = getQuestBoardItems(posts, quests).filter(id =>
+        quests.find(q => q.id === id)
+      );
+    } else if (userId && board.id === 'my-quests') {
       boardItems = quests.filter(q => q.authorId === userId).map(q => q.id);
     }
 

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -58,7 +58,7 @@ router.post(
     const quest = questId ? quests.find(q => q.id === questId) : null;
     const parent = replyTo ? posts.find(p => p.id === replyTo) : null;
 
-    if (boardId === 'request-board' &&
+    if (boardId === 'quest-board' &&
         !(type === 'request' || (type === 'quest' && helpRequest))) {
       res.status(400).json({ error: 'Only help requests allowed on this board' });
       return;

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -5,7 +5,12 @@ export type UUID = string;
 export type Timestamp = string;
 
 // 🔒 Access Control
-export type Visibility = 'public' | 'private' | 'hidden' | 'system';
+export type Visibility =
+  | 'public'
+  | 'private'
+  | 'hidden'
+  | 'system'
+  | 'request_board';
 
 export type UserRole = 'user' | 'admin' | 'moderator';
 
@@ -171,6 +176,8 @@ export interface Quest {
   };
 
   tags?: string[];
+  /** When true this quest appears on the Quest Board */
+  displayOnBoard?: boolean;
   defaultBoardId?: string;
   /** Graph edges between tasks/logs */
   taskGraph?: TaskEdge[];

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -80,6 +80,8 @@ export interface DBQuest {
   };
   createdAt?: string;
   tags?: string[];
+  /** When true this quest appears on the Quest Board */
+  displayOnBoard?: boolean;
   defaultBoardId?: string;
   taskGraph?: TaskEdge[];
 

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -316,35 +316,35 @@ describe('post routes', () => {
     expect((store[1].linkedItems as any[])[0].itemId).toBe('t1');
   });
 
-  it('rejects non-help posts on request board', async () => {
+  it('rejects non-help posts on quest board', async () => {
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'free_speech', boardId: 'request-board' });
+      .send({ type: 'free_speech', boardId: 'quest-board' });
     expect(res.status).toBe(400);
   });
 
-  it('allows request post on request board', async () => {
+  it('allows request post on quest board', async () => {
     postsStore.read.mockReturnValue([]);
     postsStore.write.mockClear();
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'request', boardId: 'request-board' });
+      .send({ type: 'request', boardId: 'quest-board' });
     expect(res.status).toBe(201);
     const written = postsStore.write.mock.calls[0][0][0];
     expect(written.helpRequest).toBe(true);
   });
 
-  it('requires help flag for quest on request board', async () => {
+  it('requires help flag for quest on quest board', async () => {
     postsStore.read.mockReturnValue([]);
     let res = await request(app)
       .post('/posts')
-      .send({ type: 'quest', boardId: 'request-board' });
+      .send({ type: 'quest', boardId: 'quest-board' });
     expect(res.status).toBe(400);
 
     postsStore.write.mockClear();
     res = await request(app)
       .post('/posts')
-      .send({ type: 'quest', boardId: 'request-board', helpRequest: true });
+      .send({ type: 'quest', boardId: 'quest-board', helpRequest: true });
     expect(res.status).toBe(201);
     const writtenQuest = postsStore.write.mock.calls[0][0][0];
     expect(writtenQuest.helpRequest).toBe(true);

--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { Spinner } from './components/ui';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 
 import { ROUTES } from './constants/routes';
 import { AuthProvider } from './contexts/AuthContext';
@@ -66,6 +66,7 @@ const App: React.FC = () => {
                     <Route path={ROUTES.PROFILE} element={<Profile />} />
                     <Route path={ROUTES.QUEST()} element={<Quest />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
+                    <Route path="/board/quests" element={<Navigate to={ROUTES.BOARD('quest-board')} replace />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />
                     <Route path={ROUTES.FLAGGED_QUESTS} element={<FlaggedQuests />} />
                     <Route path={ROUTES.BANNED_QUESTS} element={<BannedQuests />} />

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -55,7 +55,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [helpRequest] = useState(boardId === 'request-board');
+  const [helpRequest] = useState(boardId === 'quest-board');
 
 const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
@@ -63,7 +63,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
     boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
 
   const allowedPostTypes: PostType[] =
-    boardId === 'request-board'
+    boardId === 'quest-board'
       ? ['request', 'quest']
       : boardType === 'quest'
       ? ['quest', 'task', 'log']

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -88,7 +88,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const handleRequestHelp = async () => {
     try {
       const reqPost = await requestHelpForTask(post.id);
-      appendToBoard?.('request-board', reqPost);
+      appendToBoard?.('quest-board', reqPost);
     } catch (err) {
       console.error('[PostCard] Failed to request help:', err);
     }

--- a/ethos-frontend/src/components/quest/CreateQuest.tsx
+++ b/ethos-frontend/src/components/quest/CreateQuest.tsx
@@ -43,7 +43,7 @@ const CreateQuest: React.FC<CreateQuestProps> = ({
   const [collaberatorRoles, setCollaberatorRoles] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [syncRepo, setSyncRepo] = useState(true); // default checked
-  const [helpRequest] = useState(boardId === 'request-board');
+  const [helpRequest] = useState(boardId === 'quest-board');
 
   const syncGit = useSyncGitRepo();
   const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -17,16 +17,16 @@ const HomePage: React.FC = () => {
   const { boards } = useBoardContext();
   const [postType, setPostType] = useState('');
 
-  const requestBoard = boards['request-board'];
+  const questBoard = boards['quest-board'];
   const postTypes = useMemo(() => {
-    if (!requestBoard?.enrichedItems) return [] as string[];
+    if (!questBoard?.enrichedItems) return [] as string[];
     const types = new Set<string>();
-    getRenderableBoardItems(requestBoard.enrichedItems).forEach((it) => {
+    getRenderableBoardItems(questBoard.enrichedItems).forEach((it) => {
       if ('type' in it) types.add((it as any).type);
     });
     return Array.from(types);
-  }, [requestBoard?.enrichedItems]);
-  const showPostFilter = postTypes.length > 1 && (requestBoard?.enrichedItems?.length || 0) > 0;
+  }, [questBoard?.enrichedItems]);
+  const showPostFilter = postTypes.length > 1 && (questBoard?.enrichedItems?.length || 0) > 0;
 
   if (authLoading) {
     return (
@@ -57,16 +57,16 @@ const HomePage: React.FC = () => {
           <PostTypeFilter value={postType} onChange={setPostType} />
         )}
         <Board
-          boardId="request-board"
-          title="🙋 Requests"
+          boardId="quest-board"
+          title="🗺️ Quest Board"
           layout="grid"
           user={user as User}
           hideControls
           filter={postType ? { postType } : {}}
         />
         <div className="text-right">
-          <Link to={ROUTES.BOARD('request-board')} className="text-blue-600 underline text-sm">
-            View Board Details
+          <Link to="/board/quests" className="text-blue-600 underline text-sm">
+            → See all
           </Link>
         </div>
       </section>

--- a/ethos-frontend/tests/CreatePostBoardType.test.tsx
+++ b/ethos-frontend/tests/CreatePostBoardType.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
     selectedBoard: 'b1',
     boards: {
       b1: { id: 'b1', title: 'Board', boardType: 'quest', layout: 'grid', items: [], createdAt: '' },
-      'request-board': { id: 'request-board', title: 'Request', boardType: 'post', layout: 'grid', items: [], createdAt: '' },
+      'quest-board': { id: 'quest-board', title: 'Quest', boardType: 'post', layout: 'grid', items: [], createdAt: '' },
     },
     appendToBoard: jest.fn(),
   }),
@@ -38,10 +38,10 @@ describe('CreatePost board type filtering', () => {
     expect(options).toEqual(['Quest']);
   });
 
-  it('limits post type options for request board', () => {
+  it('limits post type options for quest board', () => {
     render(
       <BrowserRouter>
-        <CreatePost onCancel={() => {}} boardId="request-board" />
+        <CreatePost onCancel={() => {}} boardId="quest-board" />
       </BrowserRouter>
     );
     const select = screen.getByLabelText('Item Type');


### PR DESCRIPTION
## Summary
- rename "Request Board" to "Quest Board" everywhere
- add `displayOnBoard` support and `request_board` visibility type
- update backend board logic for the new Quest Board
- adjust frontend components and routes
- update tests and sample data

## Testing
- `npm test --silent --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --silent --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d9e901c8832f9161c8806b762238