### PR TITLE
Enhance post summary tags

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -36,13 +36,15 @@ const post: Post = {
   linkedItems: [],
 } as any;
 
-describe('PostCard summary text', () => {
-  it('renders summary using quest title and node id', () => {
+describe('PostCard summary tags', () => {
+  it('renders summary tags with quest title and node id', () => {
     render(
       <BrowserRouter>
         <PostCard post={post} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(screen.getByText('Quest: Quest A Task:T1 In Progress')).toBeInTheDocument();
+    expect(screen.getByText('Quest: Quest A')).toBeInTheDocument();
+    expect(screen.getByText('Task: T1')).toBeInTheDocument();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -23,7 +23,8 @@ import EditPost from './EditPost';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
 import NestedReply from './NestedReply';
-import { getPostSummary } from '../../utils/displayUtils';
+import { buildSummaryTags } from '../../utils/displayUtils';
+import SummaryTag from '../ui/SummaryTag';
 
 const PREVIEW_LIMIT = 240;
 const makeHeader = (content: string): string => {
@@ -148,7 +149,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || (post.type === 'task' ? post.content : '');
-  const summaryText = getPostSummary(post, questTitle);
+  const summaryTags = buildSummaryTags(post, questTitle, questId);
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -342,8 +343,12 @@ const PostCard: React.FC<PostCardProps> = ({
           className
         )}
       >
-        {summaryText && (
-          <div className="text-sm font-semibold text-secondary">{summaryText}</div>
+        {summaryTags.length > 0 && (
+          <div className="flex flex-wrap gap-1 text-sm font-semibold text-secondary">
+            {summaryTags.map((tag, idx) => (
+              <SummaryTag key={idx} {...tag} />
+            ))}
+          </div>
         )}
         <div className="flex justify-between text-sm text-secondary">
           <div className="flex items-center gap-2">
@@ -394,8 +399,12 @@ const PostCard: React.FC<PostCardProps> = ({
         className
       )}
     >
-      {summaryText && (
-        <div className="text-sm font-semibold text-secondary">{summaryText}</div>
+      {summaryTags.length > 0 && (
+        <div className="flex flex-wrap gap-1 text-sm font-semibold text-secondary">
+          {summaryTags.map((tag, idx) => (
+            <SummaryTag key={idx} {...tag} />
+          ))}
+        </div>
       )}
       <div className="flex justify-between text-sm text-secondary">
         <div className="flex items-center gap-2">

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  FaBookOpen,
+  FaTasks,
+  FaBug,
+  FaStickyNote,
+  FaStar,
+  FaCommentAlt,
+  FaUser
+} from 'react-icons/fa';
+import clsx from 'clsx';
+
+export type SummaryTagType =
+  | 'quest'
+  | 'task'
+  | 'issue'
+  | 'log'
+  | 'review'
+  | 'category'
+  | 'status'
+  | 'free_speech'
+  | 'type';
+
+export interface SummaryTagData {
+  type: SummaryTagType;
+  label: string;
+  link?: string;
+}
+
+const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> = {
+  quest: FaBookOpen,
+  task: FaTasks,
+  issue: FaBug,
+  log: FaStickyNote,
+  review: FaStar,
+  category: FaStickyNote,
+  status: FaStickyNote,
+  free_speech: FaCommentAlt,
+  type: FaUser,
+};
+
+const baseClasses = 'inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+
+const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({ type, label, link, className }) => {
+  const Icon = icons[type] || FaStickyNote;
+  const content = (
+    <>
+      <Icon className="w-3 h-3" />
+      {label}
+    </>
+  );
+  if (link) {
+    return (
+      <Link to={link} className={clsx(baseClasses, className)}>
+        {content}
+      </Link>
+    );
+  }
+  return <span className={clsx(baseClasses, className)}>{content}</span>;
+};
+
+export default SummaryTag;


### PR DESCRIPTION
## Summary
- add SummaryTag component for clickable tag badges
- support structured summary tags in displayUtils
- render tags in PostCard using SummaryTag
- update unit test for new tag elements

## Testing
- `bash setup.sh`
- `npm test --prefix ethos-frontend` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685723a45b98832fb1988bfad5bffa6e