### PR TITLE
Add minimal task card

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Select, StatusBadge } from '../ui';
+import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
+import type { Post, QuestTaskStatus } from '../../types/postTypes';
+
+interface TaskPreviewCardProps {
+  post: Post;
+  onUpdate?: (updated: Post) => void;
+}
+
+const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate }) => {
+  const [status, setStatus] = useState<QuestTaskStatus>(post.status || 'To Do');
+  const [taskType, setTaskType] = useState(post.taskType || 'abstract');
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value as QuestTaskStatus;
+    setStatus(val);
+    onUpdate?.({ ...post, status: val });
+  };
+  const handleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value as 'file' | 'folder' | 'abstract';
+    setTaskType(val);
+    onUpdate?.({ ...post, taskType: val });
+  };
+
+  return (
+    <div className="border border-secondary rounded bg-surface p-2 text-xs space-y-1">
+      <div className="font-semibold text-sm">{post.content}</div>
+      {post.gitFilePath && (
+        <div className="text-secondary">{post.gitFilePath}</div>
+      )}
+      <div className="flex items-center gap-2">
+        <StatusBadge status={status} />
+        <Select
+          value={status}
+          onChange={handleStatusChange}
+          options={STATUS_OPTIONS as any}
+          className="text-xs"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Select
+          value={taskType}
+          onChange={handleTypeChange}
+          options={TASK_TYPE_OPTIONS as any}
+          className="text-xs"
+        />
+        {taskType === 'file' && (
+          <button className="text-accent underline text-xs">Make Main File</button>
+        )}
+        {taskType === 'folder' && (
+          <button className="text-accent underline text-xs">Organize Dependencies</button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskPreviewCard;

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -16,7 +16,7 @@ import LinkControls from '../controls/LinkControls';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
 import QuestNodeInspector from './QuestNodeInspector';
-import PostCard from '../post/PostCard';
+import TaskPreviewCard from '../post/TaskPreviewCard';
 import FileEditorPanel from './FileEditorPanel';
 import StatusBoardPanel from './StatusBoardPanel';
 import LogThreadPanel from './LogThreadPanel';
@@ -230,7 +230,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
         <>
           {selectedNode && (
             <div className="mb-2">
-              <PostCard post={selectedNode} user={user} questId={quest.id} />
+              <TaskPreviewCard post={selectedNode} />
             </div>
           )}
           <Select
@@ -247,7 +247,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       <>
         {selectedNode && (
           <div className="mb-2">
-            <PostCard post={selectedNode} user={user} questId={quest.id} />
+            <TaskPreviewCard post={selectedNode} />
           </div>
         )}
         <Select
@@ -296,15 +296,15 @@ const QuestCard: React.FC<QuestCardProps> = ({
                         onCancel={() => setShowAddItemForm(false)}
                       />
                     )}
-                    <PostCard
-                      post={task}
-                      user={user}
-                      questId={quest.id}
-                      replyOverride={{
-                        label: 'Add Item',
-                        onClick: () => setShowAddItemForm(true),
-                      }}
-                    />
+                    <TaskPreviewCard post={task} />
+                    <div className="text-right">
+                      <button
+                        className="text-accent underline text-xs"
+                        onClick={() => setShowAddItemForm(true)}
+                      >
+                        Add Item
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- add a TaskPreviewCard for simplified task display
- show TaskPreviewCard in quest map panels

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest couldn't find jsdom and more)*

------
https://chatgpt.com/codex/tasks/task_e_685626732cb4832f8b916c73a01fb118