### PR TITLE
Enable status on request and issue posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ different stages. Each card can be in one of four statuses:
 - **Blocked** – something is preventing progress
 - **Done** – completed and ready for review
 
+Request and Issue posts can use these same status labels so progress on
+bugs or help requests can be tracked alongside tasks.
+
 Click and hold a card to drag it to another column. Dropping the card updates
 its status immediately and the overall quest progress reflects the change for
 everyone on the board.

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -131,7 +131,8 @@ router.post(
       needsHelp = undefined,
     } = req.body;
 
-    const finalStatus = status ?? (type === 'task' ? 'To Do' : undefined);
+    const finalStatus =
+      status ?? (['task', 'request', 'issue'].includes(type) ? 'To Do' : undefined);
 
     const posts = postsStore.read();
     const quests = questsStore.read();

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -106,7 +106,9 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
         visibility: 'public',
         linkedItems: autoLinkItems,
         helpRequest: type === 'request' || helpRequest || undefined,
-        ...(type === 'task' ? { status } : {}),
+        ...(type === 'task' || type === 'request' || type === 'issue'
+          ? { status }
+          : {}),
         ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
         ...(targetBoard ? { boardId: targetBoard } : {}),
         ...(replyTo ? { replyTo: replyTo.id, parentPostId: replyTo.id, linkType: 'reply' } : {}),
@@ -163,7 +165,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
             onChange={(e) => {
               const val = e.target.value as PostType;
               setType(val);
-              if (val === 'task') setStatus('To Do');
+              if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
             }}
             options={allowedPostTypes.map((t) => {
               const opt = POST_TYPES.find((o) => o.value === t)!;
@@ -201,7 +203,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (val === 'task') setStatus('To Do');
+            if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
           }}
           options={allowedPostTypes.map((t) => {
             const opt = POST_TYPES.find((o) => o.value === t)!;
@@ -209,7 +211,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           })}
         />
 
-        {type === 'task' && (
+        {['task', 'request', 'issue'].includes(type) && (
           <>
             <Label htmlFor="task-status">Status</Label>
             <Select

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -49,7 +49,9 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       content,
       ...(type === 'task' && details ? { details } : {}),
       ...(type === 'quest' && { collaborators }),
-      ...(type === 'task' ? { status } : {}),
+      ...(type === 'task' || type === 'request' || type === 'issue'
+        ? { status }
+        : {}),
       linkedItems,
       repostedFrom: repostedFrom || null,
     };
@@ -76,12 +78,12 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (val === 'task') setStatus('To Do');
+            if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
           }}
           options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
 
-        {type === 'task' && (
+        {['task', 'request', 'issue'].includes(type) && (
           <>
             <Label htmlFor="task-status">Status</Label>
             <Select

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -268,7 +268,7 @@ const PostCard: React.FC<PostCardProps> = ({
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />
           {post.status && <StatusBadge status={post.status} />}
-          {canEdit && post.type === 'task' && showStatusControl && (
+          {canEdit && ['task', 'request', 'issue'].includes(post.type) && showStatusControl && (
             <div className="ml-1 w-28">
               <Select
                 value={post.status || 'To Do'}


### PR DESCRIPTION
## Summary
- allow request and issue posts to have a status
- update creation and edit forms to show status for these types
- show status dropdown for requests and issues in post cards
- default request/issue status to **To Do** on the backend
- document that requests and issues support task status labels

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856d8419438832f82e0f85eb0042828