### PR TITLE
Implement ActiveQuestBoard component

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -225,3 +225,15 @@ export const getPropagationStatus = async (
   const res = await axiosWithAuth.get(`${BASE_URL}/${postId}/propagation-status`);
   return res.data;
 };
+
+export const fetchRecentPosts = async (
+  userId?: string,
+  hops = 1
+): Promise<Post[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  if (hops) params.set('hops', hops.toString());
+  const url = `${BASE_URL}/recent${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -43,8 +43,25 @@ export const fetchAllQuests = async (): Promise<Quest[]> => {
   return res.data;
 };
 
-export const fetchFeaturedQuests = async (): Promise<Quest[]> => {
-  const res = await axiosWithAuth.get(`${BASE_URL}/featured`);
+export const fetchFeaturedQuests = async (
+  userId?: string
+): Promise<Quest[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  const url = `${BASE_URL}/featured${
+    params.toString() ? `?${params.toString()}` : ''
+  }`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};
+
+export const fetchActiveQuests = async (userId?: string): Promise<Quest[]> => {
+  const params = new URLSearchParams();
+  if (userId) params.set('userId', userId);
+  const url = `${BASE_URL}/active${
+    params.toString() ? `?${params.toString()}` : ''
+  }`;
+  const res = await axiosWithAuth.get(url);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchActiveQuests } from '../../api/quest';
+import { fetchRecentPosts } from '../../api/post';
+import Board from '../board/Board';
+import { Spinner } from '../ui';
+import { ROUTES } from '../../constants/routes';
+import type { Quest } from '../../types/questTypes';
+import type { Post } from '../../types/postTypes';
+import type { BoardData } from '../../types/boardTypes';
+
+interface QuestWithLog extends Quest {
+  lastLog?: Post;
+}
+
+const ActiveQuestBoard: React.FC = () => {
+  const { user } = useAuth();
+  const [board, setBoard] = useState<BoardData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [quests, recent] = await Promise.all([
+          fetchActiveQuests(user.id),
+          fetchRecentPosts(user.id, 1),
+        ]);
+        const questMap: Record<string, QuestWithLog> = {};
+        quests.forEach(q => {
+          questMap[q.id] = { ...q };
+        });
+        recent.forEach(p => {
+          if (!p.questId || !questMap[p.questId]) return;
+          const current = questMap[p.questId];
+          if (
+            !current.lastLog ||
+            (p.createdAt || p.timestamp) > (current.lastLog.createdAt || current.lastLog.timestamp)
+          ) {
+            questMap[p.questId] = { ...current, lastLog: p };
+          }
+        });
+        const enriched = Object.values(questMap);
+        if (enriched.length) {
+          setBoard({
+            id: 'active-quests',
+            title: 'Active Quests',
+            boardType: 'quest',
+            layout: 'grid',
+            items: enriched.map(q => q.id),
+            enrichedItems: enriched,
+            createdAt: new Date().toISOString(),
+          });
+        } else {
+          setBoard(null);
+        }
+      } catch (err) {
+        console.warn('[ActiveQuestBoard] Failed to load quests', err);
+        setBoard(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [user]);
+
+  if (!user) return null;
+  if (loading) return <Spinner />;
+  if (!board) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">🧭 Active Quests</h2>
+        <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
+          → See all
+        </Link>
+      </div>
+      <Board board={board} layout="grid" hideControls compact />
+    </div>
+  );
+};
+
+export default ActiveQuestBoard;

--- a/ethos-frontend/src/pages/board/[boardType].tsx
+++ b/ethos-frontend/src/pages/board/[boardType].tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchAllQuests } from '../../api/quest';
+import { fetchAllQuests, fetchActiveQuests } from '../../api/quest';
 import { fetchAllPosts } from '../../api/post';
 import ContributionCard from '../../components/contribution/ContributionCard';
 import { Spinner, Button } from '../../components/ui';
@@ -24,12 +24,13 @@ const BoardTypePage: React.FC = () => {
       setLoading(true);
       try {
         if (boardType === 'quests' || boardType === 'active') {
-          const quests = await fetchAllQuests();
-          const filtered =
-            boardType === 'active'
-              ? quests.filter(q => q.status === 'active')
-              : quests;
-          setItems(filtered);
+          if (boardType === 'active') {
+            const active = await fetchActiveQuests();
+            setItems(active);
+          } else {
+            const quests = await fetchAllQuests();
+            setItems(quests);
+          }
         } else if (boardType === 'requests') {
           const posts = await fetchAllPosts();
           setItems(posts.filter(p => p.type === 'request' || p.helpRequest));


### PR DESCRIPTION
## Summary
- add frontend API helpers `fetchActiveQuests` and `fetchRecentPosts`
- extend `fetchFeaturedQuests` to support userId
- implement `ActiveQuestBoard` component for displaying user's active quests
- update `/board/[boardType]` page to use new active quests API

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855e1154548832f9bed276df632650a