### PR TITLE
Update CreatePost reply behavior

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -48,7 +48,12 @@ const CreatePost: React.FC<CreatePostProps> = ({
   initialLinkedNodeId,
   currentView,
 }) => {
-  const [type, setType] = useState<PostType>(initialType);
+  const restrictedReply =
+    replyTo && ['task', 'log', 'commit', 'issue'].includes(replyTo.type);
+
+  const [type, setType] = useState<PostType>(
+    restrictedReply ? 'log' : initialType
+  );
   const [status, setStatus] = useState<string>('To Do');
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
@@ -63,14 +68,15 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   const boardType: BoardType | undefined =
     boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
 
-  const allowedPostTypes: PostType[] =
-    boardId === 'quest-board'
-      ? ['request']
-      : boardType === 'quest'
-      ? ['quest', 'task', 'log']
-      : boardType === 'post'
-      ? ['quest', 'free_speech', 'request', 'review']
-      : POST_TYPES.map((p) => p.value as PostType);
+  const allowedPostTypes: PostType[] = restrictedReply
+    ? ['log']
+    : boardId === 'quest-board'
+    ? ['request']
+    : boardType === 'quest'
+    ? ['quest', 'task', 'log']
+    : boardType === 'post'
+    ? ['quest', 'free_speech', 'request', 'review']
+    : POST_TYPES.map((p) => p.value as PostType);
 
   const renderQuestForm = type === 'quest';
 
@@ -81,7 +87,9 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
     const targetBoard = boardId || selectedBoard;
     const boardQuestMatch = targetBoard?.match(/^(?:log|map)-(.+)$/);
-    const questIdFromBoard = boardQuestMatch ? boardQuestMatch[1] : questId || null;
+    const questIdFromBoard = boardQuestMatch
+      ? boardQuestMatch[1]
+      : questId || replyTo?.questId || null;
 
     // Check for quest linkage if required
     if (requiresQuestLink(type)) {

--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: null,
+    boards: {},
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+const CreatePost = require('../src/components/post/CreatePost').default;
+
+const { addPost } = require('../src/api/post');
+
+describe('CreatePost replying', () => {
+  it('limits options to log when replying to a task', () => {
+    const reply = { id: 't1', type: 'task' } as any;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={reply} />
+      </BrowserRouter>
+    );
+    const options = Array.from(
+      screen.getByLabelText('Item Type').querySelectorAll('option')
+    ).map((o) => o.textContent);
+    expect(options).toEqual(['Quest Log']);
+  });
+
+  it('includes reply questId in payload', async () => {
+    const reply = { id: 'r1', type: 'task', questId: 'q123' } as any;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={reply} />
+      </BrowserRouter>
+    );
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 't' } });
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'content' },
+    });
+    fireEvent.click(screen.getByText('Create Post'));
+    await waitFor(() => expect(addPost).toHaveBeenCalled());
+    expect(addPost).toHaveBeenCalledWith(
+      expect.objectContaining({ questId: 'q123' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- restrict CreatePost type to logs when replying to tasks, logs, commits or issues
- auto-forward questId from the parent when replying
- add regression tests for reply behavior

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest encountered unexpected token due to ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856fa43f1dc832f95f78b6b4c9e52f1