### PR TITLE
Refactor context modules

### DIFF
--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { AuthContext } from '../../contexts/AuthContext';
+import { AuthContext } from '../../contexts/AuthContextBase';
 import type { AuthContextType } from '../../types/authTypes';
 import { logoutUser } from '../../utils/authUtils';
 import { useTheme } from '../../contexts/ThemeContext';

--- a/ethos-frontend/src/contexts/AuthContext.tsx
+++ b/ethos-frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import type { AuthContextType } from '../types/authTypes';
 import type { AuthUser } from '../types/userTypes';
 import {
@@ -11,7 +11,7 @@ import {
   deleteUserAccount as apiDeleteUser,
 } from '../api/auth';
 
-export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+import { AuthContext } from './AuthContextBase';
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<AuthUser | null>(null);

--- a/ethos-frontend/src/contexts/AuthContextBase.ts
+++ b/ethos-frontend/src/contexts/AuthContextBase.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { AuthContextType } from '../types/authTypes';
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -9,30 +9,12 @@ import React, {
 import { useAuth } from './AuthContext';
 import { fetchBoards as fetchBoardsAPI, updateBoard } from '../api/board';
 import type { BoardData } from '../types/boardTypes';
+import type {
+  BoardItem,
+  BoardMap,
+  BoardContextType,
+} from './BoardContextTypes';
 import type { GitFileNode, GitStatus } from '../types/gitTypes';
-
-export interface BoardItem {
-  id: string;
-  gitStatus?: GitStatus;
-  fileTree?: GitFileNode[];
-  [key: string]: any;
-}
-
-export type BoardMap = Record<string, BoardData>;
-
-export interface BoardContextType {
-  boards: BoardMap;
-  selectedBoard: string | null;
-  setSelectedBoard: React.Dispatch<React.SetStateAction<string | null>>;
-  loading: boolean;
-  refreshBoards: () => Promise<void>;
-  appendToBoard: (boardId: string, newItem: BoardItem) => void;
-  updateBoardItem: (boardId: string, updatedItem: BoardItem) => void;
-  removeItemFromBoard: (boardId: string, itemId: string) => void;
-  setBoardMeta: (meta: { id: string; title: string; layout: string }) => void;
-  updateBoardGitStatus: (boardId: string, status: GitStatus) => void;
-  setBoardFileTree: (boardId: string, tree: GitFileNode[]) => void;
-}
 
 const BoardContext = createContext<BoardContextType | undefined>(undefined);
 
@@ -212,3 +194,4 @@ export const useBoardContextEnhanced = () => {
     userPostBoard,
   };
 };
+

--- a/ethos-frontend/src/contexts/BoardContextTypes.ts
+++ b/ethos-frontend/src/contexts/BoardContextTypes.ts
@@ -1,0 +1,26 @@
+import type { BoardData } from '../types/boardTypes';
+import type { GitFileNode, GitStatus } from '../types/gitTypes';
+
+export interface BoardItem {
+  id: string;
+  gitStatus?: GitStatus;
+  fileTree?: GitFileNode[];
+  [key: string]: any;
+}
+
+export type BoardMap = Record<string, BoardData>;
+
+export interface BoardContextType {
+  boards: BoardMap;
+  selectedBoard: string | null;
+  setSelectedBoard: React.Dispatch<React.SetStateAction<string | null>>;
+  loading: boolean;
+  refreshBoards: () => Promise<void>;
+  appendToBoard: (boardId: string, newItem: BoardItem) => void;
+  updateBoardItem: (boardId: string, updatedItem: BoardItem) => void;
+  removeItemFromBoard: (boardId: string, itemId: string) => void;
+  setBoardMeta: (meta: { id: string; title: string; layout: string }) => void;
+  updateBoardGitStatus: (boardId: string, status: GitStatus) => void;
+  setBoardFileTree: (boardId: string, tree: GitFileNode[]) => void;
+}
+

--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -1,13 +1,6 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-
-export type Theme = 'light' | 'dark' | 'system';
-
-export const getSystemTheme = (): 'light' | 'dark' =>
-  typeof window !== 'undefined' &&
-  window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light';
+import { Theme, getSystemTheme } from './ThemeHelpers';
 
 interface ThemeContextType {
   theme: Theme;

--- a/ethos-frontend/src/contexts/ThemeHelpers.ts
+++ b/ethos-frontend/src/contexts/ThemeHelpers.ts
@@ -1,0 +1,8 @@
+export type Theme = 'light' | 'dark' | 'system';
+
+export const getSystemTheme = (): 'light' | 'dark' =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+

--- a/ethos-frontend/src/contexts/TimelineContext.tsx
+++ b/ethos-frontend/src/contexts/TimelineContext.tsx
@@ -1,22 +1,14 @@
 // src/contexts/TimelineContext.tsx
 
-import React, { createContext, useState, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import type { TimelineEvent } from '../types/postTypes';
+import { TimelineContext } from './TimelineContextBase';
 
 /**
  * Context value type for managing timeline state.
  * Each board ID maps to a list of timeline events.
  */
-interface TimelineContextValue {
-  timelines: Record<string, TimelineEvent[]>;
-  setTimelineEvents: (boardId: string, events: TimelineEvent[]) => void;
-}
-
-/**
- * Default context value before the provider is initialized.
- */
-export const TimelineContext = createContext<TimelineContextValue | undefined>(undefined);
 
 /**
  * Props for the TimelineProvider component.

--- a/ethos-frontend/src/contexts/TimelineContextBase.ts
+++ b/ethos-frontend/src/contexts/TimelineContextBase.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+import type { TimelineEvent } from '../types/postTypes';
+
+interface TimelineContextValue {
+  timelines: Record<string, TimelineEvent[]>;
+  setTimelineEvents: (boardId: string, events: TimelineEvent[]) => void;
+}
+
+export const TimelineContext = createContext<TimelineContextValue | undefined>(undefined);
+export type { TimelineContextValue };

--- a/ethos-frontend/src/hooks/usePermissions.ts
+++ b/ethos-frontend/src/hooks/usePermissions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useRef } from 'react';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/AuthContextBase';
 import type { AuthContextType } from '../types/authTypes';
 import { getBoardPermissions } from '../api/board';
 

--- a/ethos-frontend/src/hooks/useTimeline.ts
+++ b/ethos-frontend/src/hooks/useTimeline.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react';
-import { TimelineContext } from '../contexts/TimelineContext';
+import { TimelineContext } from '../contexts/TimelineContextBase';
 import { addPost, fetchPostsByBoardId } from '../api/post';
 import type { TimelineEvent } from '../types/postTypes';
 

--- a/ethos-frontend/src/routes/ProtectedRoute.tsx
+++ b/ethos-frontend/src/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/AuthContextBase';
 import { Spinner } from '../components/ui';
 
 


### PR DESCRIPTION
## Summary
- split context constants & helpers into separate files
- keep provider/hook logic in context components

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685729781240832f99040f6e4f0bdddb