### PR TITLE
Fix timeline board filtering

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -196,6 +196,15 @@ router.get(
     let boardItems = board.items;
     if (board.id === 'quest-board') {
       boardItems = getQuestBoardItems(posts);
+    } else if (board.id === 'timeline-board') {
+      boardItems = posts
+        .filter(
+          p =>
+            p.type !== 'meta_system' &&
+            p.visibility !== 'private'
+        )
+        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
+        .map(p => p.id);
     } else if (userId && board.id === 'my-posts') {
       boardItems = posts
         .filter(
@@ -248,6 +257,15 @@ router.get(
     let boardItems = board.items;
     if (board.id === 'quest-board') {
       boardItems = getQuestBoardItems(posts);
+    } else if (board.id === 'timeline-board') {
+      boardItems = posts
+        .filter(
+          p =>
+            p.type !== 'meta_system' &&
+            p.visibility !== 'private'
+        )
+        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
+        .map(p => p.id);
     } else if (userId && board.id === 'my-posts') {
       boardItems = posts
         .filter(


### PR DESCRIPTION
## Summary
- update timeline board server route to dynamically pull recent posts
- exclude system and private posts from timeline board results

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc959c34832fa09d9a6c14155f27