### PR TITLE
Add title field to posts

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -116,6 +116,7 @@ router.post(
   (req: AuthenticatedRequest, res: Response): void => {
     const {
       type = 'free_speech',
+      title = '',
       content = '',
       details = '',
       visibility = 'public',
@@ -156,6 +157,7 @@ router.post(
       id: uuidv4(),
       authorId: req.user!.id,
       type,
+      title: type === 'task' ? content : title || makeQuestNodeTitle(content),
       content,
       details,
       visibility,
@@ -227,6 +229,12 @@ router.patch(
   const originalType = post.type;
 
   Object.assign(post, req.body);
+
+  if (post.type === 'task') {
+    post.title = post.content;
+  } else if (post.type !== 'free_speech' && (!post.title || post.title.trim() === '')) {
+    post.title = makeQuestNodeTitle(post.content);
+  }
 
   if (
     post.questId &&

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -92,6 +92,8 @@ export interface Post {
 
   type: PostType;
   subtype?: string;
+  /** Short header for the post */
+  title?: string;
   content: string;
   /** Optional extra details for task posts */
   details?: string;

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -23,6 +23,8 @@ export interface DBPost {
   authorId: string;
   type: PostType;
   subtype?: string;
+  /** Short header for the post */
+  title?: string;
   content: string;
   /** Optional extra details for task posts */
   details?: string;

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -50,6 +50,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
 }) => {
   const [type, setType] = useState<PostType>(initialType);
   const [status, setStatus] = useState<string>('To Do');
+  const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
   const [details, setDetails] = useState<string>('');
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
@@ -101,6 +102,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
       const payload: Partial<Post> = {
         type,
+        title: type === 'task' ? content : title || undefined,
         content,
         ...(type === 'task' && details ? { details } : {}),
         visibility: 'public',
@@ -208,6 +210,18 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
             return { value: opt.value, label: opt.label };
           })}
         />
+
+        {type !== 'task' && (
+          <>
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              required={type !== 'free_speech'}
+            />
+          </>
+        )}
 
         {type === 'task' && (
           <>

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -22,6 +22,7 @@ interface EditPostProps {
 const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
   const [type, setType] = useState<PostType>(post.type);
   const [status, setStatus] = useState<string>(post.status || 'To Do');
+  const [title, setTitle] = useState<string>(post.title || '');
   const [content, setContent] = useState<string>(post.content || '');
   const [details, setDetails] = useState<string>(post.details || '');
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>(post.collaborators || []);
@@ -46,6 +47,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
 
     const payload: Partial<Post> = {
       type,
+      title: type === 'task' ? content : title || undefined,
       content,
       ...(type === 'task' && details ? { details } : {}),
       ...(type === 'quest' && { collaborators }),
@@ -89,6 +91,18 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
               value={status}
               onChange={(e) => setStatus(e.target.value)}
               options={STATUS_OPTIONS.map(({ value, label }) => ({ value, label }))}
+            />
+          </>
+        )}
+
+        {type !== 'task' && (
+          <>
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              required={type !== 'free_speech'}
             />
           </>
         )}

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -103,6 +103,7 @@ const PostCard: React.FC<PostCardProps> = ({
     : 'Unknown time';
 
   const content = post.renderedContent || post.content;
+  const titleText = post.title || (post.type === 'task' ? post.content : '');
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -312,6 +313,10 @@ const PostCard: React.FC<PostCardProps> = ({
       )}
 
       {renderRepostInfo()}
+
+      {titleText && (
+        <h3 className="font-semibold text-lg mt-1">{titleText}</h3>
+      )}
 
       <div className="text-sm text-primary">
         {post.type === 'task' ? (

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -14,6 +14,8 @@ export interface Post {
 
   type: PostType;
   subtype?: string;
+  /** Short header for the post */
+  title?: string;
   content: string;
   /** Optional extra details for task posts */
   details?: string;

--- a/ethos-frontend/tests/CreatePostTitle.test.tsx
+++ b/ethos-frontend/tests/CreatePostTitle.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    boards: {
+      b1: { id: 'b1', title: 'Board', boardType: 'post', layout: 'grid', items: [], createdAt: '' },
+    },
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+const CreatePost = require('../src/components/post/CreatePost').default;
+
+describe('CreatePost title requirement', () => {
+  it('title optional for free speech', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} initialType="free_speech" />
+      </BrowserRouter>
+    );
+    const input = screen.getByLabelText('Title');
+    expect(input.required).toBe(false);
+  });
+
+  it('title required for request posts', () => {
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} initialType="request" />
+      </BrowserRouter>
+    );
+    const input = screen.getByLabelText('Title');
+    expect(input.required).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `title` property to post types and backend DB
- require title input when posting (except Free Speech)
- generate default title for Free Speech posts
- display titles in post cards
- add tests for title input behavior

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: Jest couldn't parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6edd85c832fbcef40c51d7c76d0