### PR TITLE
Implement featured board filters

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -23,6 +23,18 @@ export const fetchAllPosts = async (): Promise<Post[]> => {
   return res.data;
 };
 
+export const fetchRecentPosts = async (
+  userId?: string,
+  hops: number = 1
+): Promise<Post[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  params.set('hops', hops.toString());
+  const url = `${BASE_URL}/recent${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};
+
 /**
  * ➕ Add a new post
  * @param data - Partial post data

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -43,8 +43,19 @@ export const fetchAllQuests = async (): Promise<Quest[]> => {
   return res.data;
 };
 
-export const fetchFeaturedQuests = async (): Promise<Quest[]> => {
-  const res = await axiosWithAuth.get(`${BASE_URL}/featured`);
+export const fetchFeaturedQuests = async (userId?: string): Promise<Quest[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  const url = `${BASE_URL}/featured${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};
+
+export const fetchActiveQuests = async (userId?: string): Promise<Quest[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  const url = `${BASE_URL}/active${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { fetchFeaturedQuests } from '../../api/quest';
+import { useAuth } from '../../contexts/AuthContext';
 import type { Quest } from '../../types/questTypes';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
@@ -13,6 +14,7 @@ const CARD_WIDTH = 240; // px
 const GAP = 16; // px gap between cards
 
 const FeaturedQuestBoard: React.FC = () => {
+  const { user } = useAuth();
   const [quests, setQuests] = useState<QuestWithScore[]>([]);
   const [loading, setLoading] = useState(true);
   const [current, setCurrent] = useState(0);
@@ -21,7 +23,7 @@ const FeaturedQuestBoard: React.FC = () => {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchFeaturedQuests();
+        const data = await fetchFeaturedQuests(user?.id);
         setQuests(data || []);
       } catch (err) {
         console.error('[FeaturedQuestBoard] Failed to load quests', err);
@@ -30,7 +32,7 @@ const FeaturedQuestBoard: React.FC = () => {
       }
     };
     load();
-  }, []);
+  }, [user?.id]);
 
   const maxDots = 5;
   const visibleIndices = useMemo(() => {


### PR DESCRIPTION
## Summary
- filter featured quests by involvement in backend
- add active quests API route
- expose recent posts API route
- support userId filtering from frontend
- show only uninvolved featured quests on homepage

## Testing
- `npm test` *(fails: jest environment issues)*
- `npm test` in `ethos-backend` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855e10fa67c832f97076453ad9a815a