### PR TITLE
Fix ts-ignore in ThemeContext

### DIFF
--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -43,15 +43,14 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (mql.addEventListener) {
         mql.addEventListener('change', handler);
       } else {
-        // deprecated but for older browsers/tests
-        // @ts-ignore
+        // @ts-expect-error addListener is deprecated but required for older browsers/tests
         mql.addListener(handler);
       }
       return () => {
         if (mql.removeEventListener) {
           mql.removeEventListener('change', handler);
         } else {
-          // @ts-ignore
+          // @ts-expect-error removeListener is deprecated but required for older browsers/tests
           mql.removeListener(handler);
         }
       };


### PR DESCRIPTION
## Summary
- replace `@ts-ignore` comments in `ThemeContext` with `@ts-expect-error`

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68572978f6b0832fa9e1af808221f3ff