### PR TITLE
Implement unaccept request endpoint and UI toggle

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -570,7 +570,33 @@ router.post(
     postsStore.write(posts);
 
     const users = usersStore.read();
-    res.json({ post: enrichPost(post, { users }), quest });
+  res.json({ post: enrichPost(post, { users }), quest });
+  }
+);
+
+//
+// ✅ POST /api/posts/:id/unaccept – Cancel a help request acceptance
+// Removes the pending tag for the current user
+//
+router.post(
+  '/:id/unaccept',
+  authMiddleware,
+  (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
+    const posts = postsStore.read();
+
+    const post = posts.find(p => p.id === req.params.id);
+    if (!post) {
+      res.status(404).json({ error: 'Post not found' });
+      return;
+    }
+
+    const userId = req.user!.id;
+    post.tags = (post.tags || []).filter(t => t !== `pending:${userId}`);
+
+    postsStore.write(posts);
+
+    const users = usersStore.read();
+    res.json({ post: enrichPost(post, { users }) });
   }
 );
 

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -229,6 +229,16 @@ export const acceptRequest = async (
 };
 
 /**
+ * ❌ Cancel acceptance of a help request
+ */
+export const unacceptRequest = async (
+  postId: string
+): Promise<{ post: Post }> => {
+  const res = await axiosWithAuth.post(`/posts/${postId}/unaccept`);
+  return res.data;
+};
+
+/**
  * 🔗 Get all posts linked to a post (e.g. solutions, duplicates, references)
  * @param postId - Post ID
  */

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -7,7 +7,7 @@ import { formatDistanceToNow } from 'date-fns';
 import type { Post, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest } from '../../api/post';
+import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest, unacceptRequest } from '../../api/post';
 import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
@@ -104,7 +104,9 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
   const [accepting, setAccepting] = useState(false);
-  const [accepted, setAccepted] = useState(false);
+  const [accepted, setAccepted] = useState(
+    post.tags?.includes(`pending:${user?.id}`) || false
+  );
 
   const handleRequestHelp = async () => {
     try {
@@ -119,8 +121,13 @@ const PostCard: React.FC<PostCardProps> = ({
   const handleAccept = async () => {
     try {
       setAccepting(true);
-      await acceptRequest(post.id);
-      setAccepted(true);
+      if (accepted) {
+        await unacceptRequest(post.id);
+        setAccepted(false);
+      } else {
+        await acceptRequest(post.id);
+        setAccepted(true);
+      }
     } catch (err) {
       console.error('[PostCard] Failed to accept request:', err);
     } finally {
@@ -349,9 +356,9 @@ const PostCard: React.FC<PostCardProps> = ({
           <button
             className="text-accent underline text-xs ml-2"
             onClick={handleAccept}
-            disabled={accepting || accepted}
+            disabled={accepting}
           >
-            {accepted || accepting ? 'Pending…' : 'Accept'}
+            {accepting ? 'Pending…' : accepted ? 'Pending' : 'Accept'}
           </button>
         )}
       </div>
@@ -585,9 +592,9 @@ const PostCard: React.FC<PostCardProps> = ({
         <button
           className="text-accent underline text-xs ml-2"
           onClick={handleAccept}
-          disabled={accepting || accepted}
+          disabled={accepting}
         >
-          {accepted || accepting ? 'Pending…' : 'Accept'}
+          {accepting ? 'Pending…' : accepted ? 'Pending' : 'Accept'}
         </button>
       )}
 

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../src/api/post', () => ({
   removeRepost: jest.fn(() => Promise.resolve()),
   requestHelp: jest.fn(() => Promise.resolve({})),
   acceptRequest: jest.fn(() => Promise.resolve({})),
+  unacceptRequest: jest.fn(() => Promise.resolve({})),
 }));
 
 jest.mock('../src/api/quest', () => ({
@@ -46,7 +47,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-const { acceptRequest } = require('../src/api/post');
+const { acceptRequest, unacceptRequest } = require('../src/api/post');
 
 describe('accept request button', () => {
   const post = {
@@ -78,5 +79,19 @@ describe('accept request button', () => {
     );
     fireEvent.click(screen.getByText('Accept'));
     expect(acceptRequest).toHaveBeenCalledWith('p1');
+  });
+
+  it('toggles pending state on second click', async () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' }} />
+      </BrowserRouter>
+    );
+    fireEvent.click(screen.getByText('Accept'));
+    await screen.findByText('Pending');
+
+    fireEvent.click(screen.getByText('Pending'));
+    expect(unacceptRequest).toHaveBeenCalledWith('p1');
+    await screen.findByText('Accept');
   });
 });


### PR DESCRIPTION
## Summary
- add `/api/posts/:id/unaccept` endpoint to remove pending tag
- expose `unacceptRequest` from post API
- update PostCard to toggle acceptance state
- test new accept/unaccept behaviour

## Testing
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570b7283fc832f911b0bee35169fc2