### PR TITLE
Improve quest board layout

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -10,7 +10,7 @@ import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
-const QUEST_BOARD_TYPES = ['request', 'review', 'issue', 'task'];
+const QUEST_BOARD_TYPES = ['request', 'review', 'issue'];
 const getQuestBoardItems = (
   posts: ReturnType<typeof postsStore.read>
 ) => {
@@ -20,7 +20,7 @@ const getQuestBoardItems = (
       if (p.type === 'request') {
         return p.visibility === 'public' || p.visibility === 'request_board';
       }
-      return p.helpRequest === true;
+      return p.visibility === 'public';
     })
     .map((p) => p.id);
   return ids;

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -61,6 +61,7 @@ const HomePage: React.FC = () => {
           title="🗺️ Quest Board"
           layout="grid"
           gridLayout="paged"
+          compact
           user={user as User}
           hideControls
           filter={postType ? { postType } : {}}


### PR DESCRIPTION
## Summary
- update quest board items to only display request/review/issue posts
- make paged grid horizontally scrollable with progress dots
- show quest board with compact cards on home page

## Testing
- `npm test` *(fails: Jest failed to process frontend ESM modules)*
- `npm test` in `ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6856f0a69fe8832fb798dfee49ef02c6