### PR TITLE
Fix placeholder color consistency

### DIFF
--- a/ethos-frontend/src/components/ui/Input.tsx
+++ b/ethos-frontend/src/components/ui/Input.tsx
@@ -27,7 +27,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             id={id}
             ref={ref}
             className={clsx(
-              'w-full px-3 py-2 text-sm bg-surface text-primary',
+              'w-full px-3 py-2 text-sm bg-surface text-primary placeholder-gray-600 dark:placeholder-gray-300',
               error ? 'border-error' : 'border-secondary',
               'focus:outline-none',
               className

--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -166,7 +166,7 @@ const Login: React.FC = () => {
             placeholder="Email"
             value={form.email}
             onChange={handleChange}
-            className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 dark:placeholder-gray-300"
             required
           />
 
@@ -177,7 +177,7 @@ const Login: React.FC = () => {
               placeholder="Password"
               value={form.password}
               onChange={handleChange}
-              className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 dark:placeholder-gray-300"
               required
             />
           )}
@@ -189,7 +189,7 @@ const Login: React.FC = () => {
               placeholder="Confirm Password"
               value={form.confirm}
               onChange={handleChange}
-              className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 dark:placeholder-gray-300"
               required
             />
           )}


### PR DESCRIPTION
## Summary
- set default placeholder colors for the `Input` component
- ensure login page inputs use consistent placeholder styling

## Testing
- `npm test --silent --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_68563e4c9958832fb06759c58852f265