### PR TITLE
Allow board posts to expand replies initially

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -22,6 +22,8 @@ interface ContributionCardProps {
   showStatusControl?: boolean;
   /** Render only the post header */
   headerOnly?: boolean;
+  /** Expand replies when rendering PostCard */
+  initialShowReplies?: boolean;
 }
 
 const ContributionCard: React.FC<ContributionCardProps> = ({
@@ -33,6 +35,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   questId,
   showStatusControl = true,
   headerOnly = false,
+  initialShowReplies = false,
 }) => {
   if (!contribution) return null;
 
@@ -43,7 +46,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
     return null;
   }
 
-  const sharedProps = { user, compact, onEdit, onDelete, showStatusControl, headerOnly };
+  const sharedProps = { user, compact, onEdit, onDelete, showStatusControl, headerOnly, initialShowReplies };
 
   // ✅ Render Post types
   if ('type' in contribution) {

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -28,6 +28,8 @@ type GridLayoutProps = {
   onDelete?: (id: string) => void;
   onScrollEnd?: () => void;
   loadingMore?: boolean;
+  /** Expand replies for all posts */
+  initialExpanded?: boolean;
 };
 
 const defaultKanbanColumns = ['To Do', 'In Progress', 'Blocked', 'Done'];
@@ -38,7 +40,8 @@ const DraggableCard: React.FC<{
   compact: boolean;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
-}> = ({ item, user, compact, onEdit, onDelete }) => {
+  initialExpanded?: boolean;
+}> = ({ item, user, compact, onEdit, onDelete, initialExpanded }) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: item.id,
     data: { item },
@@ -60,6 +63,7 @@ const DraggableCard: React.FC<{
         compact={compact}
         onEdit={onEdit}
         onDelete={onDelete}
+        initialShowReplies={initialExpanded}
       />
     </div>
   );
@@ -236,6 +240,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                 compact={compact || idx !== index}
                 onEdit={onEdit}
                 onDelete={onDelete}
+                initialShowReplies={initialExpanded}
               />
             </div>
           ))}
@@ -332,6 +337,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                   compact={compact}
                   onEdit={onEdit}
                   onDelete={onDelete}
+                  initialShowReplies={initialExpanded}
                 />
               ))}
             </div>
@@ -378,6 +384,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               compact={compact}
               onEdit={onEdit}
               onDelete={onDelete}
+              initialShowReplies={initialExpanded}
             />
           ))}
           {loadingMore && <Spinner />}
@@ -419,6 +426,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
             compact={compact}
             onEdit={onEdit}
             onDelete={onDelete}
+            initialShowReplies={initialExpanded}
           />
         </div>
       ))}

--- a/ethos-frontend/src/components/layout/ListLayout.tsx
+++ b/ethos-frontend/src/components/layout/ListLayout.tsx
@@ -15,6 +15,8 @@ interface ListLayoutProps {
   onScrollEnd?: () => void;
   loadingMore?: boolean;
   headerOnly?: boolean;
+  /** Expand replies for all posts */
+  initialExpanded?: boolean;
 }
 
 const ListLayout: React.FC<ListLayoutProps> = ({
@@ -27,6 +29,7 @@ const ListLayout: React.FC<ListLayoutProps> = ({
   onScrollEnd,
   loadingMore = false,
   headerOnly = false,
+  initialExpanded = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -65,6 +68,7 @@ const ListLayout: React.FC<ListLayoutProps> = ({
           onDelete={onDelete}
           questId={questId}
           headerOnly={headerOnly}
+          initialShowReplies={initialExpanded}
         />
       ))}
       {loadingMore && <Spinner />}

--- a/ethos-frontend/src/components/post/PostCard.initialShowReplies.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.initialShowReplies.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+import { fetchRepliesByPostId } from '../../api/post';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({})
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+const mockReply: Post = {
+  id: 'r1',
+  authorId: 'u2',
+  type: 'free_speech',
+  content: 'Reply',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+  replyTo: 'p1'
+} as any;
+
+describe('PostCard initialShowReplies', () => {
+  const basePost: Post = {
+    id: 'p1',
+    authorId: 'u1',
+    type: 'free_speech',
+    content: 'Post',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+  } as any;
+
+  it('loads and displays replies automatically', async () => {
+    (fetchRepliesByPostId as jest.Mock).mockResolvedValue([mockReply]);
+    render(
+      <BrowserRouter>
+        <PostCard post={basePost} initialShowReplies />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => expect(fetchRepliesByPostId).toHaveBeenCalled());
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `initialShowReplies` prop to `PostCard`
- propagate new prop through `ContributionCard`, `GridLayout`, and `ListLayout`
- automatically fetch replies when `initialShowReplies` is true
- test auto-loaded replies

## Testing
- `npm test` *(fails: Jest couldn't parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856fa30c35c832f8e55d2aa63141e6b