### PR TITLE
Add paged grid layout for Quest Board

### DIFF
--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -18,6 +18,7 @@ const HomePage: React.FC = () => {
   const [postType, setPostType] = useState('');
 
   const questBoard = boards['quest-board'];
+  const showSeeAll = (questBoard?.enrichedItems?.length || 0) > 6;
   const postTypes = useMemo(() => {
     if (!questBoard?.enrichedItems) return [] as string[];
     const types = new Set<string>();
@@ -55,15 +56,18 @@ const HomePage: React.FC = () => {
           boardId="quest-board"
           title="🗺️ Quest Board"
           layout="grid"
+          gridLayout="paged"
           user={user as User}
           hideControls
           filter={postType ? { postType } : {}}
         />
-        <div className="text-right">
-          <Link to={ROUTES.BOARD('quest-board')} className="text-blue-600 underline text-sm">
-            → See all
-          </Link>
-        </div>
+        {showSeeAll && (
+          <div className="text-right">
+            <Link to={ROUTES.BOARD('quest-board')} className="text-blue-600 underline text-sm">
+              → See all
+            </Link>
+          </div>
+        )}
       </section>
 
       <section>

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -87,7 +87,7 @@ export interface BoardProps {
   loading?: boolean;
   quest?: Quest;
   /** Layout variant for GridLayout */
-  gridLayout?: 'vertical' | 'horizontal' | 'kanban';
+  gridLayout?: 'vertical' | 'horizontal' | 'kanban' | 'paged';
   /** Expand all posts when rendering nested replies */
   initialExpanded?: boolean;
 }


### PR DESCRIPTION
## Summary
- add `paged` grid layout variant
- update board prop types
- implement a paged grid carousel in `GridLayout`
- show `See all` only when quest board has more than 6 posts

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc0f9ac8832f8b86f471b4894472