### PR TITLE
Add active quest board to homepage

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -14,9 +14,6 @@ const getQuestBoardItems = (
   posts: ReturnType<typeof postsStore.read>,
   quests: ReturnType<typeof questsStore.read>
 ) => {
-  const questIds = quests
-    .filter((q) => (q as any).displayOnBoard)
-    .map((q) => q.id);
   const requestIds = posts
     .filter(
       (p) =>
@@ -26,7 +23,7 @@ const getQuestBoardItems = (
           p.helpRequest)
     )
     .map((p) => p.id);
-  return [...questIds, ...requestIds];
+  return requestIds;
 };
 
 const router = express.Router();

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { useBoardContext } from '../contexts/BoardContext';
 import Board from '../components/board/Board';
 import PostTypeFilter from '../components/board/PostTypeFilter';
 import FeaturedQuestBoard from '../components/quest/FeaturedQuestBoard';
+import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
 import { Spinner } from '../components/ui';
@@ -69,6 +70,10 @@ const HomePage: React.FC = () => {
             → See all
           </Link>
         </div>
+      </section>
+
+      <section>
+        <ActiveQuestBoard />
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- display quests user is working on via `ActiveQuestBoard`
- clean quest-board API to only return help request posts

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6855e79db738832fb6ae94fdfa555fc4