### PR TITLE
Add double-click open to node icon

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -233,8 +233,6 @@ const GraphNode: React.FC<GraphNodeProps> = ({
         ref={setNodeRef}
         style={style}
         className={isDragging ? 'opacity-50' : ''}
-        {...attributes}
-        {...listeners}
       >
         <div
           style={{ marginLeft: depth * 16 }}
@@ -246,7 +244,16 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             )
           }
         >
-          <span className="text-xl select-none cursor-grab">
+          <span
+            className="text-xl select-none cursor-grab"
+            {...attributes}
+            {...listeners}
+            onDoubleClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
+              )
+            }
+          >
             {icon}
           </span>
           <ContributionCard


### PR DESCRIPTION
## Summary
- allow double-clicking the node icon to open a task
- stop using the entire node as the drag handle so double-click works reliably

## Testing
- `./setup.sh`
- `npm test --silent --prefix ethos-frontend` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68561eeb3d1c832f87a3a7477018dae0