### PR TITLE
Update quest board behavior

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -10,16 +10,18 @@ import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
+const QUEST_BOARD_TYPES = ['request', 'review', 'issue', 'task'];
 const getQuestBoardItems = (
   posts: ReturnType<typeof postsStore.read>
 ) => {
   const ids = posts
-    .filter(
-      (p) =>
-        p.helpRequest === true ||
-        (p.type === 'request' &&
-          (p.visibility === 'public' || p.visibility === 'request_board'))
-    )
+    .filter((p) => {
+      if (!QUEST_BOARD_TYPES.includes(p.type)) return false;
+      if (p.type === 'request') {
+        return p.visibility === 'public' || p.visibility === 'request_board';
+      }
+      return p.helpRequest === true;
+    })
     .map((p) => p.id);
   return ids;
 };

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -79,14 +79,18 @@ router.post(
     const quest = questId ? quests.find(q => q.id === questId) : null;
     const parent = replyTo ? posts.find(p => p.id === replyTo) : null;
 
-    if (
-      boardId === 'quest-board' &&
-      !(type === 'request' || helpRequest === true)
-    ) {
-      res
-        .status(400)
-        .json({ error: 'Only help requests allowed on this board' });
-      return;
+    if (boardId === 'quest-board') {
+      const allowed = ['request', 'review', 'issue', 'task'];
+      if (!allowed.includes(type)) {
+        res
+          .status(400)
+          .json({ error: 'Only request, review, issue, or task posts allowed on this board' });
+        return;
+      }
+      if (type !== 'request' && helpRequest !== true) {
+        res.status(400).json({ error: 'Help request flag required' });
+        return;
+      }
     }
 
     const newPost: DBPost = {

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -334,20 +334,21 @@ describe('post routes', () => {
     expect(written.helpRequest).toBe(true);
   });
 
-  it('requires help flag for quest on quest board', async () => {
+  it('allows task post with help flag on quest board', async () => {
     postsStore.read.mockReturnValue([]);
-    let res = await request(app)
-      .post('/posts')
-      .send({ type: 'quest', boardId: 'quest-board' });
-    expect(res.status).toBe(400);
-
     postsStore.write.mockClear();
-    res = await request(app)
+    const res = await request(app)
+      .post('/posts')
+      .send({ type: 'task', boardId: 'quest-board', helpRequest: true });
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects quest post on quest board', async () => {
+    postsStore.read.mockReturnValue([]);
+    const res = await request(app)
       .post('/posts')
       .send({ type: 'quest', boardId: 'quest-board', helpRequest: true });
-    expect(res.status).toBe(201);
-    const writtenQuest = postsStore.write.mock.calls[0][0][0];
-    expect(writtenQuest.helpRequest).toBe(true);
+    expect(res.status).toBe(400);
   });
 
   it('deleting a quest head post removes the quest instead', async () => {

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -17,7 +17,7 @@ import MapGraphLayout from '../layout/MapGraphLayout';
 import { Button, Input, Select, Spinner } from '../ui';
 
 import type { BoardData, BoardProps, BoardLayout } from '../../types/boardTypes';
-import type { Post } from '../../types/postTypes';
+import type { Post, PostType } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
 
 const Board: React.FC<BoardProps> = ({
@@ -391,6 +391,10 @@ const Board: React.FC<BoardProps> = ({
               onCancel={() => setShowCreateForm(false)}
               boardId={board.id}
               currentView={activeView}
+              initialType={
+                (localFilter.postType ||
+                  (board.id === 'quest-board' ? 'request' : 'free_speech')) as PostType
+              }
             />
           )}
         </div>

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -64,7 +64,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
   const allowedPostTypes: PostType[] =
     boardId === 'quest-board'
-      ? ['request', 'review', 'quest']
+      ? ['request', 'review', 'issue', 'task']
       : boardType === 'quest'
       ? ['quest', 'task', 'log']
       : boardType === 'post'

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -6,6 +6,7 @@ import { useSocketListener } from '../hooks/useSocket';
 import Banner from '../components/ui/Banner';
 import Board from '../components/board/Board';
 import { Spinner } from '../components/ui';
+import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
 
 import type { User } from '../types/userTypes';
 import type { BoardData } from '../types/boardTypes';
@@ -71,6 +72,10 @@ const ProfilePage: React.FC = () => {
             )}
           </>
         )}
+      </section>
+
+      <section className="mb-12">
+        <ActiveQuestBoard />
       </section>
 
       {/* 📝 Post History */}

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -1,14 +1,13 @@
-import React, { useState, useMemo, Suspense, lazy } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useBoardContext } from '../contexts/BoardContext';
 import Board from '../components/board/Board';
 import PostTypeFilter from '../components/board/PostTypeFilter';
-import FeaturedQuestBoard from '../components/quest/FeaturedQuestBoard';
 import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
+import ActivityFeed from '../components/feed/ActivityFeed';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
 import { Spinner } from '../components/ui';
-const TimelineFeed = lazy(() => import('../components/feed/TimelineFeed'));
 import { getRenderableBoardItems } from '../utils/boardUtils';
 
 import type { User } from '../types/userTypes';
@@ -48,11 +47,6 @@ const HomePage: React.FC = () => {
         </p>
       </header>
 
-      <section>
-        <h2 className="text-xl font-semibold mb-2">✨ Featured Quests</h2>
-        <FeaturedQuestBoard />
-      </section>
-
       <section className="space-y-4">
         {showPostFilter && (
           <PostTypeFilter value={postType} onChange={setPostType} />
@@ -78,9 +72,7 @@ const HomePage: React.FC = () => {
 
       <section>
         <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>
-        <Suspense fallback={<Spinner />}>
-          <TimelineFeed />
-        </Suspense>
+        <ActivityFeed />
       </section>
 
     </main>

--- a/ethos-frontend/tests/CreatePostBoardType.test.tsx
+++ b/ethos-frontend/tests/CreatePostBoardType.test.tsx
@@ -46,6 +46,6 @@ describe('CreatePost board type filtering', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Request', 'Review', 'Quest']);
+    expect(options).toEqual(['Request', 'Review', 'Issue', 'Quest Task']);
   });
 });


### PR DESCRIPTION
## Summary
- drop featured quests from the home page
- show active quests on the profile page
- use board style activity feed on the home page
- start create post forms with the filtered type
- restrict quest board posts to request, review, issue and task

## Testing
- `npm test` *(fails: Cannot find module 'supertest' and jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68562ea781e8832fb1a557fb10feab36