### PR TITLE
Add add-post buttons and user feed

### DIFF
--- a/ethos-frontend/src/components/feed/ActivityFeed.tsx
+++ b/ethos-frontend/src/components/feed/ActivityFeed.tsx
@@ -5,6 +5,7 @@ import { useBoard } from '../../hooks/useBoard';
 import { fetchBoard } from '../../api/board';
 import Board from '../board/Board';
 import { Spinner } from '../ui';
+import type { User } from '../../types/userTypes';
 
 import type { BoardData } from '../../types/boardTypes';
 
@@ -62,6 +63,7 @@ const ActivityFeed: React.FC<ActivityFeedProps> = ({ boardId = 'timeline-board' 
       board={board}
       layout="grid"
       hideControls
+      user={user as User}
       onScrollEnd={loadMore}
       loading={loading}
     />

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { fetchActiveQuests } from '../../api/quest';
 import { fetchRecentPosts, fetchPostById } from '../../api/post';
 import Board from '../board/Board';
+import type { User } from '../../types/userTypes';
 import { Spinner } from '../ui';
 import { ROUTES } from '../../constants/routes';
 import type { Quest } from '../../types/questTypes';
@@ -93,7 +94,7 @@ const ActiveQuestBoard: React.FC = () => {
 
   return (
     <div className="space-y-2">
-      <Board board={board} layout="grid" hideControls compact />
+      <Board board={board} layout="grid" hideControls compact user={user as User} />
       <div className="text-right">
         <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
           → See all


### PR DESCRIPTION
## Summary
- enable Add Item button for the ActiveQuestBoard
- allow adding items from ActivityFeed
- rework TimelineFeed to display posts from the user's quests and allow adding posts

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68562a0924bc832f9dfe2fee0ecb7e50