### PR TITLE
Implement task root default and node double-click

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -26,6 +26,8 @@ Node IDs are generated in [`nodeIdUtils.ts`](../ethos-backend/src/utils/nodeIdUt
 
 Every quest has a hidden root node. When a quest is created without a `headPostId`, the map starts from this automatic root. If a `headPostId` is set, edges originate from that post instead. New tasks link from the root (or head post) so that the map always has a starting point.
 
+The first task created in a quest uses the node ID `T00`. Root logs or files should nest under this task, for example `Q:demo:T00:L00`.
+
 ## Posts and edges in the quest map
 
 The `/api/quests/:id/map` endpoint returns:

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -97,7 +97,7 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     description = '',
     tags = [],
     fromPostId = '',
-    headType = 'log',
+    headType = 'task',
     helpRequest = false,
   } = req.body;
 

--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -240,6 +240,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           style={{ marginLeft: depth * 16 }}
           className="mb-6 flex items-start space-x-2 cursor-pointer"
           onClick={() => onSelect(node)}
+          onDoubleClick={() => onSelect(node)}
         >
           <span className="text-xl select-none cursor-grab">
             {icon}


### PR DESCRIPTION
## Summary
- default quest `headType` to `task` so first node uses T00
- mention root T00 nodes in quest map docs
- allow double-click to select graph nodes

## Testing
- `npx tsc -p ethos-backend/tsconfig.json` *(fails: Could not find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68560e4877b4832fbbee2894a130d481