### PR TITLE
Restrict quest board post type filter

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -15,6 +15,7 @@ import GraphLayout from '../layout/GraphLayout';
 import MapGraphLayout from '../layout/MapGraphLayout';
 
 import { Button, Input, Select, Spinner } from '../ui';
+import { POST_TYPES } from '../../constants/options';
 
 import type { BoardData, BoardProps, BoardLayout } from '../../types/boardTypes';
 import type { Post, PostType } from '../../types/postTypes';
@@ -176,12 +177,15 @@ const Board: React.FC<BoardProps> = ({
   }, [renderableItems]);
 
   const postTypes = useMemo(() => {
+    if (board?.id === 'quest-board') {
+      return ['request', 'review', 'issue'];
+    }
     const types = new Set<string>();
     renderableItems.forEach((it) => {
       if ('type' in it) types.add((it as Post).type);
     });
     return Array.from(types);
-  }, [renderableItems]);
+  }, [renderableItems, board?.id]);
 
   const linkTypes = useMemo(() => {
     const types = new Set<string>();
@@ -301,16 +305,19 @@ const Board: React.FC<BoardProps> = ({
                 />
               )}
               {postTypes.length > 1 && (
-                <Select
-                  value={localFilter.postType}
-                  onChange={(e) =>
-                    setLocalFilter((p) => ({ ...p, postType: e.target.value }))
-                  }
-                  options={[
-                    { value: '', label: 'All Posts' },
-                    ...postTypes.map((t) => ({ value: t, label: t }))
-                  ]}
-                />
+              <Select
+                value={localFilter.postType}
+                onChange={(e) =>
+                  setLocalFilter((p) => ({ ...p, postType: e.target.value }))
+                }
+                options={[
+                  { value: '', label: 'All Posts' },
+                  ...postTypes.map((t) => {
+                    const opt = POST_TYPES.find((o) => o.value === t);
+                    return { value: t, label: opt?.label || t };
+                  })
+                ]}
+              />
               )}
               {linkTypes.length > 1 && (
                 <Select

--- a/ethos-frontend/src/components/board/PostTypeFilter.tsx
+++ b/ethos-frontend/src/components/board/PostTypeFilter.tsx
@@ -8,8 +8,8 @@ interface PostTypeFilterProps {
 
 const options = [
   { value: '', label: 'All Posts' },
-  { value: 'quest', label: 'Quests' },
   { value: 'request', label: 'Requests' },
+  { value: 'review', label: 'Reviews' },
   { value: 'issue', label: 'Issues' },
 ];
 

--- a/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
+++ b/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PostTypeFilter from '../src/components/board/PostTypeFilter';
+
+describe('PostTypeFilter options', () => {
+  it('shows quest board filter options', () => {
+    render(<PostTypeFilter value="" onChange={() => {}} />);
+    const select = screen.getByRole('combobox');
+    const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['All Posts', 'Requests', 'Reviews', 'Issues']);
+  });
+});


### PR DESCRIPTION
## Summary
- show only request/review/issue options on the PostTypeFilter
- cap quest board filter options in Board.tsx
- test PostTypeFilter options

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test Suites: 13 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68563665f1e8832f91dae247dcdc740a