### PR TITLE
Fix request help visibility

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -50,6 +50,18 @@ describe('PostCard request help', () => {
     linkedItems: [],
   } as any;
 
+  const freeSpeechPost: Post = {
+    id: 'fs1',
+    authorId: 'u2',
+    type: 'free_speech',
+    content: 'hello',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+  } as any;
+
   it('calls endpoint and appends to board', async () => {
     render(
       <BrowserRouter>
@@ -61,5 +73,15 @@ describe('PostCard request help', () => {
 
     await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
     expect(appendMock).toHaveBeenCalled();
+  });
+
+  it('hides request help checkbox for free speech posts', () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={freeSpeechPost} user={{ id: 'u2' }} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByText(/Request Help/i)).toBeNull();
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -666,7 +666,7 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {post.type !== 'request' && (
+      {post.type !== 'request' && post.type !== 'free_speech' && (
         <label className="flex items-center gap-1 text-xs mt-1">
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- hide the 'Request Help' option for `free_speech` posts
- test that free speech posts do not render the checkbox

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest environment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68570b719120832fa94f416b6485f36c