### PR TITLE
fix login light mode background

### DIFF
--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -129,7 +129,7 @@ const Login: React.FC = () => {
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4 text-primary">
-      <section className="w-full max-w-md bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
+      <section className="w-full max-w-md bg-surface dark:bg-surface p-8 rounded-lg shadow-lg">
         <header className="mb-6 text-center">
           <h1 className="text-3xl font-bold text-primary">
             {showReset

--- a/ethos-frontend/src/pages/ResetPassword.tsx
+++ b/ethos-frontend/src/pages/ResetPassword.tsx
@@ -101,7 +101,7 @@ const ResetPassword: React.FC = () => {
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-soft dark:bg-soft-dark px-4">
-      <section className="w-full max-w-md bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg text-primary">
+      <section className="w-full max-w-md bg-surface dark:bg-surface p-8 rounded-lg shadow-lg text-primary">
         <header className="mb-6 text-center">
           <h1 className="text-2xl font-bold text-primary">Reset Your Password</h1>
           <p className="text-sm text-secondary mt-1">Enter and confirm your new password.</p>


### PR DESCRIPTION
## Summary
- use the `bg-surface` token for login form container
- update reset password page to use the same token

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68563ca834e4832fb838d6fe84f3ed79