### PR TITLE
Fix post tags and add task library

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -33,6 +33,7 @@ const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
 const FlaggedQuests = lazy(() => import('./pages/admin/FlaggedQuests'));
 const BannedQuests = lazy(() => import('./pages/admin/BannedQuests'));
+const TaskLibrary = lazy(() => import('./pages/TaskLibrary'));
 
 /**
  * The root App component of the application.
@@ -70,8 +71,9 @@ const App: React.FC = () => {
 
                   {/* 🔒 Routes requiring authentication (wrapped in PrivateRoute) */}
                   <Route element={<PrivateRoute />}>
-                    <Route path={ROUTES.PROFILE} element={<Profile />} />
-                    <Route path={ROUTES.QUEST()} element={<Quest />} />
+                  <Route path={ROUTES.PROFILE} element={<Profile />} />
+                  <Route path={ROUTES.TASK_LIBRARY} element={<TaskLibrary />} />
+                  <Route path={ROUTES.QUEST()} element={<Quest />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
                     <Route path="/board/quests" element={<Navigate to={ROUTES.BOARD('quest-board')} replace />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -343,15 +343,11 @@ const PostCard: React.FC<PostCardProps> = ({
           className
         )}
       >
-        {summaryTags.length > 0 && (
-          <div className="flex flex-wrap gap-1 text-sm font-semibold text-secondary">
+        <div className="flex justify-between text-sm text-secondary">
+          <div className="flex flex-wrap items-center gap-2">
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-          </div>
-        )}
-        <div className="flex justify-between text-sm text-secondary">
-          <div className="flex items-center gap-2">
             <PostTypeBadge type={post.type} />
             {post.status && <StatusBadge status={post.status} />}
             <button
@@ -399,15 +395,11 @@ const PostCard: React.FC<PostCardProps> = ({
         className
       )}
     >
-      {summaryTags.length > 0 && (
-        <div className="flex flex-wrap gap-1 text-sm font-semibold text-secondary">
+      <div className="flex justify-between text-sm text-secondary">
+        <div className="flex flex-wrap items-center gap-2">
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-        </div>
-      )}
-      <div className="flex justify-between text-sm text-secondary">
-        <div className="flex items-center gap-2">
           <PostTypeBadge type={post.type} />
           {post.status && <StatusBadge status={post.status} />}
           {canEdit && ['task', 'request', 'issue'].includes(post.type) && showStatusControl && (

--- a/ethos-frontend/src/components/ui/LinkViewer.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.tsx
@@ -3,6 +3,7 @@ import type { LinkedItem, Post } from '../../types/postTypes';
 import { fetchQuestById } from '../../api/quest';
 import { fetchPostById } from '../../api/post';
 import { getQuestLinkLabel } from '../../utils/displayUtils';
+import { FaExpand, FaCompress } from 'react-icons/fa';
 
 interface LinkViewerProps {
   items: LinkedItem[];
@@ -81,9 +82,9 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items, post, showReplyChain }) 
     <div className="text-xs text-primary dark:text-primary">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="text-blue-600 underline"
+        className="flex items-center gap-1 text-blue-600 underline"
       >
-        {open ? 'Collapse Details' : 'Expand Details'}
+        {open ? <FaCompress /> : <FaExpand />} {open ? 'Collapse Details' : 'Expand Details'}
       </button>
       {open && (
         <div className="mt-2 border rounded bg-background dark:bg-surface p-2 space-y-1">

--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -39,6 +39,9 @@ const NavBar: React.FC = () => {
               <Link to="/profile" className="hover:text-accent transition">
                 Account
               </Link>
+              <Link to="/task-library" className="hover:text-accent transition">
+                Task Library
+              </Link>
               <button
                 onClick={logoutUser}
                 className="hover:underline text-left"

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -22,6 +22,9 @@ export const ROUTES = {
   
     /** Logged-in user’s private profile page */
     PROFILE: '/profile',
+
+    /** Task library page */
+    TASK_LIBRARY: '/task-library',
   
     /**
      * Public profile page for any user

--- a/ethos-frontend/src/pages/TaskLibrary.tsx
+++ b/ethos-frontend/src/pages/TaskLibrary.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+
+interface TaskTemplate {
+  id: string;
+  name: string;
+  tag: string;
+  points: number;
+}
+
+const STORAGE_KEY = 'task-library';
+
+const TaskLibrary: React.FC = () => {
+  const [tasks, setTasks] = useState<TaskTemplate[]>([]);
+  const [name, setName] = useState('');
+  const [tag, setTag] = useState('');
+  const [points, setPoints] = useState(0);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        setTasks(JSON.parse(saved));
+      } catch {
+        setTasks([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+  }, [tasks]);
+
+  const addTask = () => {
+    if (!name.trim()) return;
+    setTasks([...tasks, { id: Date.now().toString(), name: name.trim(), tag: tag.trim(), points }]);
+    setName('');
+    setTag('');
+    setPoints(0);
+  };
+
+  const updateTask = (id: string, field: keyof TaskTemplate, value: string | number) => {
+    setTasks(tasks.map(t => (t.id === id ? { ...t, [field]: value } : t)));
+  };
+
+  return (
+    <main className="container mx-auto max-w-2xl p-4 space-y-6">
+      <h1 className="text-xl font-semibold">Task Library</h1>
+      <div className="space-y-2">
+        <input
+          className="border rounded px-2 py-1 w-full"
+          placeholder="Task name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1 w-full"
+          placeholder="Tag"
+          value={tag}
+          onChange={e => setTag(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1 w-full"
+          type="number"
+          placeholder="Points"
+          value={points}
+          onChange={e => setPoints(parseInt(e.target.value) || 0)}
+        />
+        <button className="bg-indigo-600 text-white px-3 py-1 rounded" onClick={addTask}>
+          Add Task
+        </button>
+      </div>
+      <ul className="space-y-3">
+        {tasks.map(t => (
+          <li key={t.id} className="border rounded p-3 space-y-2">
+            <input
+              className="border rounded px-2 py-1 w-full"
+              value={t.name}
+              onChange={e => updateTask(t.id, 'name', e.target.value)}
+            />
+            <input
+              className="border rounded px-2 py-1 w-full"
+              value={t.tag}
+              onChange={e => updateTask(t.id, 'tag', e.target.value)}
+            />
+            <input
+              className="border rounded px-2 py-1 w-full"
+              type="number"
+              value={t.points}
+              onChange={e => updateTask(t.id, 'points', parseInt(e.target.value) || 0)}
+            />
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+};
+
+export default TaskLibrary;

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -86,14 +86,17 @@ export const buildSummaryTags = (
 ): SummaryTagData[] => {
   const tags: SummaryTagData[] = [];
   const title = questTitle || post.questTitle;
+  const multipleSources = (post.linkedItems || []).length > 1;
 
   if (post.type === 'review') {
-    if (title) tags.push({ type: 'review', label: `Review: ${title}`, link: post.id ? ROUTES.POST(post.id) : undefined });
+    if (!multipleSources && title) {
+      tags.push({ type: 'review', label: `Review: ${title}`, link: post.id ? ROUTES.POST(post.id) : undefined });
+    }
     if (post.subtype) tags.push({ type: 'category', label: post.subtype });
     return tags;
   }
 
-  if (title) {
+  if (!multipleSources && title) {
     tags.push({ type: 'quest', label: `Quest: ${title}`, link: (questId || post.questId) ? ROUTES.QUEST(questId || post.questId!) : undefined });
   }
 


### PR DESCRIPTION
## Summary
- combine summary tags with meta row so each post has only one header row
- hide quest/review tags when post links to multiple sources
- style link viewer toggle with expand/collapse icons
- add a simple Task Library page for custom tasks
- expose Task Library through navigation and routing

## Testing
- `npm test` in `ethos-frontend` *(fails: SyntaxError from react-force-graph-2d)*
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68572ba567b8832f861cdde232966317