### PR TITLE
Update PostListItem with navigation

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostListItem from './PostListItem';
+import type { Post } from '../../types/postTypes';
+import { ROUTES } from '../../constants/routes';
+
+const navMock = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => navMock,
+  };
+});
+
+const basePost: Post = {
+  id: 'p1',
+  authorId: 'u1',
+  type: 'free_speech',
+  content: 'hello world',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+} as any;
+
+describe('PostListItem', () => {
+  it('navigates to post page on click', () => {
+    render(
+      <BrowserRouter>
+        <PostListItem post={basePost} />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByText(/hello world/));
+    expect(navMock).toHaveBeenCalledWith(ROUTES.POST('p1'));
+  });
+});

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -1,37 +1,32 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
 import { getDisplayTitle } from '../../utils/displayUtils';
-import PostCard from './PostCard';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
 
 interface PostListItemProps {
   post: Post;
 }
 
 const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
-  const [expanded, setExpanded] = useState(false);
+  const navigate = useNavigate();
   const timestamp = post.timestamp
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
   const header = getDisplayTitle(post);
 
   return (
-    <div className="border-b border-secondary text-primary">
-      <div
-        className="flex justify-between items-center cursor-pointer py-2"
-        onClick={() => setExpanded((e) => !e)}
-      >
+    <div
+      className="border-b border-secondary text-primary cursor-pointer py-2"
+      onClick={() => navigate(ROUTES.POST(post.id))}
+    >
+      <div className="flex justify-between items-center">
         <div className="text-sm font-semibold">
           {header}
           <span className="text-xs text-secondary ml-2">{timestamp}</span>
         </div>
-        <span className="text-xs">{expanded ? '▲' : '▼'}</span>
       </div>
-      {expanded && (
-        <div className="pb-2">
-          <PostCard post={post} />
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show only headers in PostListItem and navigate on click
- test that PostListItem navigates to the post page when clicked

## Testing
- `npm test` *(fails: Jest couldn't parse some modules and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6856eb02c4f4832faca2cd4f20f38fe7