### PR TITLE
Implement board visibility filtering

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -6,6 +6,7 @@ import { boardsStore, postsStore, questsStore, usersStore } from '../models/stor
 import { enrichBoard, enrichQuest } from '../utils/enrich';
 import { DEFAULT_PAGE_SIZE } from '../constants';
 import type { BoardData } from '../types/api';
+import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
@@ -217,14 +218,27 @@ router.get(
     }
 
     if (enrich === 'true') {
-      const enriched = enrichBoard({ ...board, items: boardItems }, { posts, quests });
+      const enriched = enrichBoard({ ...board, items: boardItems }, { posts, quests, currentUserId: userId || null });
       res.json(enriched.enrichedItems);
       return;
     }
 
     const items = boardItems
       .map((itemId) => posts.find((p) => p.id === itemId) || quests.find((q) => q.id === itemId))
-      .filter(Boolean);
+      .filter((i): i is DBPost | DBQuest => Boolean(i))
+      .filter((item) => {
+        if ('type' in item) {
+          const p = item as DBPost;
+          return p.type !== 'request' || p.visibility === 'public' || p.visibility === 'request_board' || p.needsHelp === true;
+        }
+        const q = item as DBQuest;
+        if (q.displayOnBoard === false) return false;
+        if (q.status === 'active' && userId) {
+          const participant = q.authorId === userId || (q.collaborators || []).some((c: { userId?: string }) => c.userId === userId);
+          if (!participant) return false;
+        }
+        return true;
+      });
 
   res.json(items);
   }
@@ -259,11 +273,19 @@ router.get(
 
     const boardQuests = boardItems
       .map((itemId) => quests.find((q) => q.id === itemId))
-      .filter((q): q is NonNullable<typeof q> => Boolean(q));
+      .filter((q): q is NonNullable<typeof q> => Boolean(q))
+      .filter((q) => {
+        if (q.displayOnBoard === false) return false;
+        if (q.status === 'active' && userId) {
+          const participant = q.authorId === userId || (q.collaborators || []).some((c: { userId?: string }) => c.userId === userId);
+          if (!participant) return false;
+        }
+        return true;
+      });
 
     if (enrich === 'true') {
       const enriched = boardQuests.map((q) =>
-        enrichQuest(q, { posts, users })
+        enrichQuest(q, { posts, users, currentUserId: userId || null })
       );
       res.json(enriched);
       return;

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -49,6 +49,7 @@ router.post(
       status,
       boardId,
       helpRequest = false,
+      needsHelp = undefined,
     } = req.body;
 
     const finalStatus = status ?? (type === 'task' ? 'To Do' : undefined);
@@ -80,6 +81,7 @@ router.post(
       questId,
       status: finalStatus,
       helpRequest: type === 'request' || helpRequest,
+      needsHelp: type === 'request' ? needsHelp ?? true : undefined,
       nodeId: quest ? generateNodeId({ quest, posts, postType: type, parentPost: parent }) : undefined,
     };
 
@@ -363,6 +365,7 @@ router.post(
       ],
       questId: task.questId || null,
       helpRequest: true,
+      needsHelp: true,
     };
 
     posts.push(requestPost);

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -79,6 +79,7 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     authorId,
     title,
     description,
+    displayOnBoard: req.body.displayOnBoard ?? true,
     visibility: 'public',
     approvalStatus: 'approved',
     flagCount: 0,
@@ -124,10 +125,11 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
           repoId: newQuest.gitRepo.repoId,
           repoUrl: newQuest.gitRepo.repoUrl,
           headCommitId: newQuest.gitRepo.headCommitId,
-          defaultBranch: newQuest.gitRepo.defaultBranch,
-        }
+        defaultBranch: newQuest.gitRepo.defaultBranch,
+      }
       : undefined,
     helpRequest,
+    displayOnBoard: newQuest.displayOnBoard,
   } as DBQuest;
   quests.push(dbQuest);
   questsStore.write(quests);
@@ -164,7 +166,7 @@ router.patch(
     res: Response
   ): void => {
     const { id } = req.params;
-    const { itemId, gitRepo, title, description, tags } = req.body;
+    const { itemId, gitRepo, title, description, tags, displayOnBoard } = req.body;
 
   const quests = questsStore.read();
   const quest = quests.find(q => q.id === id);
@@ -201,6 +203,7 @@ router.patch(
   if (title !== undefined) quest.title = title;
   if (description !== undefined) quest.description = description;
   if (tags !== undefined) quest.tags = tags;
+  if (displayOnBoard !== undefined) quest.displayOnBoard = displayOnBoard;
   if (gitRepo && typeof gitRepo.repoUrl === 'string') {
     quest.gitRepo = { ...(quest.gitRepo || { repoId: '' }), ...quest.gitRepo, repoUrl: gitRepo.repoUrl } as any;
   }

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -5,7 +5,7 @@ export type UUID = string;
 export type Timestamp = string;
 
 // 🔒 Access Control
-export type Visibility = 'public' | 'private' | 'hidden' | 'system';
+export type Visibility = 'public' | 'private' | 'hidden' | 'system' | 'request_board';
 
 export type UserRole = 'user' | 'admin' | 'moderator';
 
@@ -125,6 +125,9 @@ export interface Post {
 
   /** Flag indicating this post is requesting help */
   helpRequest?: boolean;
+
+  /** Whether this request still needs help */
+  needsHelp?: boolean;
 }
 
 
@@ -158,6 +161,9 @@ export interface Quest {
   approvalStatus: ApprovalStatus;
   flagCount?: number;
   status: 'active' | 'completed' | 'archived';
+
+  /** Whether this quest should appear on boards */
+  displayOnBoard?: boolean;
   headPostId: string;
   createdAt?: string;
 

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -50,6 +50,9 @@ export interface DBPost {
   /** Flag indicating this post is requesting help */
   helpRequest?: boolean;
 
+  /** Whether this request still needs help */
+  needsHelp?: boolean;
+
   questId?: string | null;
   questNodeTitle?: string;
   nodeId?: string;
@@ -67,6 +70,9 @@ export interface DBQuest {
   approvalStatus: ApprovalStatus;
   flagCount?: number;
   status: 'active' | 'completed' | 'archived';
+
+  /** Whether this quest should appear on boards */
+  displayOnBoard?: boolean;
 
   headPostId: string;
   linkedPosts: LinkedItem[];

--- a/ethos-backend/src/utils/enrich.ts
+++ b/ethos-backend/src/utils/enrich.ts
@@ -263,7 +263,25 @@ export const enrichBoard = (
 
       return null;
     })
-    .filter((i): i is Post | Quest => i !== null);
+    .filter((i): i is Post | Quest => i !== null)
+    .filter((item) => {
+      if ('type' in item) {
+        const p = item as DBPost;
+        return p.type !== 'request' ||
+          p.visibility === 'public' ||
+          p.visibility === 'request_board' ||
+          p.needsHelp === true;
+      }
+      const q = item as DBQuest;
+      if (q.displayOnBoard === false) return false;
+      if (q.status === 'active' && currentUserId) {
+        const participant =
+          q.authorId === currentUserId ||
+          (q.collaborators || []).some((c) => c.userId === currentUserId);
+        if (!participant) return false;
+      }
+      return true;
+    });
 
   const enrichedItems = board.items
     .map((id) => {
@@ -279,7 +297,25 @@ export const enrichBoard = (
 
       return null;
     })
-    .filter((i): i is EnrichedPost | EnrichedQuest => i !== null);
+    .filter((i): i is EnrichedPost | EnrichedQuest => i !== null)
+    .filter((item) => {
+      if ('type' in item) {
+        const p = item as EnrichedPost;
+        return p.type !== 'request' ||
+          p.visibility === 'public' ||
+          p.visibility === 'request_board' ||
+          p.needsHelp === true;
+      }
+      const q = item as EnrichedQuest;
+      if (q.displayOnBoard === false) return false;
+      if (q.status === 'active' && currentUserId) {
+        const participant =
+          q.authorId === currentUserId ||
+          (q.collaborators || []).some((c) => c.userId === currentUserId);
+        if (!participant) return false;
+      }
+      return true;
+    });
 
   return {
     ...board,

--- a/ethos-frontend/src/types/common.ts
+++ b/ethos-frontend/src/types/common.ts
@@ -1,3 +1,3 @@
 // types/common.ts
-export type Visibility = 'public' | 'private' | 'hidden' | 'system';
+export type Visibility = 'public' | 'private' | 'hidden' | 'system' | 'request_board';
 export type ItemType = 'post' | 'quest' | 'board';

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -50,6 +50,9 @@ export interface Post {
 
   /** Flag indicating this post is requesting help */
   helpRequest?: boolean;
+
+  /** Whether this request still needs help */
+  needsHelp?: boolean;
 }
 
 /**

--- a/ethos-frontend/src/types/questTypes.ts
+++ b/ethos-frontend/src/types/questTypes.ts
@@ -13,6 +13,8 @@ export interface Quest {
   approvalStatus: 'approved' | 'flagged' | 'banned';
   flagCount?: number;
   status: 'active' | 'completed' | 'archived';
+  /** Whether this quest should appear on boards */
+  displayOnBoard?: boolean;
   headPostId: string;
   createdAt?: string;
 


### PR DESCRIPTION
## Summary
- allow "request_board" visibility type
- support `displayOnBoard` and `needsHelp` flags
- filter board items in `enrichBoard`
- update board item routes for new filtering
- expose new flags in frontend types

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855da0f3b54832f9d580681f9288acd