### PR TITLE
Fix profile bio colors

### DIFF
--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -43,7 +43,7 @@ const Banner: React.FC<BannerProps> = ({ user, quest, creatorName }) => {
         <h1 className="text-2xl font-bold text-primary dark:text-primary">
           {user ? displayName : `📜 ${displayName}`}
         </h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300">{description}</p>
+        <p className="text-sm text-gray-800 dark:text-gray-400">{description}</p>
         {creatorDisplay && (
           <p className="text-xs text-secondary mt-1">{creatorDisplay}</p>
         )}


### PR DESCRIPTION
## Summary
- tweak user bio color in Banner component to be darker in light mode and lighter in dark mode

## Testing
- `npm test` within `ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` within `ethos-frontend` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` within `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68563cecc6c4832fa74193b9f552e51e