### PR TITLE
Convert root nodeIds to tasks

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -18,7 +18,7 @@ Q:<quest-slug>:<segment><number>
   - `I` – issue
 - `<number>` – a zero‑padded counter starting at `00` for each segment within a quest.
 
-Example: the first task in the `Ethos` quest becomes `Q:ethos:T00`. A reply log on that task would be `Q:ethos:T00:L01`.
+Example: the first task in the `Ethos` quest becomes `Q:ethos:T01`. A reply log on that task would be `Q:ethos:T01:L01`.
 
 Node IDs are generated in [`nodeIdUtils.ts`](../ethos-backend/src/utils/nodeIdUtils.ts) when a post is created or its quest/link changes.
 

--- a/ethos-backend/src/data/posts.json
+++ b/ethos-backend/src/data/posts.json
@@ -12,7 +12,7 @@
     "repostedFrom": null,
     "linkedItems": [],
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
-    "nodeId": "Q:ethos:L00",
+    "nodeId": "Q:ethos:T00",
     "questNodeTitle": "Ethos"
   },
   {
@@ -35,7 +35,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "In Progress",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T00",
+    "nodeId": "Q:ethos:T01",
     "questNodeTitle": "test out ethos platform"
   },
   {
@@ -58,7 +58,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "In Progress",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T01",
+    "nodeId": "Q:ethos:T02",
     "questNodeTitle": "test how multiple todo is supported"
   },
   {
@@ -81,7 +81,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "In Progress",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T02",
+    "nodeId": "Q:ethos:T03",
     "questNodeTitle": "add projects"
   },
   {
@@ -97,7 +97,7 @@
     "repostedFrom": null,
     "linkedItems": [],
     "questId": "41f1e562-2389-4717-a9c4-15abb17ded27",
-    "nodeId": "Q:graduateapplications:L00",
+    "nodeId": "Q:graduateapplications:T00",
     "questNodeTitle": "Graduate Applications"
   },
   {
@@ -154,7 +154,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "To Do",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T03",
+    "nodeId": "Q:ethos:T04",
     "questNodeTitle": "update quest"
   },
   {
@@ -177,7 +177,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "To Do",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T04",
+    "nodeId": "Q:ethos:T05",
     "questNodeTitle": "forat quest to when expanded to show left = file/f…"
   },
   {
@@ -201,7 +201,7 @@
     "questId": "91544b2a-a2c0-408f-b21b-15845869a23b",
     "status": "To Do",
     "helpRequest": false,
-    "nodeId": "Q:ethos:T05",
+    "nodeId": "Q:ethos:T06",
     "questNodeTitle": "testing headers"
   },
   {
@@ -217,7 +217,7 @@
     "repostedFrom": null,
     "linkedItems": [],
     "questId": "8c79bf6c-0620-443f-b884-9f2ea3a77ab9",
-    "nodeId": "Q:testquest:L00",
+    "nodeId": "Q:testquest:T00",
     "questNodeTitle": "test quest"
   },
   {
@@ -233,7 +233,7 @@
     "repostedFrom": null,
     "linkedItems": [],
     "questId": "8dcab4d0-207c-4bfe-b84f-155688f46be0",
-    "nodeId": "Q:anothertest:L00",
+    "nodeId": "Q:anothertest:T00",
     "questNodeTitle": "another test"
   },
   {
@@ -249,7 +249,8 @@
     "repostedFrom": null,
     "linkedItems": [],
     "questId": "d78fd6e3-3357-4009-a15b-dfa47022840c",
-    "nodeId": "Q:onemoretest:L00",
+    "nodeId": "Q:onemoretest:T00",
     "questNodeTitle": "one more test"
   }
 ]
+


### PR DESCRIPTION
## Summary
- shift quest root posts from `L00` to `T00`
- renumber `Ethos` quest tasks to start at `T01`
- update example node IDs in documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685616bf19fc832fa9da79ca063f8cb1