### PR TITLE
Fix timeline board see all link

### DIFF
--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -22,7 +22,7 @@ const HomePage: React.FC = () => {
   const timelineBoard = boards['timeline-board'];
   const showQuestSeeAll = (questBoard?.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
   const showTimelineSeeAll =
-    (timelineBoard?.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
+    (timelineBoard?.enrichedItems?.length || 0) >= BOARD_PREVIEW_LIMIT;
   const postTypes = useMemo(() => {
     if (!questBoard?.enrichedItems) return [] as string[];
     const types = new Set<string>();


### PR DESCRIPTION
## Summary
- show the "See all" link when timeline board has reached the preview limit

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: Jest encountered module errors)*

------
https://chatgpt.com/codex/tasks/task_e_685719f013f4832fb9c444e3838cb8fa