### PR TITLE
Add accept request endpoint and UI

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -219,6 +219,16 @@ export const requestHelp = async (postId: string): Promise<Post> => {
 };
 
 /**
+ * ✅ Accept a help request
+ */
+export const acceptRequest = async (
+  postId: string
+): Promise<{ post: Post; quest: any }> => {
+  const res = await axiosWithAuth.post(`/posts/${postId}/accept`);
+  return res.data;
+};
+
+/**
  * 🔗 Get all posts linked to a post (e.g. solutions, duplicates, references)
  * @param postId - Post ID
  */

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -6,7 +6,7 @@ import { formatDistanceToNow } from 'date-fns';
 import type { Post, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp } from '../../api/post';
+import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest } from '../../api/post';
 import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
@@ -92,6 +92,8 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
+  const [accepting, setAccepting] = useState(false);
+  const [accepted, setAccepted] = useState(false);
 
   const handleRequestHelp = async () => {
     try {
@@ -100,6 +102,18 @@ const PostCard: React.FC<PostCardProps> = ({
       setHelpRequested(true);
     } catch (err) {
       console.error('[PostCard] Failed to request help:', err);
+    }
+  };
+
+  const handleAccept = async () => {
+    try {
+      setAccepting(true);
+      await acceptRequest(post.id);
+      setAccepted(true);
+    } catch (err) {
+      console.error('[PostCard] Failed to accept request:', err);
+    } finally {
+      setAccepting(false);
     }
   };
 
@@ -298,6 +312,15 @@ const PostCard: React.FC<PostCardProps> = ({
           </h3>
         )}
         <ReactionControls post={post} user={user} onUpdate={onUpdate} replyOverride={replyOverride} />
+        {post.type === 'request' && (
+          <button
+            className="text-accent underline text-xs ml-2"
+            onClick={handleAccept}
+            disabled={accepting || accepted}
+          >
+            {accepted || accepting ? 'Pending…' : 'Accept'}
+          </button>
+        )}
       </div>
     );
   }
@@ -509,6 +532,15 @@ const PostCard: React.FC<PostCardProps> = ({
         onUpdate={onUpdate}
         replyOverride={replyOverride}
       />
+      {post.type === 'request' && (
+        <button
+          className="text-accent underline text-xs ml-2"
+          onClick={handleAccept}
+          disabled={accepting || accepted}
+        >
+          {accepted || accepting ? 'Pending…' : 'Accept'}
+        </button>
+      )}
 
       {post.type === 'task' && post.linkedNodeId && post.questId && (
         <>

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from '../src/components/post/PostCard';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+  updatePost: jest.fn(() => Promise.resolve({})),
+  fetchPostsByQuestId: jest.fn(() => Promise.resolve([])),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+  requestHelp: jest.fn(() => Promise.resolve({})),
+  acceptRequest: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../src/api/quest', () => ({
+  __esModule: true,
+  linkPostToQuest: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../src/hooks/useGraph', () => ({
+  __esModule: true,
+  useGraph: () => ({ loadGraph: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: 'b1',
+    updateBoardItem: jest.fn(),
+    boards: { b1: { boardType: 'post' } },
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+const { acceptRequest } = require('../src/api/post');
+
+describe('accept request button', () => {
+  const post = {
+    id: 'p1',
+    authorId: 'u2',
+    type: 'request',
+    content: 'help me',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+  } as any;
+
+  it('shows accept button for request posts', () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Accept')).toBeInTheDocument();
+  });
+
+  it('calls API when clicked', () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
+    fireEvent.click(screen.getByText('Accept'));
+    expect(acceptRequest).toHaveBeenCalledWith('p1');
+  });
+});


### PR DESCRIPTION
## Summary
- allow users to accept help requests via `/api/posts/:id/accept`
- expose `acceptRequest` helper in frontend API
- show **Accept** button on request posts
- basic test for the new button

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd94bb4c832f9c2c45621742706a