### PR TITLE
Improve quest board request handling

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -10,17 +10,16 @@ import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
-const QUEST_BOARD_TYPES = ['request', 'review', 'issue', 'task'];
+// Only request posts should appear on the quest board. Other post types can
+// generate request posts, but the board itself shows requests only.
+const QUEST_BOARD_TYPES = ['request'];
 const getQuestBoardItems = (
   posts: ReturnType<typeof postsStore.read>
 ) => {
   const ids = posts
     .filter((p) => {
-      if (!QUEST_BOARD_TYPES.includes(p.type)) return false;
-      if (p.type === 'request') {
-        return p.visibility === 'public' || p.visibility === 'request_board';
-      }
-      return p.helpRequest === true;
+      if (p.type !== 'request') return false;
+      return p.visibility === 'public' || p.visibility === 'request_board';
     })
     .map((p) => p.id);
   return ids;
@@ -291,12 +290,21 @@ router.get(
       .filter((item) => {
         if ('type' in item) {
           const p = item as DBPost;
-          return p.type !== 'request' || p.visibility === 'public' || p.visibility === 'request_board' || p.needsHelp === true;
+          if (p.type !== 'request') return false;
+          return (
+            p.visibility === 'public' ||
+            p.visibility === 'request_board' ||
+            p.needsHelp === true
+          );
         }
         const q = item as DBQuest;
         if (q.displayOnBoard === false) return false;
         if (q.status === 'active' && userId) {
-          const participant = q.authorId === userId || (q.collaborators || []).some((c: { userId?: string }) => c.userId === userId);
+          const participant =
+            q.authorId === userId ||
+            (q.collaborators || []).some(
+              (c: { userId?: string }) => c.userId === userId
+            );
           if (!participant) return false;
         }
         return true;

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -141,15 +141,10 @@ router.post(
     const parent = replyTo ? posts.find(p => p.id === replyTo) : null;
 
     if (boardId === 'quest-board') {
-      const allowed = ['request', 'review', 'issue', 'task'];
-      if (!allowed.includes(type)) {
+      if (type !== 'request') {
         res
           .status(400)
-          .json({ error: 'Only request, review, issue, or task posts allowed on this board' });
-        return;
-      }
-      if (type !== 'request' && helpRequest !== true) {
-        res.status(400).json({ error: 'Help request flag required' });
+          .json({ error: 'Only request posts allowed on this board' });
         return;
       }
     }
@@ -468,6 +463,46 @@ router.post(
         { itemId: task.id, itemType: 'post', linkType: 'reference' },
       ],
       questId: task.questId || null,
+      helpRequest: true,
+      needsHelp: true,
+    };
+
+    posts.push(requestPost);
+    postsStore.write(posts);
+    const users = usersStore.read();
+    res.status(201).json(enrichPost(requestPost, { users }));
+  }
+);
+
+//
+// ✅ POST /api/posts/:id/request-help – Create a help request from any post
+//
+router.post(
+  '/:id/request-help',
+  authMiddleware,
+  (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
+    const posts = postsStore.read();
+    const original = posts.find((p) => p.id === req.params.id);
+    if (!original) {
+      res.status(404).json({ error: 'Post not found' });
+      return;
+    }
+
+    const requestPost: DBPost = {
+      id: uuidv4(),
+      authorId: req.user!.id,
+      type: 'request',
+      content: original.content,
+      visibility: original.visibility,
+      timestamp: new Date().toISOString(),
+      tags: [],
+      collaborators: [],
+      replyTo: null,
+      repostedFrom: null,
+      linkedItems: [
+        { itemId: original.id, itemType: 'post', linkType: 'reference' },
+      ],
+      questId: original.questId || null,
       helpRequest: true,
       needsHelp: true,
     };

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -316,7 +316,33 @@ describe('post routes', () => {
     expect((store[1].linkedItems as any[])[0].itemId).toBe('t1');
   });
 
-  it('rejects non-help posts on quest board', async () => {
+  it('POST /:id/request-help creates request post', async () => {
+    const post = {
+      id: 'p2',
+      authorId: 'u1',
+      type: 'issue',
+      content: 'issue content',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+      questId: null,
+    };
+
+    const store = [post];
+    postsStore.read.mockReturnValue(store);
+    usersStore.read.mockReturnValue([]);
+
+    const res = await request(app).post('/posts/p2/request-help');
+
+    expect(res.status).toBe(201);
+    expect(store).toHaveLength(2);
+    expect(store[1].type).toBe('request');
+    expect((store[1].linkedItems as any[])[0].itemId).toBe('p2');
+  });
+
+  it('rejects non-request posts on quest board', async () => {
     const res = await request(app)
       .post('/posts')
       .send({ type: 'free_speech', boardId: 'quest-board' });
@@ -334,13 +360,12 @@ describe('post routes', () => {
     expect(written.helpRequest).toBe(true);
   });
 
-  it('allows task post with help flag on quest board', async () => {
+  it('rejects task post on quest board', async () => {
     postsStore.read.mockReturnValue([]);
-    postsStore.write.mockClear();
     const res = await request(app)
       .post('/posts')
       .send({ type: 'task', boardId: 'quest-board', helpRequest: true });
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(400);
   });
 
   it('rejects quest post on quest board', async () => {

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -211,10 +211,10 @@ export const solvePost = async (postId: string): Promise<{ success: boolean }> =
 };
 
 /**
- * 🤝 Request help for a task
+ * 🤝 Request help for any post
  */
-export const requestHelpForTask = async (taskId: string): Promise<Post> => {
-  const res = await axiosWithAuth.post(`/posts/tasks/${taskId}/request-help`);
+export const requestHelp = async (postId: string): Promise<Post> => {
+  const res = await axiosWithAuth.post(`/posts/${postId}/request-help`);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -65,7 +65,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
   const allowedPostTypes: PostType[] =
     boardId === 'quest-board'
-      ? ['request', 'review', 'issue', 'task']
+      ? ['request']
       : boardType === 'quest'
       ? ['quest', 'task', 'log']
       : boardType === 'post'

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -2,12 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
-import { requestHelpForTask } from '../../api/post';
+import { requestHelp } from '../../api/post';
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
-  requestHelpForTask: jest.fn(() =>
+  requestHelp: jest.fn(() =>
     Promise.resolve({
       id: 'r1',
       authorId: 'u1',
@@ -59,7 +59,7 @@ describe('PostCard request help', () => {
 
     fireEvent.click(screen.getByText(/Request Help/i));
 
-    await waitFor(() => expect(requestHelpForTask).toHaveBeenCalledWith('t1'));
+    await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
     expect(appendMock).toHaveBeenCalled();
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -6,7 +6,7 @@ import { formatDistanceToNow } from 'date-fns';
 import type { Post, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelpForTask } from '../../api/post';
+import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp } from '../../api/post';
 import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
@@ -88,10 +88,13 @@ const PostCard: React.FC<PostCardProps> = ({
     }
   };
 
+  const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
+
   const handleRequestHelp = async () => {
     try {
-      const reqPost = await requestHelpForTask(post.id);
+      const reqPost = await requestHelp(post.id);
       appendToBoard?.('quest-board', reqPost);
+      setHelpRequested(true);
     } catch (err) {
       console.error('[PostCard] Failed to request help:', err);
     }
@@ -543,13 +546,18 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {post.type === 'task' && (
-        <button
-          onClick={handleRequestHelp}
-          className="text-accent underline text-xs mt-1"
-        >
+      {post.type !== 'request' && (
+        <label className="flex items-center gap-1 text-xs mt-1">
+          <input
+            type="checkbox"
+            checked={helpRequested}
+            onChange={() => !helpRequested && handleRequestHelp()}
+          />
           Request Help
-        </button>
+          {helpRequested && (
+            <span className="ml-1 text-secondary">tracking</span>
+          )}
+        </label>
       )}
 
       {(initialReplies > 0 || replies.length > 0) && (

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -61,6 +61,7 @@ const HomePage: React.FC = () => {
           title="🗺️ Quest Board"
           layout="grid"
           gridLayout="paged"
+          compact
           user={user as User}
           hideControls
           filter={postType ? { postType } : {}}


### PR DESCRIPTION
## Summary
- only allow request posts on quest board
- add /posts/:id/request-help endpoint
- add Request Help checkbox for all posts
- restrict create post form to requests on quest board

## Testing
- `npm test` in `ethos-backend` *(fails: missing modules)*
- `npm test` in `ethos-frontend` *(fails: missing jest environment)*

------
https://chatgpt.com/codex/tasks/task_e_6856f0a69fe8832fb798dfee49ef02c6