### PR TITLE
Add basic About, Privacy and Terms pages

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -20,6 +20,9 @@ import PrivateRoute from './routes/ProtectedRoute';
  */
 const Home = lazy(() => import('./pages/index'));
 const Login = lazy(() => import('./pages/Login'));
+const About = lazy(() => import('./pages/About'));
+const Privacy = lazy(() => import('./pages/Privacy'));
+const Terms = lazy(() => import('./pages/Terms'));
 const Profile = lazy(() => import('./pages/Profile'));
 const Quest = lazy(() => import('./pages/quest/[id]'));
 const Post = lazy(() => import('./pages/post/[id]'));
@@ -59,6 +62,9 @@ const App: React.FC = () => {
                   {/* ✅ Publicly accessible routes */}
                   <Route path={ROUTES.HOME} element={<Home />} />
                   <Route path={ROUTES.LOGIN} element={<Login />} />
+                  <Route path={ROUTES.ABOUT} element={<About />} />
+                  <Route path={ROUTES.PRIVACY} element={<Privacy />} />
+                  <Route path={ROUTES.TERMS} element={<Terms />} />
                   <Route path={ROUTES.PUBLIC_PROFILE()} element={<PublicProfile />} />
                   <Route path={ROUTES.RESET_PASSWORD()} element={<ResetPassword />} />
 

--- a/ethos-frontend/src/components/ui/Footer.tsx
+++ b/ethos-frontend/src/components/ui/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
 
 /**
  * Simple footer with navigation links and credits.
@@ -10,13 +11,13 @@ const Footer: React.FC = () => {
     <footer className="w-full border-t border-background bg-surface text-sm text-secondary">
       <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-12 xl:px-24 py-6 flex flex-col sm:flex-row items-center justify-between gap-4">
         <nav className="flex gap-4">
-          <Link to="/about" className="hover:text-accent transition-colors">
+          <Link to={ROUTES.ABOUT} className="hover:text-accent transition-colors">
             About
           </Link>
-          <Link to="/privacy" className="hover:text-accent transition-colors">
+          <Link to={ROUTES.PRIVACY} className="hover:text-accent transition-colors">
             Privacy
           </Link>
-          <Link to="/terms" className="hover:text-accent transition-colors">
+          <Link to={ROUTES.TERMS} className="hover:text-accent transition-colors">
             Terms
           </Link>
         </nav>

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -10,6 +10,15 @@ export const ROUTES = {
   
     /** Login page (public) */
     LOGIN: '/login',
+
+    /** Informational about page */
+    ABOUT: '/about',
+
+    /** Privacy policy page */
+    PRIVACY: '/privacy',
+
+    /** Terms of service page */
+    TERMS: '/terms',
   
     /** Logged-in user’s private profile page */
     PROFILE: '/profile',

--- a/ethos-frontend/src/pages/About.tsx
+++ b/ethos-frontend/src/pages/About.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const AboutPage: React.FC = () => (
+  <main className="container mx-auto px-4 py-8 max-w-3xl text-primary bg-soft dark:bg-soft-dark">
+    <h1 className="text-3xl font-bold mb-4">About Ethos</h1>
+    <p className="mb-4">
+      Ethos is a collaborative quest platform where communities tackle tasks
+      together. This project is open source and aims to make solving problems
+      a shared adventure.
+    </p>
+    <p>
+      Join quests, track your progress and connect with others while working
+      toward common goals.
+    </p>
+  </main>
+);
+
+export default AboutPage;

--- a/ethos-frontend/src/pages/Privacy.tsx
+++ b/ethos-frontend/src/pages/Privacy.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const PrivacyPage: React.FC = () => (
+  <main className="container mx-auto px-4 py-8 max-w-3xl text-primary bg-soft dark:bg-soft-dark">
+    <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
+    <p className="mb-4">
+      We respect your privacy and collect only the data required to provide
+      core functionality. Information is never sold or shared with third
+      parties.
+    </p>
+    <p>
+      By using Ethos you agree that basic usage data may be stored to improve
+      the experience.
+    </p>
+  </main>
+);
+
+export default PrivacyPage;

--- a/ethos-frontend/src/pages/Terms.tsx
+++ b/ethos-frontend/src/pages/Terms.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const TermsPage: React.FC = () => (
+  <main className="container mx-auto px-4 py-8 max-w-3xl text-primary bg-soft dark:bg-soft-dark">
+    <h1 className="text-3xl font-bold mb-4">Terms of Service</h1>
+    <p className="mb-4">
+      Ethos is provided "as is" without warranties. By using the site you
+      agree to abide by community guidelines and applicable laws.
+    </p>
+    <p>
+      Content you submit must be your own and you assume responsibility for
+      your interactions on the platform.
+    </p>
+  </main>
+);
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- create simple About, Privacy, and Terms pages
- register new routes for those pages
- update footer navigation to use the route constants

## Testing
- `npm install` *(fails: some network requests blocked but installation succeeded)*
- `npm test` *(fails: many test suites fail due to module transform errors)*

------
https://chatgpt.com/codex/tasks/task_e_68563a1b1f04832f9c9f713ffbecd4e1