### PR TITLE
Fix ESLint warnings in core files

### DIFF
--- a/ethos-frontend/src/api/auth.ts
+++ b/ethos-frontend/src/api/auth.ts
@@ -1,6 +1,6 @@
 // src/api/auth.ts
 
-import { axiosWithAuth, setAccessToken, refreshAccessToken } from '../utils/authUtils';
+import { axiosWithAuth, setAccessToken } from '../utils/authUtils';
 import type { User } from '../types/userTypes';
 
 /**

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -1,7 +1,8 @@
 // src/api/post.ts
 
 import { axiosWithAuth } from '../utils/authUtils';
-import type { Post } from '../types/postTypes';
+import type { Post, Reaction } from '../types/postTypes';
+import type { Quest } from '../types/questTypes';
 import type { BoardData } from '../types/boardTypes';
 
 const BASE_URL = '/posts';
@@ -106,7 +107,10 @@ export const fetchPostsByBoardId = async (
   const res = await axiosWithAuth.get(
     `/boards/${boardId}/items?${params.toString()}`
   );
-  return (res.data || []).filter((item: any) => 'content' in item);
+  const data = (res.data || []) as unknown[];
+  return data.filter((item): item is Post =>
+    typeof item === 'object' && item !== null && 'content' in item
+  );
 };
 
 /**
@@ -148,7 +152,7 @@ export const updateReaction = async (
  * 🔁 Fetch all reactions on a post
  * @param postId - Post ID
  */
-export const fetchReactions = async (postId: string): Promise<any[]> => {
+export const fetchReactions = async (postId: string): Promise<Reaction[]> => {
   const res = await axiosWithAuth.get(`${BASE_URL}/${postId}/reactions`);
   return res.data;
 };
@@ -223,7 +227,7 @@ export const requestHelp = async (postId: string): Promise<Post> => {
  */
 export const acceptRequest = async (
   postId: string
-): Promise<{ post: Post; quest: any }> => {
+): Promise<{ post: Post; quest: Quest }> => {
   const res = await axiosWithAuth.post(`/posts/${postId}/accept`);
   return res.data;
 };

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -47,7 +47,7 @@ const Board: React.FC<BoardProps> = ({
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
 
   const { canEditBoard } = usePermissions();
-  const { setSelectedBoard, appendToBoard, updateBoardItem, boards } = useBoardContext();
+  const { setSelectedBoard, appendToBoard, boards } = useBoardContext();
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<'createdAt' | 'displayTitle'>('createdAt');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
@@ -68,12 +68,14 @@ const Board: React.FC<BoardProps> = ({
   }, [filter.itemType, filter.postType, filter.linkType]);
 
   // Keep items state in sync with BoardContext updates
+  const boardItemsKey = board?.id ? boards[board.id]?.enrichedItems : undefined;
   useEffect(() => {
     if (!board?.id) return;
     const enriched = boards[board.id]?.enrichedItems || [];
     setItems(enriched as Post[]);
-  }, [board?.id, boards[board?.id]?.enrichedItems]);
+  }, [board?.id, boardItemsKey]);
 
+  const userId = user?.id;
   useEffect(() => {
     const loadBoard = async () => {
       if (!boardId) {
@@ -112,7 +114,7 @@ const Board: React.FC<BoardProps> = ({
     } else {
       loadBoard();
     }
-  }, [boardId, boardProp]);
+  }, [boardId, boardProp, setSelectedBoard, userId]);
 
   useSocketListener('board:update', (payload: { boardId: string }) => {
     if (!board?.id || payload.boardId !== board.id) return;

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import { formatDistanceToNow } from 'date-fns';
 
-import type { Post, PostType } from '../../types/postTypes';
+import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
 import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest, unacceptRequest } from '../../api/post';
@@ -547,7 +547,11 @@ const PostCard: React.FC<PostCardProps> = ({
                   <select
                     className="border rounded px-1 py-0.5 text-xs w-full"
                     value={edgeType}
-                    onChange={e => setEdgeType(e.target.value as any)}
+                    onChange={e =>
+                      setEdgeType(
+                        e.target.value as 'sub_problem' | 'solution_branch' | 'folder_split'
+                      )
+                    }
                   >
                     <option value="sub_problem">sub_problem</option>
                     <option value="solution_branch">solution_branch</option>

--- a/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
@@ -38,7 +38,7 @@ const FeaturedQuestBoard: React.FC = () => {
   const visibleIndices = useMemo(() => {
     const total = quests.length;
     const count = Math.min(maxDots, total);
-    let start = Math.max(0, Math.min(current - Math.floor(count / 2), total - count));
+    const start = Math.max(0, Math.min(current - Math.floor(count / 2), total - count));
     return Array.from({ length: count }, (_, i) => start + i);
   }, [current, quests]);
 

--- a/ethos-frontend/src/contexts/AuthContext.tsx
+++ b/ethos-frontend/src/contexts/AuthContext.tsx
@@ -39,7 +39,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       await apiLogin(email, password);
       const userData = await fetchCurrentUser();
       setUser(userData);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Login failed:', err);
       setError('Login failed');
     }
@@ -51,7 +51,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       await apiRegister(email, password);
       const userData = await fetchCurrentUser();
       setUser(userData);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Registration failed:', err);
       setError('Registration failed');
     }

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -116,6 +116,11 @@ export type ReactionType = 'like' | 'heart' | 'repost';
  */
 export type ReactionCountMap = Record<ReactionType, number>;
 
+export interface Reaction {
+  userId: string;
+  type: ReactionType;
+}
+
 /**
  * Raw user reactions.
  */


### PR DESCRIPTION
## Summary
- remove unused `refreshAccessToken` import
- improve typing in post API
- address hook dependency warnings in `Board`
- clean up types and any usage in `PostCard`
- update error types in `AuthContext`
- minor lint fix in `FeaturedQuestBoard`

## Testing
- `npx eslint . --fix`
- `npm test --silent` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6857289bb8b4832f8f753ef96e2efeee