### PR TITLE
Update test imports

### DIFF
--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -17,8 +17,8 @@ jest.mock('../src/models/stores', () => ({
   questsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
-const { postsStore, questsStore, usersStore, reactionsStore } = require('../src/models/stores');
-const { generateNodeId } = require('../src/utils/nodeIdUtils');
+import { postsStore, questsStore, usersStore, reactionsStore } from '../src/models/stores';
+import { generateNodeId } from '../src/utils/nodeIdUtils';
 
 const app = express();
 app.use(express.json());

--- a/ethos-backend/tests/questModeration.test.ts
+++ b/ethos-backend/tests/questModeration.test.ts
@@ -14,7 +14,7 @@ jest.mock('../src/models/stores', () => ({
   usersStore: { read: jest.fn(() => [{ id: 'u1', role: 'moderator' }]), write: jest.fn() }
 }));
 
-const { questsStore, postsStore } = require('../src/models/stores');
+import { questsStore, postsStore } from '../src/models/stores';
 
 const app = express();
 app.use(express.json());

--- a/ethos-backend/tests/reviews.test.ts
+++ b/ethos-backend/tests/reviews.test.ts
@@ -14,7 +14,7 @@ jest.mock('../src/models/stores', () => ({
   reviewsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
-const { reviewsStore } = require('../src/models/stores');
+import { reviewsStore } from '../src/models/stores';
 
 const app = express();
 app.use(express.json());

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -43,6 +43,15 @@ jest.mock('../src/models/stores', () => ({
   boardLogsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
+import {
+  boardsStore,
+  postsStore,
+  questsStore,
+  usersStore,
+  reactionsStore,
+  boardLogsStore,
+} from '../src/models/stores';
+
 const app = express();
 app.use(express.json());
 app.use('/boards', boardRoutes);
@@ -64,7 +73,7 @@ describe('route handlers', () => {
   });
 
   it('POST /quests creates quest with head post', async () => {
-    const { postsStore, questsStore } = require('../src/models/stores');
+    
     postsStore.read.mockReturnValue([]);
     questsStore.read.mockReturnValue([]);
     postsStore.write.mockClear();
@@ -122,7 +131,7 @@ describe('route handlers', () => {
   });
 
   it('GET /quests/:id/map returns nodes and edges', async () => {
-    const { postsStore, questsStore } = require('../src/models/stores');
+    
     postsStore.read.mockReturnValue([
       {
         id: 't1',
@@ -153,7 +162,7 @@ describe('route handlers', () => {
   });
 
   it('POST /quests/:id/link adds task edge with type and label', async () => {
-    const { postsStore, questsStore } = require('../src/models/stores');
+    
     const quest: any = {
       id: 'q1',
       authorId: 'u1',
@@ -192,7 +201,7 @@ describe('route handlers', () => {
   });
 
   it('POST /quests/:id/link links task to task when parentId provided', async () => {
-    const { postsStore, questsStore } = require('../src/models/stores');
+    
     const quest: any = {
       id: 'q1',
       authorId: 'u1',
@@ -234,7 +243,7 @@ describe('route handlers', () => {
   });
 
   it('POST /quests/:id/complete cascades solution', async () => {
-    const { questsStore, postsStore } = require('../src/models/stores');
+    
     const quest: any = {
       id: 'q1',
       authorId: 'u1',
@@ -281,7 +290,7 @@ describe('route handlers', () => {
   });
 
   it('GET /boards/:id/quests returns quests from board', async () => {
-    const { boardsStore, questsStore } = require('../src/models/stores');
+    
     boardsStore.read.mockReturnValue([
       { id: 'b1', title: 'Board', boardType: 'post', description: '', layout: 'grid', items: ['q1'] },
     ]);
@@ -304,7 +313,7 @@ describe('route handlers', () => {
   });
 
   it('GET /boards/:id/quests?enrich=true returns enriched quests', async () => {
-    const { boardsStore, questsStore, usersStore } = require('../src/models/stores');
+    
     boardsStore.read.mockReturnValue([
       { id: 'b1', title: 'Board', boardType: 'post', description: '', layout: 'grid', items: ['q1'] },
     ]);
@@ -327,7 +336,7 @@ describe('route handlers', () => {
   });
 
   it('PATCH /boards/:id creates board when not found', async () => {
-    const { boardsStore } = require('../src/models/stores');
+    
     const store: any[] = [];
     boardsStore.read.mockReturnValue(store);
 
@@ -342,7 +351,7 @@ describe('route handlers', () => {
   });
 
   it('POST /boards logs creation', async () => {
-    const { boardsStore, boardLogsStore } = require('../src/models/stores');
+    
     boardsStore.read.mockReturnValue([]);
     boardLogsStore.read.mockReturnValue([]);
     boardLogsStore.write.mockClear();
@@ -355,7 +364,7 @@ describe('route handlers', () => {
   });
 
   it('PATCH /boards/:id logs update', async () => {
-    const { boardsStore, boardLogsStore } = require('../src/models/stores');
+    
     boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', boardType: 'post', layout: 'grid', items: [] }]);
     boardLogsStore.read.mockReturnValue([]);
     boardLogsStore.write.mockClear();
@@ -366,7 +375,7 @@ describe('route handlers', () => {
   });
 
   it('DELETE /boards/:id logs deletion', async () => {
-    const { boardsStore, boardLogsStore } = require('../src/models/stores');
+    
     boardsStore.read.mockReturnValue([{ id: 'b1', title: 'B', boardType: 'post', layout: 'grid', items: [] }]);
     boardLogsStore.read.mockReturnValue([]);
     boardLogsStore.write.mockClear();
@@ -377,7 +386,7 @@ describe('route handlers', () => {
   });
   
   it('GET /boards/thread/:postId paginates replies', async () => {
-    const { postsStore } = require('../src/models/stores');
+    
     postsStore.read.mockReturnValue([
       {
         id: 'r1',

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -47,7 +47,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-const { acceptRequest, unacceptRequest } = require('../src/api/post');
+import { acceptRequest, unacceptRequest } from '../src/api/post';
 
 describe('accept request button', () => {
   const post = {

--- a/ethos-frontend/tests/Board.test.js
+++ b/ethos-frontend/tests/Board.test.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const { render, screen, waitFor } = require('@testing-library/react');
-const { BrowserRouter } = require('react-router-dom');
-const Board = require('../src/components/board/Board').default;
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Board from '../src/components/board/Board';
 
 jest.mock('../src/api/board', () => ({
   __esModule: true,
@@ -29,7 +29,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const { fetchBoard, fetchBoardItems } = require('../src/api/board');
+import { fetchBoard, fetchBoardItems } from '../src/api/board';
 
   describe('Board layout logic', () => {
     it('falls back to grid when posts from other quests exist', async () => {

--- a/ethos-frontend/tests/CreatePostBoardType.test.tsx
+++ b/ethos-frontend/tests/CreatePostBoardType.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const CreatePost = require('../src/components/post/CreatePost').default;
+import CreatePost from '../src/components/post/CreatePost';
 
 describe('CreatePost board type filtering', () => {
   it('limits post type options for quest board', () => {

--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -21,9 +21,9 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const CreatePost = require('../src/components/post/CreatePost').default;
+import CreatePost from '../src/components/post/CreatePost';
 
-const { addPost } = require('../src/api/post');
+import { addPost } from '../src/api/post';
 
 describe('CreatePost replying', () => {
   it('limits options to log when replying to a task', () => {

--- a/ethos-frontend/tests/CreatePostTitle.test.tsx
+++ b/ethos-frontend/tests/CreatePostTitle.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const CreatePost = require('../src/components/post/CreatePost').default;
+import CreatePost from '../src/components/post/CreatePost';
 
 describe('CreatePost title requirement', () => {
   it('title optional for free speech', () => {

--- a/ethos-frontend/tests/CreatePostView.test.tsx
+++ b/ethos-frontend/tests/CreatePostView.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const CreatePost = require('../src/components/post/CreatePost').default;
+import CreatePost from '../src/components/post/CreatePost';
 
 describe('CreatePost view filtering', () => {
   const getOptions = () => {

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, screen, fireEvent, waitFor } = require('@testing-library/react');
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
@@ -20,8 +20,8 @@ jest.mock('../src/contexts/BoardContext', () => ({
   })
 }));
 
-const { useGitDiff } = require('../src/hooks/useGit');
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import { useGitDiff } from '../src/hooks/useGit';
+import GraphLayout from '../src/components/layout/GraphLayout';
 
 describe('GraphLayout node interaction', () => {
   it('loads git diff and dispatches event on node click', async () => {

--- a/ethos-frontend/tests/GraphLayoutDragDrop.test.js
+++ b/ethos-frontend/tests/GraphLayoutDragDrop.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, act, within } = require('@testing-library/react');
+import React from 'react';
+import { render, act, within } from '@testing-library/react';
 
 let isOverMock = false;
 
@@ -51,9 +51,9 @@ jest.mock('../src/api/quest', () => ({
   linkPostToQuest: jest.fn(() => Promise.resolve({}))
 }));
 
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import GraphLayout from '../src/components/layout/GraphLayout';
 
-const { linkPostToQuest } = require('../src/api/quest');
+import { linkPostToQuest } from '../src/api/quest';
 
 describe('GraphLayout drag and drop', () => {
   it('links tasks on drop and updates hierarchy', async () => {

--- a/ethos-frontend/tests/GraphLayoutReorg.test.js
+++ b/ethos-frontend/tests/GraphLayoutReorg.test.js
@@ -1,6 +1,6 @@
-const React = require('react');
-const { render, within } = require('@testing-library/react');
-const { BrowserRouter } = require('react-router-dom');
+import React from 'react';
+import { render, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import GraphLayout from '../src/components/layout/GraphLayout';
 
 describe('GraphLayout task graph reorg', () => {
   it('nests child tasks when edges define hierarchy', () => {

--- a/ethos-frontend/tests/GraphLayoutScroll.test.js
+++ b/ethos-frontend/tests/GraphLayoutScroll.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, fireEvent, act } = require('@testing-library/react');
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
@@ -33,7 +33,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import GraphLayout from '../src/components/layout/GraphLayout';
 
 describe('GraphLayout scroll alignment', () => {
   it('recomputes connector paths when scrolling', () => {

--- a/ethos-frontend/tests/GraphLayoutSvg.test.js
+++ b/ethos-frontend/tests/GraphLayoutSvg.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render } = require('@testing-library/react');
+import React from 'react';
+import { render } from '@testing-library/react';
 
 jest.mock('../src/hooks/useGit', () => ({
   __esModule: true,
@@ -24,7 +24,7 @@ jest.mock('../src/components/layout/GraphNode', () => ({
     }),
 }), { virtual: true });
 
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import GraphLayout from '../src/components/layout/GraphLayout';
 
 describe('GraphLayout edges svg', () => {
   it('renders a svg path when an edge exists', () => {

--- a/ethos-frontend/tests/GraphNodeAnchor.test.js
+++ b/ethos-frontend/tests/GraphNodeAnchor.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, act, within } = require('@testing-library/react');
+import React from 'react';
+import { render, act, within } from '@testing-library/react';
 
 let dragHandler;
 
@@ -36,7 +36,7 @@ jest.mock('../src/hooks/useGit', () => ({
   useGitDiff: () => ({ data: null, isLoading: false })
 }));
 
-const GraphLayout = require('../src/components/layout/GraphLayout').default;
+import GraphLayout from '../src/components/layout/GraphLayout';
 
 describe('GraphLayout anchor interaction', () => {
   it('creates a new child when dragging from anchor', async () => {

--- a/ethos-frontend/tests/GridLayoutIndexReset.test.js
+++ b/ethos-frontend/tests/GridLayoutIndexReset.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, fireEvent, screen } = require('@testing-library/react');
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 // Mock ESM-only deps used deep in GridLayout to avoid Jest ESM parsing issues
 jest.mock('react-markdown', () => () => null, { virtual: true });
@@ -21,7 +21,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   })
 }));
 
-const GridLayout = require('../src/components/layout/GridLayout').default;
+import GridLayout from '../src/components/layout/GridLayout';
 
 const makePost = id => ({
   id,

--- a/ethos-frontend/tests/GridLayoutKanban.test.js
+++ b/ethos-frontend/tests/GridLayoutKanban.test.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { render, act } = require('@testing-library/react');
+import React from 'react';
+import { render, act } from '@testing-library/react';
 
 // Mock ESM-only deps used deep in GridLayout to avoid Jest ESM parsing issues
 jest.mock('react-markdown', () => () => null, { virtual: true });
@@ -58,11 +58,11 @@ let dragHandler;
 
 jest.mock('@dnd-kit/utilities', () => ({ CSS: { Translate: { toString: () => '' } } }), { virtual: true });
 
-const GridLayout = require('../src/components/layout/GridLayout').default;
+import GridLayout from '../src/components/layout/GridLayout';
 
 const updateBoardItem = global.updateBoardItemMock;
 const removeItemFromBoard = global.removeItemFromBoardMock;
-const { updatePost, archivePost } = require('../src/api/post');
+import { updatePost, archivePost } from '../src/api/post';
 
 const basePost = {
   id: 't1',

--- a/ethos-frontend/tests/TaskList.test.tsx
+++ b/ethos-frontend/tests/TaskList.test.tsx
@@ -72,7 +72,7 @@ jest.mock(
 
 jest.mock('remark-gfm', () => () => ({}), { virtual: true });
 
-const { updatePost } = require('../src/api/post');
+import { updatePost } from '../src/api/post';
 
 describe('task list checkbox', () => {
   it('toggles checkbox and updates post', async () => {

--- a/ethos-frontend/tests/ThemeProvider.test.js
+++ b/ethos-frontend/tests/ThemeProvider.test.js
@@ -1,6 +1,6 @@
-const React = require('react');
-const { render } = require('@testing-library/react');
-const { ThemeProvider } = require('../src/contexts/ThemeContext');
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '../src/contexts/ThemeContext';
 
 function setupMatchMedia(matches) {
   Object.defineProperty(window, 'matchMedia', {

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
-const CreatePost = require('../src/components/post/CreatePost').default;
+import CreatePost from '../src/components/post/CreatePost';
 
 describe('Timeline board post types', () => {
   it('shows allowed options for timeline board', () => {


### PR DESCRIPTION
## Summary
- modernize test files to use `import` instead of `require`

## Testing
- `npm --prefix ethos-backend test` *(fails: Cannot find module 'supertest' etc.)*
- `npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857297a3720832f87cd66e48309f892