### PR TITLE
Add sidebar filter to profile posts

### DIFF
--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -139,6 +139,7 @@ const BoardPage: React.FC = () => {
               quest={quest || undefined}
               editable={editable}
               showCreate={editable}
+              hideControls
               onScrollEnd={loadMore}
               loading={loadingMore}
             />


### PR DESCRIPTION
## Summary
- mirror board page sidebar filter on Profile posts
- remove board header controls on board details and user post board

## Testing
- `npm test --prefix ethos-frontend` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6856362f8dfc832fa484efb0eaf11d3a