### PR TITLE
Update quest board and request posts

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -376,7 +376,7 @@ const Board: React.FC<BoardProps> = ({
           )}
           {showCreate && user && (
             <Button variant="contrast" onClick={() => setShowCreateForm(true)}>
-              + Add Item
+              {board?.id === 'quest-board' ? '+ Add Request' : '+ Add Item'}
             </Button>
           )}
           {editable && (

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -116,7 +116,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
         visibility: 'public',
         linkedItems: autoLinkItems,
         helpRequest: type === 'request' || helpRequest || undefined,
-        ...(type === 'task' || type === 'request' || type === 'issue'
+        ...(type === 'task' || type === 'issue'
           ? { status }
           : {}),
         ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
@@ -187,7 +187,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
             onChange={(e) => {
               const val = e.target.value as PostType;
               setType(val);
-              if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
+              if (['task', 'issue'].includes(val)) setStatus('To Do');
             }}
             options={allowedPostTypes.map((t) => {
               const opt = POST_TYPES.find((o) => o.value === t)!;
@@ -225,7 +225,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
+            if (['task', 'issue'].includes(val)) setStatus('To Do');
           }}
           options={allowedPostTypes.map((t) => {
             const opt = POST_TYPES.find((o) => o.value === t)!;
@@ -233,7 +233,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           })}
         />
 
-        {['task', 'request', 'issue'].includes(type) && (
+        {['task', 'issue'].includes(type) && (
           <>
             <Label htmlFor="task-status">Status</Label>
             <Select

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -51,7 +51,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       content,
       ...(type === 'task' && details ? { details } : {}),
       ...(type === 'quest' && { collaborators }),
-      ...(type === 'task' || type === 'request' || type === 'issue'
+      ...(type === 'task' || type === 'issue'
         ? { status }
         : {}),
       linkedItems,
@@ -80,12 +80,12 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (['task', 'request', 'issue'].includes(val)) setStatus('To Do');
+            if (['task', 'issue'].includes(val)) setStatus('To Do');
           }}
           options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
 
-        {['task', 'request', 'issue'].includes(type) && (
+        {['task', 'issue'].includes(type) && (
           <>
             <Label htmlFor="task-status">Status</Label>
             <Select


### PR DESCRIPTION
## Summary
- tweak Board creation button text for quest board
- remove progress status for request posts

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm test --prefix ethos-backend` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68571f303bdc832fa6894910b1931770