### PR TITLE
Add markdown editor and title field to post creation

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -5,6 +5,7 @@ export default {
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
     '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true, diagnostics: false }],
+    '^.+\\.mjs$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true, diagnostics: false }],
   },
   transformIgnorePatterns: [
     '/node_modules/(?!(react-force-graph-2d|react-force-graph|three|force-graph)(/|$))'

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { addPost } from '../../api/post';
-import { Button, TextArea, Select, Label, FormSection, Input } from '../ui';
+import { Button, Select, Label, FormSection, Input, MarkdownEditor } from '../ui';
 import CollaberatorControls from '../controls/CollaberatorControls';
 import LinkControls from '../controls/LinkControls';
 import CreateQuest from '../quest/CreateQuest';
@@ -237,31 +237,43 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           </>
         )}
 
+        {type !== 'task' && (
+          <>
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required={type !== 'free_speech'}
+            />
+          </>
+        )}
+
         {type === 'task' ? (
           <>
             <Label htmlFor="content">Task Title</Label>
             <Input
               id="content"
               value={content}
-              onChange={e => setContent(e.target.value)}
+              onChange={(e) => setContent(e.target.value)}
               placeholder="Short task summary"
               required
             />
             <Label htmlFor="details">Details</Label>
-            <TextArea
+            <MarkdownEditor
               id="details"
               value={details}
-              onChange={e => setDetails(e.target.value)}
+              onChange={setDetails}
               placeholder="Additional information (optional)"
             />
           </>
         ) : (
           <>
-            <Label htmlFor="content">Content</Label>
-            <TextArea
+            <Label htmlFor="content">Description</Label>
+            <MarkdownEditor
               id="content"
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              onChange={setContent}
               placeholder={
                 replyTo
                   ? 'Reply to this post...'
@@ -269,7 +281,6 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
                   ? 'Add a comment to your repost...'
                   : 'Share your thoughts or progress...'
               }
-              required
             />
           </>
         )}

--- a/ethos-frontend/src/components/ui/MarkdownEditor.tsx
+++ b/ethos-frontend/src/components/ui/MarkdownEditor.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import TextArea from './TextArea';
+import MarkdownRenderer from './MarkdownRenderer';
+
+interface MarkdownEditorProps {
+  id?: string;
+  value: string;
+  placeholder?: string;
+  rows?: number;
+  onChange: (value: string) => void;
+}
+
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  id,
+  value,
+  placeholder = '',
+  rows = 6,
+  onChange,
+}) => {
+  const [preview, setPreview] = useState(false);
+
+  const applyWrap = (start: string, end: string = start) => {
+    const ta = document.getElementById(id || '') as HTMLTextAreaElement | null;
+    if (!ta) return;
+    const { selectionStart, selectionEnd } = ta;
+    const before = value.slice(0, selectionStart);
+    const selected = value.slice(selectionStart, selectionEnd);
+    const after = value.slice(selectionEnd);
+    const newVal = before + start + selected + end + after;
+    onChange(newVal);
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.selectionStart = selectionStart + start.length;
+      ta.selectionEnd = selectionEnd + start.length;
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-1 text-sm">
+        <button type="button" className="px-1" onClick={() => applyWrap('**')}>
+          <strong>B</strong>
+        </button>
+        <button type="button" className="px-1" onClick={() => applyWrap('*')}>
+          <em>I</em>
+        </button>
+        <button type="button" className="px-1" onClick={() => applyWrap('`')}>
+          {'`</>`'}
+        </button>
+        <button type="button" className="px-1" onClick={() => applyWrap('[', '](url)')}>
+          link
+        </button>
+        <button type="button" className="px-1" onClick={() => applyWrap('## ')}>
+          H
+        </button>
+        <button
+          type="button"
+          className="ml-auto underline"
+          onClick={() => setPreview((p) => !p)}
+        >
+          {preview ? 'Edit' : 'Preview'}
+        </button>
+      </div>
+      {preview ? (
+        <div className="border rounded p-2">
+          <MarkdownRenderer content={value} />
+        </div>
+      ) : (
+        <TextArea
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={rows}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/ethos-frontend/src/components/ui/index.tsx
+++ b/ethos-frontend/src/components/ui/index.tsx
@@ -14,3 +14,5 @@ export { default as PostTypeBadge } from './PostTypeBadge';
 export { default as StatusBadge } from './StatusBadge';
 export { default as Footer } from './Footer';
 export { default as Spinner } from './Spinner';
+export { default as MarkdownRenderer } from './MarkdownRenderer';
+export { default as MarkdownEditor } from './MarkdownEditor';


### PR DESCRIPTION
## Summary
- add MarkdownEditor component with toolbar and preview
- export Markdown components
- allow entering a title when creating posts
- replace textareas with markdown editor for rich editing
- handle `.mjs` modules in Jest config

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6856da38037c832fa20b3b8ebf63eca6