### PR TITLE
Fix hook usage in quest board and markdown renderer

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchActiveQuests } from '../../api/quest';
@@ -79,7 +79,7 @@ const ActiveQuestBoard: React.FC = () => {
     load();
   }, [user]);
 
-  const scrollToIndex = (i: number) => {
+  const scrollToIndex = useCallback((i: number) => {
     const el = containerRef.current;
     if (!el) return;
     const card = el.children[i] as HTMLElement | undefined;
@@ -87,11 +87,11 @@ const ActiveQuestBoard: React.FC = () => {
       const offset = card.offsetLeft - el.clientWidth / 2 + card.clientWidth / 2;
       el.scrollTo({ left: offset, behavior: 'smooth' });
     }
-  };
+  }, []);
 
   useEffect(() => {
     scrollToIndex(index);
-  }, [index]);
+  }, [index, scrollToIndex]);
 
   if (!user) return null;
   if (loading) return <Spinner />;

--- a/ethos-frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/ethos-frontend/src/components/ui/MarkdownRenderer.tsx
@@ -12,7 +12,6 @@ interface MarkdownRendererProps {
 }
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onToggleTask }) => {
-  if (!content) return null;
   let checkboxIndex = -1;
   const components = {
     input: ({ checked, type, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => {
@@ -30,10 +29,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onToggleTa
     },
   };
   useEffect(() => {
+    if (!content) return;
     document.querySelectorAll('pre code').forEach(block => {
       hljs.highlightElement(block as HTMLElement);
     });
   }, [content]);
+
+  if (!content) return null;
+
   return (
     <div className="prose prose-sm max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{content}</ReactMarkdown>


### PR DESCRIPTION
## Summary
- avoid returning early before hooks in MarkdownRenderer
- stabilize scrollToIndex callback and include it in dependencies

## Testing
- `npm run lint -s` *(fails: @typescript-eslint/no-unused-vars in many files)*
- `npm test -i --color=false` in `ethos-backend` *(fails: cannot find module 'supertest')*
- `npm test -i --color=false` in `ethos-frontend` *(fails to parse `react-force-graph-2d.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_68572976dbd4832f8b07591d2c87e8b1