### PR TITLE
Add timeline reply navigation

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.test.tsx
@@ -13,12 +13,21 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
+const navigateMock = jest.fn();
+
+const useBoardContextMock = jest.fn(() => ({ selectedBoard: null }));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => useBoardContextMock(),
+}));
+
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return {
     __esModule: true,
     ...actual,
-    useNavigate: () => jest.fn(),
+    useNavigate: () => navigateMock,
   };
 });
 
@@ -90,5 +99,17 @@ describe('ReactionControls', () => {
     const btn = screen.getByText('Add Item');
     fireEvent.click(btn);
     expect(handler).toHaveBeenCalled();
+  });
+
+  it('navigates to post page with reply flag when on timeline board', () => {
+    useBoardContextMock.mockReturnValue({ selectedBoard: 'timeline-board' });
+    const fsPost = { ...basePost, type: 'free_speech' } as Post;
+    render(
+      <BrowserRouter>
+        <ReactionControls post={fsPost} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
+    fireEvent.click(screen.getByText('Reply'));
+    expect(navigateMock).toHaveBeenCalledWith('/post/p1?reply=1');
   });
 });

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useBoardContext } from '../../contexts/BoardContext';
 import { ROUTES } from '../../constants/routes';
 import {
   FaThumbsUp,
@@ -33,6 +34,8 @@ interface ReactionControlsProps {
   onToggleReplies?: () => void;
   /** Override default reply behavior */
   replyOverride?: { label: string; onClick: () => void };
+  /** Treat reply action as coming from the timeline board */
+  isTimeline?: boolean;
 }
 
 const ReactionControls: React.FC<ReactionControlsProps> = ({
@@ -43,6 +46,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   showReplies,
   onToggleReplies,
   replyOverride,
+  isTimeline,
 }) => {
   const [reactions, setReactions] = useState({ like: false, heart: false });
   const [counts, setCounts] = useState({ like: 0, heart: 0, repost: 0 });
@@ -53,6 +57,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [repostLoading, setRepostLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const navigate = useNavigate();
+  const { selectedBoard } = useBoardContext() || {};
+  const isTimelineBoard = isTimeline ?? selectedBoard === 'timeline-board';
 
   useEffect(() => {
     const fetchData = async () => {
@@ -168,6 +174,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               navigate(ROUTES.BOARD(`log-${post.questId}`));
             } else if (post.type === 'commit') {
               navigate(ROUTES.POST(post.id));
+            } else if (isTimelineBoard) {
+              navigate(ROUTES.POST(post.id) + '?reply=1');
             } else {
               setShowReplyPanel(prev => !prev);
             }

--- a/ethos-frontend/src/pages/__tests__/PostPageReply.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/PostPageReply.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostPage from '../post/[id]';
+
+const fetchPostById = jest.fn(() => Promise.resolve({
+  id: 'p1',
+  authorId: 'u1',
+  type: 'free_speech',
+  content: 'hi',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+}));
+const fetchReplyBoard = jest.fn(() => Promise.resolve({ id: 'thread-p1', items: [], enrichedItems: [] }));
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchPostById: (...args: any[]) => fetchPostById(...args),
+  fetchReplyBoard: (...args: any[]) => fetchReplyBoard(...args),
+}));
+
+jest.mock('../../components/board/Board', () => ({
+  __esModule: true,
+  default: () => <div>Board</div>,
+}));
+
+jest.mock('../../components/post/PostCard', () => ({
+  __esModule: true,
+  default: () => <div>PostCard</div>,
+}));
+
+jest.mock('../../components/post/CreatePost', () => ({
+  __esModule: true,
+  default: () => <div>CreatePost</div>,
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+jest.mock('../../hooks/useSocket', () => ({
+  useSocket: () => ({ socket: null }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useParams: () => ({ id: 'p1' }),
+    useSearchParams: () => [new URLSearchParams('reply=1')],
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('PostPage reply flag', () => {
+  it('auto opens reply form when reply=1', async () => {
+    render(
+      <BrowserRouter>
+        <PostPage />
+      </BrowserRouter>
+    );
+    await waitFor(() => expect(fetchPostById).toHaveBeenCalled());
+    expect(screen.getByText('CreatePost')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import Board from '../../components/board/Board';
 import PostCard from '../../components/post/PostCard';
+import CreatePost from '../../components/post/CreatePost';
 import { useSocket } from '../../hooks/useSocket';
 import { Spinner } from '../../components/ui';
 import { useAuth } from '../../contexts/AuthContext';
+
+import { ROUTES } from '../../constants/routes';
 
 import { fetchPostById, fetchReplyBoard } from '../../api/post';
 import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
@@ -16,6 +19,8 @@ const PostPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { socket } = useSocket();
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const [post, setPost] = useState<Post | null>(null);
   const [replyBoard, setReplyBoard] = useState<BoardData | null>(null);
@@ -23,11 +28,18 @@ const PostPage: React.FC = () => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(1);
+  const [showReplyForm, setShowReplyForm] = useState(false);
 
   const boardWithPost = useMemo<BoardData | null>(() => {
     if (!replyBoard) return null;
     return replyBoard;
   }, [replyBoard]);
+
+  useEffect(() => {
+    if (searchParams.get('reply') === '1') {
+      setShowReplyForm(true);
+    }
+  }, [searchParams]);
 
   const fetchPostData = useCallback(async () => {
     if (!id) return;
@@ -109,6 +121,22 @@ const PostPage: React.FC = () => {
 
       <section>
         <PostCard post={post} />
+        {showReplyForm && (
+          <div className="mt-4">
+            <CreatePost
+              replyTo={post}
+              onSave={() => {
+                setShowReplyForm(false);
+                navigate(ROUTES.POST(post.id), { replace: true });
+                fetchPostData();
+              }}
+              onCancel={() => {
+                setShowReplyForm(false);
+                navigate(ROUTES.POST(post.id), { replace: true });
+              }}
+            />
+          </div>
+        )}
       </section>
 
 


### PR DESCRIPTION
## Summary
- detect timeline board in `ReactionControls`
- navigate to single post with `?reply=1` when replying from timeline
- auto-open reply form on `PostPage` when `reply=1`
- cover behaviour with unit tests

## Testing
- `npm test --silent` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd89d3dc832fb0f7645126573c72