### PR TITLE
Show reply chain in post details

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -49,6 +49,8 @@ interface PostCardProps {
   className?: string;
   /** Expand replies when first rendered */
   initialShowReplies?: boolean;
+  /** Show detailed view including reply chain */
+  showDetails?: boolean;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -64,6 +66,7 @@ const PostCard: React.FC<PostCardProps> = ({
   depth = 0,
   className = '',
   initialShowReplies = false,
+  showDetails = false,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [replies, setReplies] = useState<Post[]>([]);
@@ -240,8 +243,16 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const renderLinkSummary = () => {
-    if (!post.linkedItems || post.linkedItems.length === 0) return null;
-    return <LinkViewer items={post.linkedItems} />;
+    if (!showDetails && (!post.linkedItems || post.linkedItems.length === 0)) {
+      return null;
+    }
+    return (
+      <LinkViewer
+        items={post.linkedItems || []}
+        post={post}
+        showReplyChain={showDetails}
+      />
+    );
   };
 
   const renderCommitDiff = () => {

--- a/ethos-frontend/src/components/ui/LinkViewer.test.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import LinkViewer from './LinkViewer';
+import type { LinkedItem, Post } from '../../types/postTypes';
+
+jest.mock('../../api/quest', () => ({
+  __esModule: true,
+  fetchQuestById: jest.fn(() => Promise.resolve({ title: 'Quest' })),
+}));
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchPostById: jest.fn((id: string) => {
+    const chain: Record<string, Post> = {
+      p2: {
+        id: 'p2',
+        authorId: 'u1',
+        type: 'task',
+        content: 'parent',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+        replyTo: 'p1',
+        questId: 'q1',
+        nodeId: 'T02',
+      } as any,
+      p1: {
+        id: 'p1',
+        authorId: 'u1',
+        type: 'task',
+        content: 'root',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+        replyTo: null,
+        questId: 'q1',
+        nodeId: 'T01',
+      } as any,
+    };
+    return Promise.resolve(chain[id]);
+  }),
+}));
+
+describe('LinkViewer', () => {
+  const items: LinkedItem[] = [
+    { itemId: 'q1', itemType: 'quest', linkType: 'related' },
+  ];
+
+  const post: Post = {
+    id: 'p3',
+    authorId: 'u1',
+    type: 'task',
+    content: 'child',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: items,
+    replyTo: 'p2',
+    questId: 'q1',
+    nodeId: 'T03',
+  } as any;
+
+  it('toggles label text', () => {
+    render(<LinkViewer items={items} />);
+    const btn = screen.getByText('Expand Details');
+    fireEvent.click(btn);
+    expect(screen.getByText('Collapse Details')).toBeInTheDocument();
+  });
+
+  it('shows reply chain when enabled', async () => {
+    render(<LinkViewer items={[]} post={post} showReplyChain />);
+    fireEvent.click(screen.getByText('Expand Details'));
+    await waitFor(() => {
+      expect(screen.getByText('Q:T02')).toBeInTheDocument();
+      expect(screen.getByText('Q:T01')).toBeInTheDocument();
+    });
+  });
+});

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -120,7 +120,7 @@ const PostPage: React.FC = () => {
       )}
 
       <section>
-        <PostCard post={post} />
+        <PostCard post={post} showDetails />
         {showReplyForm && (
           <div className="mt-4">
             <CreatePost


### PR DESCRIPTION
## Summary
- rename link viewer toggle labels
- fetch parent chain via `replyTo` for expanded details
- show details in post page
- test `LinkViewer` toggle and chain

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom missing)*
- `cd ethos-backend && npm test --silent` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68571e685c74832f8a6913aab7fdd3e9