### PR TITLE
Add active quest board to homepage

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -11,12 +11,8 @@ import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
 const getQuestBoardItems = (
-  posts: ReturnType<typeof postsStore.read>,
-  quests: ReturnType<typeof questsStore.read>
+  posts: ReturnType<typeof postsStore.read>
 ) => {
-  const questIds = quests
-    .filter((q) => (q as any).displayOnBoard)
-    .map((q) => q.id);
   const requestIds = posts
     .filter(
       (p) =>
@@ -26,7 +22,7 @@ const getQuestBoardItems = (
           p.helpRequest)
     )
     .map((p) => p.id);
-  return [...questIds, ...requestIds];
+  return requestIds;
 };
 
 const router = express.Router();
@@ -61,7 +57,7 @@ router.get(
       }
 
       if (board.id === 'quest-board') {
-        const items = getQuestBoardItems(posts, quests);
+        const items = getQuestBoardItems(posts);
         return { ...board, items };
       }
 
@@ -193,7 +189,7 @@ router.get(
     const end = start + pageSize;
     let boardItems = board.items;
     if (board.id === 'quest-board') {
-      boardItems = getQuestBoardItems(posts, quests);
+      boardItems = getQuestBoardItems(posts);
     } else if (userId && board.id === 'my-posts') {
       boardItems = posts.filter(p => p.authorId === userId).map(p => p.id);
     } else if (userId && board.id === 'my-quests') {
@@ -238,7 +234,7 @@ router.get(
 
     let boardItems = board.items;
     if (board.id === 'quest-board') {
-      boardItems = getQuestBoardItems(posts, quests);
+      boardItems = getQuestBoardItems(posts);
     } else if (userId && board.id === 'my-posts') {
       boardItems = posts.filter(p => p.authorId === userId).map(p => p.id);
     } else if (userId && board.id === 'my-quests') {
@@ -296,7 +292,7 @@ router.get(
 
     let boardItems = board.items;
     if (board.id === 'quest-board') {
-      boardItems = getQuestBoardItems(posts, quests).filter(id =>
+      boardItems = getQuestBoardItems(posts).filter(id =>
         quests.find(q => q.id === id)
       );
     } else if (userId && board.id === 'my-quests') {

--- a/ethos-frontend/src/components/feed/TimelineFeed.tsx
+++ b/ethos-frontend/src/components/feed/TimelineFeed.tsx
@@ -84,7 +84,7 @@ const TimelineFeed: React.FC<TimelineFeedProps> = ({ boardId = 'timeline-board' 
   return (
     <div
       onScroll={handleScroll}
-      className="grid gap-4 overflow-auto max-h-[80vh] snap-y snap-mandatory p-2"
+      className="grid gap-4 overflow-auto max-h-[65vh] snap-y snap-mandatory p-2"
     >
       <Suspense fallback={<Spinner />}>
         {items.map(item =>

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { useBoardContext } from '../contexts/BoardContext';
 import Board from '../components/board/Board';
 import PostTypeFilter from '../components/board/PostTypeFilter';
 import FeaturedQuestBoard from '../components/quest/FeaturedQuestBoard';
+import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
 import { Spinner } from '../components/ui';
@@ -69,6 +70,10 @@ const HomePage: React.FC = () => {
             → See all
           </Link>
         </div>
+      </section>
+
+      <section>
+        <ActiveQuestBoard />
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- display quests user is working on via `ActiveQuestBoard`
- clean quest-board API to only return help request posts
- fix quest board helper and adjust timeline size

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6855e79db738832fb6ae94fdfa555fc4