### PR TITLE
Improve active quest board display

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -25,6 +25,8 @@ interface GraphLayoutProps {
   condensed?: boolean;
   /** Show status dropdowns for tasks */
   showStatus?: boolean;
+  /** Display side inspector panel */
+  showInspector?: boolean;
   /** Notify parent when a node is selected */
   onSelectNode?: (n: Post) => void;
   onScrollEnd?: () => void;
@@ -58,6 +60,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   compact = false,
   condensed = false,
   showStatus = true,
+  showInspector = true,
   onSelectNode,
   onScrollEnd,
   loadingMore = false,
@@ -343,21 +346,23 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           </div>
         )}
       </div>
-      <div
-        className={
-          'fixed top-0 right-0 h-full w-80 bg-surface dark:bg-background shadow-lg transform transition-transform duration-300 ' +
-          (activeNodeId ? 'translate-x-0' : 'translate-x-full')
-        }
-        data-testid="quest-node-inspector"
-      >
-        {activeNode && (
-          <QuestNodeInspector
-            node={activeNode}
-            user={user}
-            onClose={() => setActiveNodeId(null)}
-          />
-        )}
-      </div>
+      {showInspector && (
+        <div
+          className={
+            'fixed top-0 right-0 h-full w-80 bg-surface dark:bg-background shadow-lg transform transition-transform duration-300 ' +
+            (activeNodeId ? 'translate-x-0' : 'translate-x-full')
+          }
+          data-testid="quest-node-inspector"
+        >
+          {activeNode && (
+            <QuestNodeInspector
+              node={activeNode}
+              user={user}
+              onClose={() => setActiveNodeId(null)}
+            />
+          )}
+        </div>
+      )}
     </DndContext>
   );
 };

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -195,7 +195,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                     key={item.id}
                     item={item}
                     user={user}
-                    compact={compact}
+                    compact={true}
                     onEdit={onEdit}
                     onDelete={onDelete}
                   />
@@ -221,19 +221,22 @@ const GridLayout: React.FC<GridLayoutProps> = ({
           ref={containerRef}
           className="flex overflow-x-auto gap-4 snap-x snap-mandatory px-2 pb-4 scroll-smooth"
         >
-          {items.map((item) => (
-            <div key={item.id} className="snap-center min-w-[280px] flex-shrink-0">
+          {items.map((item, idx) => (
+            <div
+              key={item.id}
+              className={`snap-center flex-shrink-0 transition-all ${idx === index ? 'w-full sm:w-[640px]' : 'w-64 sm:w-[300px] opacity-80'}`}
+            >
               <ContributionCard
                 contribution={item}
                 user={user}
-                compact={compact}
+                compact={compact || idx !== index}
                 onEdit={onEdit}
                 onDelete={onDelete}
               />
             </div>
           ))}
         </div>
-        {items.length > 3 && (
+        {items.length > 1 && (
           <>
             <button
               type="button"
@@ -250,14 +253,20 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               ▶
             </button>
             <div className="flex justify-center mt-2">
-              {items.map((_, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={() => setIndex(i)}
-                  className={`mx-1 w-2 h-2 rounded-full ${i === index ? 'bg-accent' : 'bg-background'} focus:outline-none`}
-                />
-              ))}
+              {(() => {
+                const dots = items.length > 3 ? [index - 1, index, index + 1] : items.map((_, i) => i);
+                return dots.map((i, idx) => {
+                  const actual = ((i % items.length) + items.length) % items.length;
+                  return (
+                    <button
+                      key={idx}
+                      type="button"
+                      onClick={() => setIndex(actual)}
+                      className={`mx-1 w-2 h-2 rounded-full ${actual === index ? 'bg-accent' : 'bg-background'} focus:outline-none`}
+                    />
+                  );
+                });
+              })()}
             </div>
           </>
         )}

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -99,7 +99,7 @@ const ActiveQuestBoard: React.FC = () => {
           → See all
         </Link>
       </div>
-      <Board board={board} layout="grid" hideControls compact />
+      <Board board={board} layout="horizontal" hideControls />
     </div>
   );
 };

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -16,6 +16,9 @@ import LinkControls from '../controls/LinkControls';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
 import QuestNodeInspector from './QuestNodeInspector';
+import PostCard from '../post/PostCard';
+import FileEditorPanel from './FileEditorPanel';
+import StatusBoardPanel from './StatusBoardPanel';
 
 
 /**
@@ -211,6 +214,11 @@ const QuestCard: React.FC<QuestCardProps> = ({
     }
     return (
       <>
+        {selectedNode && (
+          <div className="mb-2">
+            <PostCard post={selectedNode} user={user} questId={quest.id} />
+          </div>
+        )}
         {showTaskForm && (
           <div className="mb-4">
             <CreatePost
@@ -248,6 +256,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
           questId={quest.id}
           showStatus={false}
           onSelectNode={setSelectedNode}
+          showInspector={false}
         />
       </>
     );
@@ -273,8 +282,13 @@ const QuestCard: React.FC<QuestCardProps> = ({
       );
     }
     return (
-      <div className="p-2">
-        <QuestNodeInspector questId={quest.id} node={selectedNode} user={user} />
+      <div className="space-y-2 p-2">
+        <FileEditorPanel
+          questId={quest.id}
+          filePath={selectedNode.gitFilePath || 'file.txt'}
+          content={selectedNode.content}
+        />
+        <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
       </div>
     );
   };
@@ -283,96 +297,105 @@ const QuestCard: React.FC<QuestCardProps> = ({
     if (!expanded) return null;
     switch (activeTab) {
       case "logs":
-        return (
-          <>
-            {showLogForm && (
-              <div className="mb-4">
-                <CreatePost
-                  initialType="log"
-                  questId={quest.id}
-                  boardId={`log-${quest.id}`}
-                  onSave={(p) => {
-                    setLogs((prev) => [...prev, p]);
-                    setShowLogForm(false);
-                  }}
-                  onCancel={() => setShowLogForm(false)}
-                />
-              </div>
-            )}
-            <GridLayout
-              questId={quest.id}
-              items={logs}
-              user={user}
-              layout="vertical"
-              editable={canEdit}
-            />
-            <div className="text-right mt-2">
-              {canEdit ? (
-                <Button
-                  size="sm"
-                  variant="contrast"
-                  onClick={() => setShowLogForm(true)}
-                >
-                  + Add Item
-                </Button>
-              ) : (
-                <Button
-                  size="sm"
-                  variant="contrast"
-                  onClick={handleJoinRequest}
-                >
-                  Request to Join
-                </Button>
+        if (!selectedNode)
+          return (
+            <>
+              {showLogForm && (
+                <div className="mb-4">
+                  <CreatePost
+                    initialType="log"
+                    questId={quest.id}
+                    boardId={`log-${quest.id}`}
+                    onSave={(p) => {
+                      setLogs((prev) => [...prev, p]);
+                      setShowLogForm(false);
+                    }}
+                    onCancel={() => setShowLogForm(false)}
+                  />
+                </div>
               )}
-            </div>
-          </>
+              <GridLayout
+                questId={quest.id}
+                items={logs}
+                user={user}
+                layout="vertical"
+                editable={canEdit}
+              />
+              <div className="text-right mt-2">
+                {canEdit ? (
+                  <Button
+                    size="sm"
+                    variant="contrast"
+                    onClick={() => setShowLogForm(true)}
+                  >
+                    + Add Item
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="contrast"
+                    onClick={handleJoinRequest}
+                  >
+                    Request to Join
+                  </Button>
+                )}
+              </div>
+            </>
+          );
+        return (
+          <LogThreadPanel questId={quest.id} node={selectedNode} user={user} />
         );
       case "file":
         return renderFileView();
       case "status":
-        return (
-          <>
-            {showTaskForm && (
-              <div className="mb-4">
-                <CreatePost
-                  initialType="task"
-                  questId={quest.id}
-                  boardId={`map-${quest.id}`}
-                  onSave={(p) => {
-                    setLogs((prev) => [...prev, p]);
-                    setShowTaskForm(false);
-                  }}
-                  onCancel={() => setShowTaskForm(false)}
-                />
-              </div>
-            )}
-            <GridLayout
-              questId={quest.id}
-              items={logs}
-              user={user}
-              layout="kanban"
-              editable={canEdit}
-            />
-            <div className="text-right mt-2">
-              {canEdit ? (
-                <Button
-                  size="sm"
-                  variant="contrast"
-                  onClick={() => setShowTaskForm(true)}
-                >
-                  + Add Item
-                </Button>
-              ) : (
-                <Button
-                  size="sm"
-                  variant="contrast"
-                  onClick={handleJoinRequest}
-                >
-                  Request to Join
-                </Button>
+        if (!selectedNode)
+          return (
+            <>
+              {showTaskForm && (
+                <div className="mb-4">
+                  <CreatePost
+                    initialType="task"
+                    questId={quest.id}
+                    boardId={`map-${quest.id}`}
+                    onSave={(p) => {
+                      setLogs((prev) => [...prev, p]);
+                      setShowTaskForm(false);
+                    }}
+                    onCancel={() => setShowTaskForm(false)}
+                  />
+                </div>
               )}
-            </div>
-          </>
+              <GridLayout
+                questId={quest.id}
+                items={logs}
+                user={user}
+                layout="kanban"
+                editable={canEdit}
+                compact
+              />
+              <div className="text-right mt-2">
+                {canEdit ? (
+                  <Button
+                    size="sm"
+                    variant="contrast"
+                    onClick={() => setShowTaskForm(true)}
+                  >
+                    + Add Item
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="contrast"
+                    onClick={handleJoinRequest}
+                  >
+                    Request to Join
+                  </Button>
+                )}
+              </div>
+            </>
+          );
+        return (
+          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
         );
       case 'map':
         return (
@@ -415,6 +438,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
               user={user}
               edges={questData.taskGraph}
               condensed
+              showInspector={false}
             />
           </>
         );
@@ -464,7 +488,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       </div>
       {expanded && (
         <div className="flex flex-col md:flex-row gap-4">
-          <div className="md:w-1/2 lg:w-1/3 md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700">
+          <div className="md:w-1/3 lg:w-1/4 md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700">
             {renderMap()}
           </div>
           <div className="flex-1 md:pl-4">{renderRightPanel()}</div>

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -8,14 +8,16 @@ interface QuestNodeInspectorProps {
   questId: string;
   node: Post | null;
   user?: User;
+  showPost?: boolean;
+  showLogs?: boolean;
 }
 
-const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({ questId, node, user }) => {
+const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({ questId, node, user, showPost = true, showLogs = true }) => {
   if (!node) return <div className="p-2 text-sm">Select a task</div>;
   return (
     <div className="space-y-4">
-      <PostCard post={node} user={user} questId={questId} />
-      <LogThreadPanel questId={questId} node={node} user={user} />
+      {showPost && <PostCard post={node} user={user} questId={questId} />}
+      {showLogs && <LogThreadPanel questId={questId} node={node} user={user} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- switch active quest board to horizontal layout
- increase quest card width in horizontal layout
- simplify navigation dots for large quest lists
- show file editor and status panels when selecting tasks

## Testing
- `npm test --silent` *(no output)*
- `npx tsc -p ethos-frontend/tsconfig.app.json` *(failed to compile: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855f6a8ae9c832f8296276efd905cfb