### PR TITLE
Add new post tags and surface them

### DIFF
--- a/.github/posts.json
+++ b/.github/posts.json
@@ -20,7 +20,9 @@
     "content": "you can reply which is standard",
     "visibility": "public",
     "timestamp": "2025-06-12T15:58:58.605Z",
-    "tags": [],
+    "tags": [
+      "task"
+    ],
     "collaborators": [],
     "replyTo": "c882ad20-74f4-4f19-9484-81818ccd5915",
     "repostedFrom": null,
@@ -34,7 +36,9 @@
     "content": "I want to put on a battle of the bands.\nAny one down to help out and collaborate?",
     "visibility": "public",
     "timestamp": "2025-06-12T15:59:47.676Z",
-    "tags": [],
+    "tags": [
+      "issue"
+    ],
     "collaborators": [],
     "replyTo": null,
     "repostedFrom": null,
@@ -58,7 +62,9 @@
     "content": "Make poster design's:\n\n- [x] 1. Instagram poster - IN PROGRESS\n- [ ] 2. Website event poster\n  - [ ] Pre event poster - Free \n   - [ ] Simplest approach would be to have a vendor viewing and pre signing , listen party  or get to meet the judges if they are famous \n  - [ ] Main event poster - Early Admission, Special Deals, & General admission\n    - [ ] 4 - 8 bands tournament style \n  - [ ] Afterparty poster - Early bird, General entry\n    - [ ] closed of venue or spefic club partmenad with to pleay crataors music or have a photographer ready, possible singing\n  - [ ] Get Updates pages\n    - [ ] email subscriptions to stay up to date\n  - [ ] Get Tickets pages\n    - [ ] Posh and architecture of homosapien's \n\n",
     "visibility": "public",
     "timestamp": "2025-06-12T16:08:03.282Z",
-    "tags": [],
+    "tags": [
+      "task"
+    ],
     "collaborators": [],
     "replyTo": null,
     "repostedFrom": null,
@@ -84,7 +90,9 @@
     "content": "Post and quest I make aren't showing up on my profile page",
     "visibility": "public",
     "timestamp": "2025-06-12T16:11:15.473Z",
-    "tags": [],
+    "tags": [
+      "issue"
+    ],
     "collaborators": [],
     "replyTo": null,
     "repostedFrom": null,

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -47,6 +47,9 @@ export type PostTag =
   | 'release'
   | 'repost'
   | 'quest'
+  | 'task'
+  | 'issue'
+  | 'review'
   | string;
 
 /**

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -411,6 +411,18 @@ const PostCard: React.FC<PostCardProps> = ({
           </div>
         )}
         <MediaPreview media={post.mediaPreviews} />
+        {post.tags && post.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {post.tags.map(tag => (
+              <span
+                key={tag}
+                className="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded text-gray-700 dark:text-gray-200"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {renderCommitDiff()}

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -178,6 +178,9 @@ export type PostTag =
   | 'release'
   | 'repost'
   | 'quest'
+  | 'task'
+  | 'issue'
+  | 'review'
   | string;
 
 


### PR DESCRIPTION
## Summary
- allow `task`, `issue`, `review` tags on posts
- display tags in PostCard component
- add example tags in sample posts
- sync API PostTag union with frontend

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: Jest configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd9797d4832f9dcfbdad39b95703