### PR TITLE
Add theme accent backgrounds

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -275,8 +275,8 @@ const Board: React.FC<BoardProps> = ({
     return <div className="text-error p-4">Board not found.</div>;
   }
 
-  const containerBg = 'bg-surface';
-  const panelBg = 'bg-surface';
+  const containerBg = 'bg-accent-muted';
+  const panelBg = 'bg-accent-muted';
 
   return (
     <div className={`space-y-4 p-6 rounded-xl shadow-lg max-w-5xl mx-auto ${containerBg}`}>

--- a/ethos-frontend/src/components/quest/FeaturedQuestsBanner.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestsBanner.tsx
@@ -23,7 +23,7 @@ const FeaturedQuestsBanner: React.FC<FeaturedQuestsBannerProps> = ({ quests }) =
   const statusLabel = (q: Quest) => (q.status === 'active' ? 'Open' : 'Closed');
 
   return (
-    <div className="bg-soft dark:bg-soft-dark p-4 rounded-lg shadow">
+    <div className="bg-accent-muted p-4 rounded-lg shadow">
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         {featured.map((q) => (
           <Link

--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -37,7 +37,7 @@ const Banner: React.FC<BannerProps> = ({ user, quest, creatorName }) => {
       : null;
 
   return (
-    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-surface dark:bg-background p-4 sm:p-6 rounded-lg shadow mb-6">
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-accent-muted p-4 sm:p-6 rounded-lg shadow mb-6">
       {/* Left: Name + Description */}
       <div className="flex flex-col gap-1 text-left max-w-2xl">
         <h1 className="text-2xl font-bold text-primary dark:text-primary">

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const navClasses =
-    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-surface dark:bg-soft-dark border-gray-200 dark:border-gray-700';
+    'w-full px-4 sm:px-6 lg:px-8 py-4 backdrop-blur border-b bg-accent-muted border-gray-200 dark:border-gray-700';
 
   return (
     <nav className={navClasses}>

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -23,6 +23,7 @@
   --color-soft: #e5e7eb;
   --color-background: #f9fafb;
   --color-surface: #ffffff;
+  --color-accent-muted: #f3f4f6;
   --info-background: #bfdbfe;
   --bg-soft: var(--color-soft);
   --bg-soft-dark: #1f2937;
@@ -47,6 +48,7 @@
   --color-soft-dark: #1f2937;
   --color-background: #1f2937;
   --color-surface: #374151;
+  --color-accent-muted: #2a3442;
   --info-background: #1e40af;
   --bg-soft: var(--color-soft-dark);
   --bg-soft-dark: var(--color-soft-dark);

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -123,7 +123,7 @@ const BoardPage: React.FC = () => {
   const isTimeline = boardData.id === 'timeline-board';
 
   return (
-    <main className="max-w-7xl mx-auto p-4 space-y-8 bg-soft dark:bg-soft-dark">
+    <main className="max-w-7xl mx-auto p-4 space-y-8 bg-accent-muted">
       <div className="flex flex-col md:flex-row gap-6">
         {!isTimeline && (
           <BoardSearchFilter
@@ -133,7 +133,7 @@ const BoardPage: React.FC = () => {
           />
         )}
         <div className="flex-1">
-          <div className="bg-soft dark:bg-soft-dark rounded-xl shadow-lg p-6 space-y-6">
+          <div className="bg-accent-muted rounded-xl shadow-lg p-6 space-y-6">
             <div className="flex justify-between items-center">
               <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
               {editable && (

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -13,6 +13,7 @@ export const colors: Record<string, Palette> = {
   error: { light: '#EF4444', dark: '#fca5a5' },
   background: { light: '#f9fafb', dark: '#1f2937' },
   surface: { light: '#ffffff', dark: '#374151' },
+  accentMuted: { light: '#f3f4f6', dark: '#2a3442' },
   infoBackground: { light: '#bfdbfe', dark: '#1e40af' },
 };
 

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -22,6 +22,7 @@ module.exports = {
           'soft-dark': 'var(--color-soft-dark)',
           background: 'var(--color-background)',
           surface: 'var(--color-surface)',
+          'accent-muted': 'var(--color-accent-muted)',
           'info-background': 'var(--info-background)',
         },
         borderRadius: {


### PR DESCRIPTION
## Summary
- introduce `--color-accent-muted` token
- expose it as `accent-muted` in Tailwind and theme maps
- use the accent for banners, boards and navigation

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68571fc98a38832fac2330cbe4430d01