### PR TITLE
Show "See all" links only for full boards

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -7,6 +7,7 @@ import Board from '../board/Board';
 import type { User } from '../../types/userTypes';
 import { Spinner } from '../ui';
 import { ROUTES } from '../../constants/routes';
+import { BOARD_PREVIEW_LIMIT } from '../../constants/pagination';
 import type { Quest } from '../../types/questTypes';
 import type { Post } from '../../types/postTypes';
 import type { BoardData } from '../../types/boardTypes';
@@ -92,14 +93,18 @@ const ActiveQuestBoard: React.FC = () => {
   if (loading) return <Spinner />;
   if (!board) return null;
 
+  const showSeeAll = (board.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
+
   return (
     <div className="space-y-2">
       <Board board={board} layout="grid" hideControls compact user={user as User} />
-      <div className="text-right">
-        <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
-          → See all
-        </Link>
-      </div>
+      {showSeeAll && (
+        <div className="text-right">
+          <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
+            → See all
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
@@ -6,6 +6,7 @@ import { fetchPostsByQuestId, fetchRepliesByPostId } from '../../api/post';
 import Board from '../board/Board';
 import { Spinner } from '../ui';
 import { ROUTES } from '../../constants/routes';
+import { BOARD_PREVIEW_LIMIT } from '../../constants/pagination';
 import type { Post } from '../../types/postTypes';
 import type { BoardData } from '../../types/boardTypes';
 
@@ -80,13 +81,17 @@ const ActiveQuestsBoard: React.FC = () => {
   if (loading) return <Spinner />;
   if (!board) return null;
 
+  const showSeeAll = (board.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
+
   return (
     <div className="space-y-2">
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-semibold">🧭 Active Quests</h2>
-        <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
-          → See all
-        </Link>
+        {showSeeAll && (
+          <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">
+            → See all
+          </Link>
+        )}
       </div>
       <Board board={board} layout="grid" hideControls compact />
     </div>

--- a/ethos-frontend/src/constants/pagination.ts
+++ b/ethos-frontend/src/constants/pagination.ts
@@ -1,1 +1,6 @@
 export const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Number of items shown in preview boards before a "See all" link should appear.
+ */
+export const BOARD_PREVIEW_LIMIT = 6;

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -7,6 +7,7 @@ import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
 import RecentActivityBoard from '../components/feed/RecentActivityBoard';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../constants/routes';
+import { BOARD_PREVIEW_LIMIT } from '../constants/pagination';
 import { Spinner } from '../components/ui';
 import { getRenderableBoardItems } from '../utils/boardUtils';
 
@@ -18,7 +19,10 @@ const HomePage: React.FC = () => {
   const [postType, setPostType] = useState('');
 
   const questBoard = boards['quest-board'];
-  const showSeeAll = (questBoard?.enrichedItems?.length || 0) > 6;
+  const timelineBoard = boards['timeline-board'];
+  const showQuestSeeAll = (questBoard?.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
+  const showTimelineSeeAll =
+    (timelineBoard?.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
   const postTypes = useMemo(() => {
     if (!questBoard?.enrichedItems) return [] as string[];
     const types = new Set<string>();
@@ -61,7 +65,7 @@ const HomePage: React.FC = () => {
           hideControls
           filter={postType ? { postType } : {}}
         />
-        {showSeeAll && (
+        {showQuestSeeAll && (
           <div className="text-right">
             <Link to={ROUTES.BOARD('quest-board')} className="text-blue-600 underline text-sm">
               → See all
@@ -73,11 +77,13 @@ const HomePage: React.FC = () => {
       <section>
         <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>
         <RecentActivityBoard />
-        <div className="text-right">
-          <Link to={ROUTES.BOARD('timeline-board')} className="text-blue-600 underline text-sm">
-            → See all
-          </Link>
-        </div>
+        {showTimelineSeeAll && (
+          <div className="text-right">
+            <Link to={ROUTES.BOARD('timeline-board')} className="text-blue-600 underline text-sm">
+              → See all
+            </Link>
+          </div>
+        )}
       </section>
 
     </main>


### PR DESCRIPTION
## Summary
- add `BOARD_PREVIEW_LIMIT` constant
- only show "See all" on index page when board items exceed limit
- hide "See all" for active quest previews when not needed

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint --prefix ethos-frontend` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856d7f23564832faa99abf58c79bb69