### PR TITLE
Add activity tab to board detail

### DIFF
--- a/ethos-frontend/src/components/feed/ActivityList.tsx
+++ b/ethos-frontend/src/components/feed/ActivityList.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchRecentPosts } from '../../api/post';
+import { Spinner } from '../ui';
+import PostListItem from '../post/PostListItem';
+import type { Post } from '../../types/postTypes';
+
+const ActivityList: React.FC = () => {
+  const { user } = useAuth();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const recent = await fetchRecentPosts(user.id);
+        setPosts(recent);
+      } catch (err) {
+        console.warn('[ActivityList] Failed to load activity:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [user]);
+
+  if (!user) return null;
+  if (loading) return <Spinner />;
+  if (posts.length === 0)
+    return <div className="text-center text-secondary py-12 text-sm">No activity yet.</div>;
+
+  return (
+    <div>
+      {posts.map((p) => (
+        <PostListItem key={p.id} post={p} />
+      ))}
+    </div>
+  );
+};
+
+export default ActivityList;

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import type { Post } from '../../types/postTypes';
+
+interface PostListItemProps {
+  post: Post;
+}
+
+const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
+  const timestamp = post.timestamp
+    ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
+    : '';
+  const content = post.renderedContent || post.content || '';
+  const excerpt = content.length > 120 ? content.slice(0, 120) + '…' : content;
+
+  return (
+    <div className="py-3 border-b border-secondary text-primary space-y-1">
+      <div className="text-sm">
+        <strong>@{post.author?.username || post.authorId}</strong>{' '}
+        <span className="text-secondary text-xs">{timestamp}</span>
+      </div>
+      <div className="text-sm">{excerpt}</div>
+    </div>
+  );
+};
+
+export default PostListItem;

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -10,6 +10,7 @@ import { usePermissions } from '../../hooks/usePermissions';
 import Board from '../../components/board/Board';
 import BoardSearchFilter from '../../components/board/BoardSearchFilter';
 import { Spinner } from '../../components/ui';
+import ActivityList from '../../components/feed/ActivityList';
 import { fetchQuestById } from '../../api/quest';
 
 import type { BoardData } from '../../types/boardTypes';
@@ -30,6 +31,7 @@ const BoardPage: React.FC = () => {
   const [hasMore, setHasMore] = useState(true);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [view, setView] = useState<'grid' | 'list'>('grid');
+  const [tab, setTab] = useState<'board' | 'activity'>('board');
 
   const loadQuest = useCallback(async (questId: string) => {
     try {
@@ -121,11 +123,13 @@ const BoardPage: React.FC = () => {
   return (
     <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
       <div className="flex flex-col md:flex-row gap-6">
-        <BoardSearchFilter
-          tags={availableTags}
-          className="md:w-64"
-          onChange={(f) => setView(f.view)}
-        />
+        {tab === 'board' && (
+          <BoardSearchFilter
+            tags={availableTags}
+            className="md:w-64"
+            onChange={(f) => setView(f.view)}
+          />
+        )}
         <div className="flex-1">
           <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
             <div className="flex justify-between items-center">
@@ -137,17 +141,36 @@ const BoardPage: React.FC = () => {
               )}
             </div>
 
-            <Board
-              boardId={id}
-              board={boardData}
-              layout={view}
-              quest={quest || undefined}
-              editable={editable}
-              showCreate={editable}
-              hideControls
-              onScrollEnd={loadMore}
-              loading={loadingMore}
-            />
+            <div className="flex gap-4 border-b border-secondary pb-2">
+              <button
+                className={`pb-1 ${tab === 'board' ? 'border-b-2 border-accent' : ''}`}
+                onClick={() => setTab('board')}
+              >
+                Quest Board
+              </button>
+              <button
+                className={`pb-1 ${tab === 'activity' ? 'border-b-2 border-accent' : ''}`}
+                onClick={() => setTab('activity')}
+              >
+                Recent Activity
+              </button>
+            </div>
+
+            {tab === 'board' ? (
+              <Board
+                boardId={id}
+                board={boardData}
+                layout={view}
+                quest={quest || undefined}
+                editable={editable}
+                showCreate={editable}
+                hideControls
+                onScrollEnd={loadMore}
+                loading={loadingMore}
+              />
+            ) : (
+              <ActivityList />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `PostListItem` for reddit-like feed items
- add `ActivityList` component to show recent posts without card styling
- update board detail page with tabs for Quest Board and Recent Activity

## Testing
- `npm test` *(fails: jest environment not found)*
- `npm run build` *(fails: missing types for various packages)*
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856411fd068832f868902067836ca82