### PR TITLE
Fix duplicate export in posts API

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -237,15 +237,3 @@ export const getPropagationStatus = async (
   const res = await axiosWithAuth.get(`${BASE_URL}/${postId}/propagation-status`);
   return res.data;
 };
-
-export const fetchRecentPosts = async (
-  userId?: string,
-  hops = 1
-): Promise<Post[]> => {
-  const params = new URLSearchParams();
-  if (userId) params.set('userId', userId);
-  if (hops) params.set('hops', hops.toString());
-  const url = `${BASE_URL}/recent${params.toString() ? `?${params.toString()}` : ''}`;
-  const res = await axiosWithAuth.get(url);
-  return res.data;
-};


### PR DESCRIPTION
## Summary
- remove duplicated `fetchRecentPosts` export causing build errors

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855e51b50dc832fb4dfd94f8e2ec25f