### PR TITLE
Refine board details view

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -11,6 +11,7 @@ import CreatePost from '../post/CreatePost';
 import CreateQuest from '../quest/CreateQuest';
 
 import GridLayout from '../layout/GridLayout';
+import ListLayout from '../layout/ListLayout';
 import GraphLayout from '../layout/GraphLayout';
 import MapGraphLayout from '../layout/MapGraphLayout';
 
@@ -253,6 +254,7 @@ const Board: React.FC<BoardProps> = ({
 
   const Layout = {
     grid: GridLayout,
+    list: ListLayout,
     horizontal: GridLayout,
     kanban: GridLayout,
     graph: GraphLayout,
@@ -345,6 +347,7 @@ const Board: React.FC<BoardProps> = ({
                 onChange={(e) => setViewMode(e.target.value as BoardLayout)}
                 options={[
                   { value: 'grid', label: 'Grid' },
+                  { value: 'list', label: 'List' },
                   { value: 'horizontal', label: 'Horizontal' },
                   { value: 'kanban', label: 'Kanban' },
                   ...(graphEligible
@@ -441,7 +444,7 @@ const Board: React.FC<BoardProps> = ({
               ? { edges: quest?.taskGraph }
               : {})}
           {...(resolvedStructure === 'graph-condensed' ? { condensed: true } : {})}
-          {...(['grid', 'horizontal', 'kanban'].includes(resolvedStructure)
+          {...(['grid', 'list', 'horizontal', 'kanban'].includes(resolvedStructure)
             ? { layout: resolvedStructure === 'grid' ? gridLayout : resolvedStructure }
             : {})}
         />

--- a/ethos-frontend/src/components/board/BoardSearchFilter.tsx
+++ b/ethos-frontend/src/components/board/BoardSearchFilter.tsx
@@ -9,6 +9,7 @@ export interface FilterState {
   postType: string;
   role: string;
   sortBy: string;
+  view: 'grid' | 'list';
 }
 
 interface BoardSearchFilterProps {
@@ -44,6 +45,11 @@ const SORT_OPTIONS: option[] = [
   { value: 'trending', label: 'Trending' },
 ];
 
+const VIEW_OPTIONS: option[] = [
+  { value: 'grid', label: 'Grid' },
+  { value: 'list', label: 'List' },
+];
+
 const DEFAULT_FILTERS: FilterState = {
   search: '',
   tags: [],
@@ -51,6 +57,7 @@ const DEFAULT_FILTERS: FilterState = {
   postType: '',
   role: '',
   sortBy: 'recent',
+  view: 'grid',
 };
 
 const STORAGE_KEY = 'boardFilters';
@@ -151,6 +158,11 @@ const BoardSearchFilter: React.FC<BoardSearchFilterProps> = ({
             value={filters.sortBy}
             onChange={(e) => setFilters({ ...filters, sortBy: e.target.value })}
             options={SORT_OPTIONS}
+          />
+          <Select
+            value={filters.view}
+            onChange={(e) => setFilters({ ...filters, view: e.target.value as 'grid' | 'list' })}
+            options={VIEW_OPTIONS}
           />
         </div>
       )}

--- a/ethos-frontend/src/components/layout/ListLayout.tsx
+++ b/ethos-frontend/src/components/layout/ListLayout.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import ContributionCard from '../contribution/ContributionCard';
+import { Spinner } from '../ui';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+interface ListLayoutProps {
+  items: Post[];
+  questId: string;
+  user?: User;
+  compact?: boolean;
+  editable?: boolean;
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onScrollEnd?: () => void;
+  loadingMore?: boolean;
+}
+
+const ListLayout: React.FC<ListLayoutProps> = ({
+  items,
+  questId,
+  user,
+  compact = false,
+  onEdit,
+  onDelete,
+  onScrollEnd,
+  loadingMore = false,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !onScrollEnd) return;
+    const handle = () => {
+      if (el.scrollHeight - el.scrollTop <= el.clientHeight + 150) {
+        onScrollEnd();
+      }
+    };
+    el.addEventListener('scroll', handle);
+    return () => el.removeEventListener('scroll', handle);
+  }, [onScrollEnd]);
+
+  if (!items || items.length === 0) {
+    return (
+      <div className="text-center text-secondary py-12 text-sm">
+        No contributions found.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="space-y-4 overflow-y-auto max-h-[80vh] px-2"
+    >
+      {items.map((item) => (
+        <ContributionCard
+          key={item.id}
+          contribution={item}
+          user={user}
+          compact={compact}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          questId={questId}
+        />
+      ))}
+      {loadingMore && <Spinner />}
+    </div>
+  );
+};
+
+export default ListLayout;

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -4,6 +4,7 @@ import type { PostType } from '../types/postTypes';
 
 export const STRUCTURE_OPTIONS: { value: BoardLayout; label: string }[] = [
   { value: 'grid', label: 'Grid' },
+  { value: 'list', label: 'List' },
   { value: 'horizontal', label: 'Horizontal' },
   { value: 'kanban', label: 'Kanban' },
   { value: 'graph', label: 'Graph' },

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -29,6 +29,7 @@ const BoardPage: React.FC = () => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
+  const [view, setView] = useState<'grid' | 'list'>('grid');
 
   const loadQuest = useCallback(async (questId: string) => {
     try {
@@ -120,7 +121,11 @@ const BoardPage: React.FC = () => {
   return (
     <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
       <div className="flex flex-col md:flex-row gap-6">
-        <BoardSearchFilter tags={availableTags} className="md:w-64" />
+        <BoardSearchFilter
+          tags={availableTags}
+          className="md:w-64"
+          onChange={(f) => setView(f.view)}
+        />
         <div className="flex-1">
           <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
             <div className="flex justify-between items-center">
@@ -135,10 +140,11 @@ const BoardPage: React.FC = () => {
             <Board
               boardId={id}
               board={boardData}
-              layout={boardData.layout}
+              layout={view}
               quest={quest || undefined}
               editable={editable}
               showCreate={editable}
+              hideControls
               onScrollEnd={loadMore}
               loading={loadingMore}
             />

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -61,6 +61,7 @@ export type BoardItem = RenderableItem | Post | Quest | Board ;
 
 export type BoardLayout =
   | 'grid'
+  | 'list'
   | 'horizontal'
   | 'kanban'
   | 'graph'


### PR DESCRIPTION
## Summary
- add a ListLayout component for single-column board display
- extend board layout types and options to include `list`
- wire BoardSearchFilter to control list/grid view
- hide header controls on board detail page and use side filter

## Testing
- `npm test` *(fails: Jest configuration issues)*
- `npm run build` in `ethos-frontend` *(fails: TypeScript errors)*
- `npm install` && `npm test` in `ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_685636262e60832f9047f9745dec3a32