### PR TITLE
Add board search filter component

### DIFF
--- a/ethos-frontend/src/components/board/BoardSearchFilter.tsx
+++ b/ethos-frontend/src/components/board/BoardSearchFilter.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from 'react';
+import { Input, Select, Button } from '../ui';
+import type { option } from '../../constants/options';
+
+export interface FilterState {
+  search: string;
+  tags: string[];
+  status: string;
+  postType: string;
+  role: string;
+  sortBy: string;
+}
+
+interface BoardSearchFilterProps {
+  tags?: string[];
+  onChange?: (filters: FilterState) => void;
+  className?: string;
+}
+
+const STATUS_OPTIONS: option[] = [
+  { value: '', label: 'Any Status' },
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'closed', label: 'Closed' },
+];
+
+const POST_TYPE_OPTIONS: option[] = [
+  { value: '', label: 'All Types' },
+  { value: 'request', label: 'Request' },
+  { value: 'quest_log', label: 'Quest Log' },
+  { value: 'deliverable', label: 'Deliverable' },
+];
+
+const ROLE_OPTIONS: option[] = [
+  { value: '', label: 'Any Role' },
+  { value: 'developer', label: 'Developer' },
+  { value: 'wizard', label: 'Wizard' },
+  { value: 'creator', label: 'Creator' },
+];
+
+const SORT_OPTIONS: option[] = [
+  { value: 'recent', label: 'Most Recent' },
+  { value: 'replies', label: 'Most Replies' },
+  { value: 'trending', label: 'Trending' },
+];
+
+const DEFAULT_FILTERS: FilterState = {
+  search: '',
+  tags: [],
+  status: '',
+  postType: '',
+  role: '',
+  sortBy: 'recent',
+};
+
+const STORAGE_KEY = 'boardFilters';
+
+const BoardSearchFilter: React.FC<BoardSearchFilterProps> = ({
+  tags = [],
+  onChange,
+  className = '',
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const [filters, setFilters] = useState<FilterState>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          return { ...DEFAULT_FILTERS, ...JSON.parse(stored) } as FilterState;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    return DEFAULT_FILTERS;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+    if (onChange) onChange(filters);
+  }, [filters, onChange]);
+
+  const toggleTag = (tag: string) => {
+    setFilters((prev) => ({
+      ...prev,
+      tags: prev.tags.includes(tag)
+        ? prev.tags.filter((t) => t !== tag)
+        : [...prev.tags, tag],
+    }));
+  };
+
+  const reset = () => setFilters(DEFAULT_FILTERS);
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <Input
+        value={filters.search}
+        onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+        placeholder="Search..."
+      />
+      <div className="flex justify-between items-center">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setExpanded((e) => !e)}
+        >
+          + Filters
+        </Button>
+        {expanded && (
+          <Button variant="ghost" size="sm" onClick={reset}>
+            Reset
+          </Button>
+        )}
+      </div>
+      {expanded && (
+        <div className="space-y-3 border rounded-md p-3 bg-surface">
+          {tags.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold mb-1">Tags</p>
+              <div className="flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <label key={tag} className="text-xs flex items-center gap-1">
+                    <input
+                      type="checkbox"
+                      checked={filters.tags.includes(tag)}
+                      onChange={() => toggleTag(tag)}
+                    />
+                    <span>#{tag}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+          <Select
+            value={filters.status}
+            onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+            options={STATUS_OPTIONS}
+          />
+          <Select
+            value={filters.postType}
+            onChange={(e) => setFilters({ ...filters, postType: e.target.value })}
+            options={POST_TYPE_OPTIONS}
+          />
+          <Select
+            value={filters.role}
+            onChange={(e) => setFilters({ ...filters, role: e.target.value })}
+            options={ROLE_OPTIONS}
+          />
+          <Select
+            value={filters.sortBy}
+            onChange={(e) => setFilters({ ...filters, sortBy: e.target.value })}
+            options={SORT_OPTIONS}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BoardSearchFilter;

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -8,6 +8,7 @@ import { useSocket } from '../../hooks/useSocket';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import Board from '../../components/board/Board';
+import BoardSearchFilter from '../../components/board/BoardSearchFilter';
 import { Spinner } from '../../components/ui';
 import { fetchQuestById } from '../../api/quest';
 
@@ -27,6 +28,7 @@ const BoardPage: React.FC = () => {
   const [page, setPage] = useState(1);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
 
   const loadQuest = useCallback(async (questId: string) => {
     try {
@@ -68,6 +70,11 @@ const BoardPage: React.FC = () => {
       } else {
         setQuest(null);
       }
+      const tagSet = new Set<string>();
+      (boardData.enrichedItems || []).forEach((it: any) => {
+        (it.tags || []).forEach((t: string) => tagSet.add(t));
+      });
+      setAvailableTags(Array.from(tagSet));
     }
   }, [boardData, setBoardMeta, loadQuest]);
 
@@ -112,26 +119,31 @@ const BoardPage: React.FC = () => {
 
   return (
     <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
-      <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
-          {editable && (
-            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-              Edit Board
-            </button>
-          )}
-        </div>
+      <div className="flex flex-col md:flex-row gap-6">
+        <BoardSearchFilter tags={availableTags} className="md:w-64" />
+        <div className="flex-1">
+          <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
+            <div className="flex justify-between items-center">
+              <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
+              {editable && (
+                <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                  Edit Board
+                </button>
+              )}
+            </div>
 
-        <Board
-          boardId={id}
-          board={boardData}
-          layout={boardData.layout}
-          quest={quest || undefined}
-          editable={editable}
-          showCreate={editable}
-          onScrollEnd={loadMore}
-          loading={loadingMore}
-        />
+            <Board
+              boardId={id}
+              board={boardData}
+              layout={boardData.layout}
+              quest={quest || undefined}
+              editable={editable}
+              showCreate={editable}
+              onScrollEnd={loadMore}
+              loading={loadingMore}
+            />
+          </div>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- add `BoardSearchFilter` component with expandable filters
- integrate filter panel in board page

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6855da03bea0832fbf6a7a83652bb2e0