### PR TITLE
Update timeline board display

### DIFF
--- a/ethos-frontend/src/components/feed/RecentActivityBoard.jsx
+++ b/ethos-frontend/src/components/feed/RecentActivityBoard.jsx
@@ -15,14 +15,14 @@
 // - Sort by most recent post timestamp (or last reply)
 // - Add filters for type (log, request, reply)
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useRef, useEffect } from 'react';
 import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
 import { useAuth } from '../../contexts/AuthContext';
 import { useBoard } from '../../hooks/useBoard';
 import { useSocketListener } from '../../hooks/useSocket';
 import { fetchBoard } from '../../api/board';
-import Board from '../board/Board';
 import { Spinner } from '../ui';
+import PostListItem from '../post/PostListItem';
 
 /**
  * RecentActivityBoard renders a board showing the latest activity for the
@@ -78,19 +78,34 @@ const RecentActivityBoard = ({ boardId = 'timeline-board' }) => {
     fetchBoard(boardId, { enrich: true, userId: user?.id }).then(setBoard);
   });
 
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = () => {
+      if (el.scrollHeight - el.scrollTop <= el.clientHeight + 150) {
+        loadMore();
+      }
+    };
+    el.addEventListener('scroll', handler);
+    return () => el.removeEventListener('scroll', handler);
+  }, [loadMore]);
+
   if (!board) return <Spinner />;
 
+  const items = board.enrichedItems || [];
+
   return (
-    <Board
-      boardId={boardId}
-      board={board}
-      layout="list"
-      compact
-      hideControls
-      onScrollEnd={loadMore}
-      loading={loading}
-      user={user}
-    />
+    <div
+      ref={containerRef}
+      className="space-y-2 overflow-y-auto max-h-[80vh] border rounded-lg p-2"
+    >
+      {items.map((item) => (
+        <PostListItem key={item.id} post={item} />
+      ))}
+      {loading && <Spinner />}
+    </div>
   );
 };
 

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -4,6 +4,7 @@ import Board from '../../components/board/Board';
 import PostCard from '../../components/post/PostCard';
 import { useSocket } from '../../hooks/useSocket';
 import { Spinner } from '../../components/ui';
+import { useAuth } from '../../contexts/AuthContext';
 
 import { fetchPostById, fetchReplyBoard } from '../../api/post';
 import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
@@ -14,6 +15,7 @@ import type { BoardData } from '../../types/boardTypes';
 const PostPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { socket } = useSocket();
+  const { user } = useAuth();
 
   const [post, setPost] = useState<Post | null>(null);
   const [replyBoard, setReplyBoard] = useState<BoardData | null>(null);
@@ -121,6 +123,7 @@ const PostPage: React.FC = () => {
             editable={false}
             compact={true}
             initialExpanded={true}
+            user={user || undefined}
           />
         ) : (
           <Spinner />


### PR DESCRIPTION
## Summary
- show post headers only on RecentActivityBoard
- ensure Post page shows reply form

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest config / module errors)*
- `npm test --prefix ethos-backend` *(fails: missing supertest/bcryptjs)*

------
https://chatgpt.com/codex/tasks/task_e_6856ed743b44832fb13ba67dffad4c80