### PR TITLE
Add RequestCard UI component

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PostCard from '../post/PostCard';
 import QuestCard from '../quest/QuestCard';
+import RequestCard from '../request/RequestCard';
 
 import type { Post } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
@@ -50,9 +51,13 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
 
   // ✅ Render Post types
   if ('type' in contribution) {
+    const post = contribution as Post;
+    if (post.type === 'request') {
+      return <RequestCard post={post} user={user} onUpdate={onEdit as any} />;
+    }
     return (
       <PostCard
-        post={contribution as Post}
+        post={post}
         questId={questId}
         {...sharedProps}
         headerOnly={headerOnly}

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+import { PostTypeBadge, Button } from '../ui';
+import CreatePost from '../post/CreatePost';
+
+interface RequestCardProps {
+  post: Post;
+  user?: User;
+  onUpdate?: (post: Post) => void;
+  className?: string;
+}
+
+const RequestCard: React.FC<RequestCardProps> = ({ post, user, onUpdate, className }) => {
+  const [showReply, setShowReply] = useState(false);
+  const collaboratorCount = post.collaborators?.filter(c => c.userId).length || 0;
+
+  return (
+    <div className={"border border-secondary rounded bg-surface p-4 space-y-2 " + (className || '')}>
+      <div className="flex items-center gap-2 text-sm text-secondary">
+        <PostTypeBadge type="request" />
+        {post.questId && <PostTypeBadge type="quest" />}
+      </div>
+      {post.title && <h3 className="font-semibold text-lg">{post.title}</h3>}
+      {post.content && <p className="text-sm text-primary">{post.content}</p>}
+      <div className="text-xs text-secondary">
+        {collaboratorCount} collaborators approved
+      </div>
+      <div className="flex gap-2">
+        <Button variant="ghost" size="sm" onClick={() => setShowReply(r => !r)}>
+          {showReply ? 'Cancel' : 'Reply'}
+        </Button>
+        <Button variant="primary" size="sm">
+          {post.questId ? 'Join' : 'Apply'}
+        </Button>
+      </div>
+      {showReply && (
+        <CreatePost
+          replyTo={post}
+          onSave={(p) => {
+            onUpdate?.(p);
+            setShowReply(false);
+          }}
+          onCancel={() => setShowReply(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RequestCard;


### PR DESCRIPTION
## Summary
- add RequestCard component to render request posts
- use RequestCard in ContributionCard when item type is `request`

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError in react-force-graph-2d module)*

------
https://chatgpt.com/codex/tasks/task_e_685712bca918832f84786404b927c8a5