### PR TITLE
Fix timeline board updates

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -143,6 +143,18 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           console.error('[CreatePost] Failed to update my-posts board:', err)
         );
       }
+
+      // Ensure the timeline board reflects new posts immediately
+      if (boards?.['timeline-board']) {
+        appendToBoard('timeline-board', newPost);
+        const timelineItems = [
+          newPost.id,
+          ...(boards['timeline-board'].items || []),
+        ];
+        updateBoard('timeline-board', { items: timelineItems }).catch((err) =>
+          console.error('[CreatePost] Failed to update timeline board:', err)
+        );
+      }
       onSave?.(newPost);
     } catch (err) {
       console.error('[CreatePost] Error creating post:', err);


### PR DESCRIPTION
## Summary
- update CreatePost logic so new posts appear on Timeline board immediately

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm test --prefix ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6856d7badf14832f8e16d88437b5ab46