### PR TITLE
Update quest left panel

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -238,21 +238,23 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           style={{ marginLeft: depth * 16 }}
           className="mb-6 flex items-start space-x-2 cursor-pointer"
           onClick={() => onSelect(node)}
-          onDoubleClick={() =>
+          onDoubleClick={() => {
+            onSelect(node);
             window.dispatchEvent(
               new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
-            )
-          }
+            );
+          }}
         >
           <span
             className="text-xl select-none cursor-grab"
             {...attributes}
             {...listeners}
-            onDoubleClick={() =>
+            onDoubleClick={() => {
+              onSelect(node);
               window.dispatchEvent(
                 new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
-              )
-            }
+              );
+            }}
           >
             {icon}
           </span>

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -225,121 +225,11 @@ const QuestCard: React.FC<QuestCardProps> = ({
 
   const renderMap = () => {
     if (!expanded) return null;
-    if (mapMode === "graph") {
-      return (
-        <>
-          {selectedNode && (
-            <div className="mb-2">
-              <TaskPreviewCard post={selectedNode} />
-            </div>
-          )}
-          <Select
-            className="mb-2"
-            value={mapMode}
-            onChange={(e) => setMapMode(e.target.value as "folder" | "graph")}
-            options={mapOptions}
-          />
-          <MapGraphLayout items={logs as any} edges={questData.taskGraph} />
-        </>
-      );
-    }
-    return (
-      <>
-        {selectedNode && (
-          <div className="mb-2">
-            <TaskPreviewCard post={selectedNode} />
-          </div>
-        )}
-        <Select
-          className="mb-2"
-          value={mapMode}
-          onChange={(e) => setMapMode(e.target.value as "folder" | "graph")}
-          options={mapOptions}
-        />
-        {openTaskId && (
-          (() => {
-            const task = logs.find((p) => p.id === openTaskId);
-            if (!task) return null;
-            return (
-              <div className="mb-2 border border-secondary rounded">
-                <div
-                  className="flex justify-between items-center p-2 bg-background cursor-pointer"
-                  onClick={() => setTaskCardOpen((prev) => !prev)}
-                >
-                  <span className="font-semibold text-sm">
-                    {task.content.slice(0, 40)}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      className="text-xs underline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setOpenTaskId(null);
-                      }}
-                    >
-                      ✕
-                    </button>
-                    <span className="text-xs">{taskCardOpen ? '▲' : '▼'}</span>
-                  </div>
-                </div>
-                {taskCardOpen && (
-                  <div className="p-2 space-y-2">
-                    {showAddItemForm && (
-                      <CreatePost
-                        questId={quest.id}
-                        boardId={`map-${quest.id}`}
-                        replyTo={task}
-                        onSave={(p) => {
-                          setLogs((prev) => [...prev, p]);
-                          setShowAddItemForm(false);
-                        }}
-                        onCancel={() => setShowAddItemForm(false)}
-                      />
-                    )}
-                    <TaskPreviewCard post={task} />
-                    <div className="text-right">
-                      <button
-                        className="text-accent underline text-xs"
-                        onClick={() => setShowAddItemForm(true)}
-                      >
-                        Add Item
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })()
-        )}
-        {showTaskForm && (
-          <div className="mb-4">
-            <CreatePost
-              initialType="task"
-              questId={quest.id}
-              boardId={`map-${quest.id}`}
-              onSave={(p) => {
-                setLogs((prev) => [...prev, p]);
-                setShowTaskForm(false);
-              }}
-              onCancel={() => setShowTaskForm(false)}
-            />
-          </div>
-        )}
-        <div className="text-right mb-2">
-          {canEdit ? (
-            <Button
-              size="sm"
-              variant="contrast"
-              onClick={() => setShowTaskForm(true)}
-            >
-              + Add Item
-            </Button>
-          ) : (
-            <Button size="sm" variant="contrast" onClick={handleJoinRequest}>
-              Request to Join
-            </Button>
-          )}
-        </div>
+
+    const canvas =
+      mapMode === 'graph' ? (
+        <MapGraphLayout items={logs as any} edges={questData.taskGraph} />
+      ) : (
         <GraphLayout
           items={logs as any}
           user={user}
@@ -350,7 +240,73 @@ const QuestCard: React.FC<QuestCardProps> = ({
           onSelectNode={setSelectedNode}
           showInspector={false}
         />
-      </>
+      );
+
+    return (
+      <div className="space-y-2">
+        {selectedNode && (
+          <div className="space-y-2">
+            <TaskPreviewCard post={selectedNode} />
+            {showTaskForm && (
+              <CreatePost
+                initialType="task"
+                questId={quest.id}
+                boardId={`map-${quest.id}`}
+                replyTo={selectedNode}
+                onSave={(p) => {
+                  setLogs((prev) => [...prev, p]);
+                  setShowTaskForm(false);
+                }}
+                onCancel={() => setShowTaskForm(false)}
+              />
+            )}
+            <div className="text-right">
+              {canEdit ? (
+                <Button
+                  size="sm"
+                  variant="contrast"
+                  onClick={() => setShowTaskForm(true)}
+                >
+                  Add Subtask
+                </Button>
+              ) : (
+                <Button size="sm" variant="contrast" onClick={handleJoinRequest}>
+                  Request to Join
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+        <hr className="border-secondary" />
+        <div className="flex justify-between items-center text-sm">
+          <span className="font-semibold">Folder or Map Layout</span>
+          <div className="flex gap-1">
+            <button
+              className={`px-2 py-1 rounded text-xs border ${
+                mapMode === 'folder'
+                  ? 'bg-accent text-white border-accent'
+                  : 'border-secondary text-secondary'
+              }`}
+              onClick={() => setMapMode('folder')}
+            >
+              Folder
+            </button>
+            <button
+              className={`px-2 py-1 rounded text-xs border ${
+                mapMode === 'graph'
+                  ? 'bg-accent text-white border-accent'
+                  : 'border-secondary text-secondary'
+              }`}
+              onClick={() => setMapMode('graph')}
+            >
+              Map
+            </button>
+          </div>
+        </div>
+        <div className="h-96 overflow-auto" data-testid="quest-map-canvas">
+          {canvas}
+        </div>
+      </div>
     );
   };
 


### PR DESCRIPTION
## Summary
- tweak quest left panel to show a task header and layout toggle
- double-clicking a graph node now selects it

## Testing
- `npm test` *(fails: cannot parse esm modules)*

------
https://chatgpt.com/codex/tasks/task_e_68570360b100832fa1d0b80ad9dd6b01