### PR TITLE
Implement collapsible post previews

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -1,25 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
+import { getDisplayTitle } from '../../utils/displayUtils';
+import PostCard from './PostCard';
 
 interface PostListItemProps {
   post: Post;
 }
 
 const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
+  const [expanded, setExpanded] = useState(false);
   const timestamp = post.timestamp
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
-  const content = post.renderedContent || post.content || '';
-  const excerpt = content.length > 120 ? content.slice(0, 120) + '…' : content;
+  const header = getDisplayTitle(post);
 
   return (
-    <div className="py-3 border-b border-secondary text-primary space-y-1">
-      <div className="text-sm">
-        <strong>@{post.author?.username || post.authorId}</strong>{' '}
-        <span className="text-secondary text-xs">{timestamp}</span>
+    <div className="border-b border-secondary text-primary">
+      <div
+        className="flex justify-between items-center cursor-pointer py-2"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <div className="text-sm font-semibold">
+          {header}
+          <span className="text-xs text-secondary ml-2">{timestamp}</span>
+        </div>
+        <span className="text-xs">{expanded ? '▲' : '▼'}</span>
       </div>
-      <div className="text-sm">{excerpt}</div>
+      {expanded && (
+        <div className="pb-2">
+          <PostCard post={post} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable expanding post previews from the activity feed

## Testing
- `npm test --prefix ethos-frontend` *(fails: Cannot find module 'jsdom')*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6856d3c3115c832f9422038da9b7278b