### PR TITLE
Fix PostCard replies prop

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -47,6 +47,8 @@ interface PostCardProps {
   depth?: number;
   /** Additional classes for outer wrapper */
   className?: string;
+  /** Expand replies when first rendered */
+  initialShowReplies?: boolean;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -61,6 +63,7 @@ const PostCard: React.FC<PostCardProps> = ({
   headerOnly = false,
   depth = 0,
   className = '',
+  initialShowReplies = false,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [replies, setReplies] = useState<Post[]>([]);


### PR DESCRIPTION
## Summary
- allow passing `initialShowReplies` to PostCard to control initial reply visibility

## Testing
- `npm test --prefix ethos-frontend` *(fails: TypeError: fetchAllPosts is not a function)*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6857000f6c40832fa23265490799fc83