### PR TITLE
Add post summary helper and render summary in PostCard

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({})
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+const post: Post = {
+  id: 'p1',
+  authorId: 'u1',
+  type: 'task',
+  nodeId: 'T1',
+  status: 'In Progress',
+  content: 'Task content',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+} as any;
+
+describe('PostCard summary text', () => {
+  it('renders summary using quest title and node id', () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={post} questTitle="Quest A" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Quest: Quest A Task:T1 In Progress')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -23,6 +23,7 @@ import EditPost from './EditPost';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
 import NestedReply from './NestedReply';
+import { getPostSummary } from '../../utils/displayUtils';
 
 const PREVIEW_LIMIT = 240;
 const makeHeader = (content: string): string => {
@@ -38,6 +39,7 @@ interface PostCardProps {
   onDelete?: (id: string) => void;
   compact?: boolean;
   questId?: string;
+  questTitle?: string;
   /** Show status dropdown controls for task posts */
   showStatusControl?: boolean;
   replyOverride?: { label: string; onClick: () => void };
@@ -58,6 +60,7 @@ const PostCard: React.FC<PostCardProps> = ({
   onDelete,
   compact = false,
   questId,
+  questTitle,
   showStatusControl = true,
   replyOverride,
   headerOnly = false,
@@ -142,6 +145,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || (post.type === 'task' ? post.content : '');
+  const summaryText = getPostSummary(post, questTitle);
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -326,6 +330,9 @@ const PostCard: React.FC<PostCardProps> = ({
           className
         )}
       >
+        {summaryText && (
+          <div className="text-sm font-semibold text-secondary">{summaryText}</div>
+        )}
         <div className="flex justify-between text-sm text-secondary">
           <div className="flex items-center gap-2">
             <PostTypeBadge type={post.type} />
@@ -374,6 +381,9 @@ const PostCard: React.FC<PostCardProps> = ({
         className
       )}
     >
+      {summaryText && (
+        <div className="text-sm font-semibold text-secondary">{summaryText}</div>
+      )}
       <div className="flex justify-between text-sm text-secondary">
         <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -54,3 +54,24 @@ export const getDisplayTitle = (post: Post): string => {
   const content = post.content?.trim() || '';
   return content.length > 50 ? content.slice(0, 50) + '…' : content;
 };
+
+/**
+ * Builds a brief summary string for a post.
+ * Format: "Quest: {title} Task:{nodeId} {status}".
+ * Quest title may be provided via optional param or `post.questTitle` field.
+ */
+export const getPostSummary = (post: Post, questTitle?: string): string => {
+  const parts: string[] = [];
+  const title = questTitle || (post as any).questTitle;
+  if (title) parts.push(`Quest: ${title}`);
+
+  if (post.nodeId) {
+    parts.push(`Task:${post.nodeId}`);
+  } else if (post.type) {
+    parts.push(post.type.charAt(0).toUpperCase() + post.type.slice(1));
+  }
+
+  if (post.status) parts.push(post.status);
+
+  return parts.join(' ').trim();
+};


### PR DESCRIPTION
## Summary
- add `getPostSummary` helper to build text like `Quest: title Task:node status`
- display summary text at the top of PostCard (normal and headerOnly)
- add unit test confirming the summary text renders

## Testing
- `npm test --silent` *(fails: jest environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68571e66a37c832f8ccd303639ad19f3