### PR TITLE
Add board type page

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -24,6 +24,7 @@ const Profile = lazy(() => import('./pages/Profile'));
 const Quest = lazy(() => import('./pages/quest/[id]'));
 const Post = lazy(() => import('./pages/post/[id]'));
 const Board = lazy(() => import('./pages/board/[id]'));
+const BoardType = lazy(() => import('./pages/board/[boardType]'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
@@ -67,6 +68,7 @@ const App: React.FC = () => {
                     <Route path={ROUTES.QUEST()} element={<Quest />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />
+                    <Route path={ROUTES.BOARD_TYPE()} element={<BoardType />} />
                     <Route path={ROUTES.FLAGGED_QUESTS} element={<FlaggedQuests />} />
                     <Route path={ROUTES.BANNED_QUESTS} element={<BannedQuests />} />
                   </Route>

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -49,6 +49,13 @@ export const ROUTES = {
      */
     BOARD: (id = ':id') => `/boards/${id}`,
 
+    /**
+     * Listing page for a board type
+     * @param boardType - board category
+     * @returns A route string like `/board/quests`
+     */
+    BOARD_TYPE: (boardType = ':boardType') => `/board/${boardType}`,
+
     FLAGGED_QUESTS: '/admin/flagged-quests',
     BANNED_QUESTS: '/admin/banned-quests',
 

--- a/ethos-frontend/src/pages/board/[boardType].tsx
+++ b/ethos-frontend/src/pages/board/[boardType].tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchAllQuests } from '../../api/quest';
+import { fetchAllPosts } from '../../api/post';
+import ContributionCard from '../../components/contribution/ContributionCard';
+import { Spinner, Button } from '../../components/ui';
+import type { Quest } from '../../types/questTypes';
+import type { Post } from '../../types/postTypes';
+
+const PAGE_SIZE = 12;
+
+const BoardTypePage: React.FC = () => {
+  const { boardType } = useParams<{ boardType: string }>();
+  const [items, setItems] = useState<(Post | Quest)[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [compact, setCompact] = useState(false);
+  const loader = useRef<HTMLDivElement | null>(null);
+
+  // Fetch data based on board type
+  useEffect(() => {
+    const load = async () => {
+      if (!boardType) return;
+      setLoading(true);
+      try {
+        if (boardType === 'quests' || boardType === 'active') {
+          const quests = await fetchAllQuests();
+          const filtered =
+            boardType === 'active'
+              ? quests.filter(q => q.status === 'active')
+              : quests;
+          setItems(filtered);
+        } else if (boardType === 'requests') {
+          const posts = await fetchAllPosts();
+          setItems(posts.filter(p => p.type === 'request' || p.helpRequest));
+        } else {
+          setItems([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [boardType]);
+
+  // Infinite scroll
+  useEffect(() => {
+    const node = loader.current;
+    if (!node) return;
+    const obs = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        setPage(p => p + 1);
+      }
+    });
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [loader.current]);
+
+  const visible = items.slice(0, page * PAGE_SIZE);
+
+  if (loading) return <Spinner />;
+
+  if (!['quests', 'requests', 'active'].includes(boardType || '')) {
+    return <div className="p-6 text-red-500">Invalid board type.</div>;
+  }
+
+  return (
+    <main className="container mx-auto p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold capitalize">{boardType}</h1>
+        <Button variant="secondary" size="sm" onClick={() => setCompact(c => !c)}>
+          {compact ? 'Grid View' : 'List View'}
+        </Button>
+      </div>
+      <div
+        className={
+          compact
+            ? 'flex flex-col gap-4'
+            : 'grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+        }
+      >
+        {visible.map(it => (
+          <ContributionCard key={(it as any).id} contribution={it as any} compact={compact} />
+        ))}
+      </div>
+      {visible.length < items.length && <div ref={loader} className="h-4" />}
+    </main>
+  );
+};
+
+export default BoardTypePage;


### PR DESCRIPTION
## Summary
- add route constant for /board/[boardType]
- support board type page in router
- implement `/board/[boardType]` dynamic page showing quests, requests, or active quests

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Jest couldn't parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855d9faac20832f9a3b8be1bd1e5006