### PR TITLE
Fix ActiveQuestBoard card width

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -109,10 +109,8 @@ const ActiveQuestBoard: React.FC = () => {
           {quests.map((q, idx) => (
             <div
               key={q.id}
-              className={`snap-center flex-shrink-0 transition-all ${
-                idx === index
-                  ? 'w-[80%] sm:w-[640px]'
-                  : 'w-64 sm:w-[300px] opacity-80'
+              className={`snap-center flex-shrink-0 w-[80%] sm:w-[640px] transition-opacity ${
+                idx === index ? '' : 'opacity-80'
               }`}
             >
               <div className="w-full">


### PR DESCRIPTION
## Summary
- keep active quest cards a consistent width to match board columns

## Testing
- `npm --prefix ethos-frontend test --silent` *(fails: Jest unable to run due to missing dependencies)*
- `npm --prefix ethos-backend test --silent` *(fails: Jest unable to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68573584dca8832fb4ca8bbeaacff2a8