### PR TITLE
Fix timeline board loading

### DIFF
--- a/ethos-frontend/src/components/feed/RecentActivityBoard.jsx
+++ b/ethos-frontend/src/components/feed/RecentActivityBoard.jsx
@@ -89,6 +89,7 @@ const RecentActivityBoard = ({ boardId = 'timeline-board' }) => {
       hideControls
       onScrollEnd={loadMore}
       loading={loading}
+      user={user}
     />
   );
 };

--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -44,7 +44,7 @@ export const useBoard = (
     async (id: string, page = 1, limit = pageSize) => {
       setIsLoading(true);
       try {
-        const enrich = typeof arg === 'object' && arg.enrich;
+        const enrich = typeof arg === 'object' ? !!arg.enrich : true;
         const result = await fetchBoard(id, {
           enrich,
           page,


### PR DESCRIPTION
## Summary
- default to enriched board data in useBoard hook
- pass user to RecentActivityBoard so the Add Item button appears

## Testing
- `npm test` *(fails: Jest couldn't find certain modules)*
- `npm test` in backend *(fails: missing dependencies like supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68564741e334832f83b9293bba390ea5