### PR TITLE
Improve quest panel layout

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -154,7 +154,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           {...listeners}
         >
           <div
-            className="mb-2 flex items-center cursor-pointer"
+            className="flex items-center text-xs cursor-pointer py-0.5 px-1 truncate"
             style={{ marginLeft: depth * 16 }}
             onClick={() => {
               setExpanded(true);
@@ -163,9 +163,10 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             }}
             title={snippet}
           >
-            <CompactNodeCard post={node} showStatus={showStatus} />
+            <span className="mr-1 select-none">{icon}</span>
+            <span className="truncate">{snippet}{node.content && node.content.length > 30 ? '…' : ''}</span>
             {edge && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 ml-1 flex items-center">
+              <span className="text-[10px] text-gray-500 dark:text-gray-400 ml-1 flex items-center">
                 {edge.label || edge.type}
                 {onRemoveEdge && (
                   <button


### PR DESCRIPTION
## Summary
- show selected node above right panel
- render condensed nodes with a minimal style
- allow resizing quest panel columns with a draggable divider

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-react-hooks')*
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_685601cc1d40832fb2ba2abc4dd2f628