### PR TITLE
Improve quest board with summary card

### DIFF
--- a/ethos-frontend/src/components/quest/QuestSummaryCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestSummaryCard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
+import type { Quest } from '../../types/questTypes';
+import Button from '../ui/Button';
+
+interface QuestSummaryCardProps {
+  quest: Quest;
+}
+
+const QuestSummaryCard: React.FC<QuestSummaryCardProps> = ({ quest }) => {
+  const rankTag = quest.tags?.find(t => t.toLowerCase().startsWith('rank:'));
+  const rewardTag = quest.tags?.find(t => t.toLowerCase().startsWith('reward:'));
+  const roleTags = quest.tags?.filter(t => t.toLowerCase().startsWith('role:')) || [];
+
+  const rank = rankTag ? rankTag.split(':')[1] : 'Unrated';
+  const reward = rewardTag ? rewardTag.split(':')[1] : 'Unknown';
+  const roles = roleTags.map(t => t.split(':')[1]).join(', ');
+
+  const desc = quest.description || '';
+  const shortDesc = desc.length > 120 ? desc.slice(0, 117) + '…' : desc;
+
+  return (
+    <div className="border border-secondary rounded bg-surface p-4 space-y-2 shadow">
+      <h3 className="text-lg font-bold text-primary">{quest.title}</h3>
+      {shortDesc && <p className="text-sm text-secondary">{shortDesc}</p>}
+      <div className="text-xs text-secondary space-y-0.5">
+        <div>Rank: {rank}</div>
+        <div>Reward: {reward}</div>
+        {roles && <div>Roles Needed: {roles}</div>}
+      </div>
+      <div className="flex gap-2 pt-2">
+        <Link to={ROUTES.QUEST(quest.id)} className="text-sm text-blue-600 underline">
+          Details
+        </Link>
+        <Button size="sm" variant="contrast">
+          Join Quest
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default QuestSummaryCard;

--- a/ethos-frontend/src/pages/board/[boardType].tsx
+++ b/ethos-frontend/src/pages/board/[boardType].tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { fetchAllQuests, fetchActiveQuests } from '../../api/quest';
 import { fetchAllPosts } from '../../api/post';
 import ContributionCard from '../../components/contribution/ContributionCard';
+import QuestSummaryCard from '../../components/quest/QuestSummaryCard';
 import { Spinner, Button } from '../../components/ui';
 import type { Quest } from '../../types/questTypes';
 import type { Post } from '../../types/postTypes';
@@ -80,9 +81,13 @@ const BoardTypePage: React.FC = () => {
             : 'grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
         }
       >
-        {visible.map(it => (
-          <ContributionCard key={(it as any).id} contribution={it as any} compact={compact} />
-        ))}
+        {visible.map(it =>
+          !compact && 'headPostId' in (it as any) ? (
+            <QuestSummaryCard key={(it as any).id} quest={it as Quest} />
+          ) : (
+            <ContributionCard key={(it as any).id} contribution={it as any} compact={compact} />
+          )
+        )}
       </div>
       {visible.length < items.length && <div ref={loader} className="h-4" />}
     </main>


### PR DESCRIPTION
## Summary
- add `QuestSummaryCard` for a concise quest preview
- show `QuestSummaryCard` on quest boards

## Testing
- `npm --prefix ethos-frontend test` *(fails: jest environment not found)*
- `npm --prefix ethos-frontend run lint` *(fails: cannot find ESLint plugin)*


------
https://chatgpt.com/codex/tasks/task_e_6856d033a444832f8f5c949dbc2b7edf