### PR TITLE
Fix active quest board loading

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -26,8 +26,13 @@ const ActiveQuestBoard: React.FC = () => {
       setLoading(true);
       try {
         const [quests, recent] = await Promise.all([
-          fetchActiveQuests(user.id),
-          fetchRecentPosts(user.id, 1),
+          // Fetch all active quests. Passing a userId would exclude
+          // quests the current user participates in, which leads to
+          // an empty board when all quests belong to this user.
+          fetchActiveQuests(),
+          // Recent posts from any user help identify the latest log
+          // entry for each quest.
+          fetchRecentPosts(undefined, 1),
         ]);
         const questMap: Record<string, QuestWithLog> = {};
         quests.forEach(q => {


### PR DESCRIPTION
## Summary
- show all active quests on the home screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855ebb63df8832fa082daaefc6c9d1b