### PR TITLE
Remove nested board elements

### DIFF
--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -22,9 +22,9 @@ const NavBar: React.FC = () => {
       <div className="w-full max-w-[1440px] px-4 sm:px-6 lg:px-12 xl:px-24 mx-auto flex items-center justify-between flex-wrap gap-4">
 
         {/* Logo or brand name linking to home */}
-        <Link to="/" className="text-xl font-bold tracking-tight text-accent">
+        <a href="/" className="text-xl font-bold tracking-tight text-accent">
           Ethos
-        </Link>
+        </a>
 
         {/* Navigation links – vary by user auth state */}
         <div className="flex flex-wrap items-center gap-4 text-sm sm:text-base">

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import Board from '../../components/board/Board';
-import { createMockBoard } from '../../utils/boardUtils';
+import PostCard from '../../components/post/PostCard';
 import { useSocket } from '../../hooks/useSocket';
 import { Spinner } from '../../components/ui';
 
@@ -23,14 +23,9 @@ const PostPage: React.FC = () => {
   const [page, setPage] = useState(1);
 
   const boardWithPost = useMemo<BoardData | null>(() => {
-    if (!post) return null;
-    if (!replyBoard) return createMockBoard(`post-${post.id}`, 'Post', [post]);
-    return {
-      ...replyBoard,
-      items: [post.id, ...(replyBoard.items ?? [])],
-      enrichedItems: [post, ...(replyBoard.enrichedItems ?? [])],
-    };
-  }, [post, replyBoard]);
+    if (!replyBoard) return null;
+    return replyBoard;
+  }, [replyBoard]);
 
   const fetchPostData = useCallback(async () => {
     if (!id) return;
@@ -111,12 +106,7 @@ const PostPage: React.FC = () => {
       )}
 
       <section>
-        <Board
-          board={createMockBoard(`post-${post.id}`, 'Post', [post])}
-          editable={false}
-          compact={false}
-          initialExpanded={true}
-        />
+        <PostCard post={post} />
       </section>
 
 

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -11,7 +11,6 @@ import Banner from '../../components/ui/Banner';
 import Board from '../../components/board/Board';
 import { Spinner } from '../../components/ui';
 import ReviewForm from '../../components/ReviewForm';
-import { createMockBoard } from '../../utils/boardUtils';
 import { fetchUserById } from '../../api/auth';
 
 import type { User } from '../../types/userTypes';
@@ -111,12 +110,6 @@ const QuestPage: React.FC = () => {
           <Spinner />
         )}
       </section>
-
-      <Board
-        board={createMockBoard(`quest-${quest.id}`, 'Quest Overview', [quest])}
-        editable={false}
-        compact={false}
-      />
 
       {/* 📜 Quest Log Section */}
       <section>


### PR DESCRIPTION
## Summary
- show a `PostCard` instead of wrapping a single post in a Board
- remove the quest overview board from quest pages
- make the Ethos logo an anchor link for a hard reload

## Testing
- `npm test` *(fails: Jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68563a3e3424832f927143230aecb5ba