### PR TITLE
Fix missing Theme export import

### DIFF
--- a/ethos-frontend/src/contexts/ThemeContext.tsx
+++ b/ethos-frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { Theme, getSystemTheme } from './ThemeHelpers';
+import { getSystemTheme } from './ThemeHelpers';
+import type { Theme } from './ThemeHelpers';
 
 interface ThemeContextType {
   theme: Theme;


### PR DESCRIPTION
## Summary
- import `Theme` as a type-only import

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm test --prefix ethos-backend` *(fails: missing packages like supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68572e56c74c832f97d7216bb5869082