### PR TITLE
Render request posts as regular posts

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import PostCard from '../post/PostCard';
 import QuestCard from '../quest/QuestCard';
-import RequestCard from '../request/RequestCard';
 
 import type { Post } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
@@ -52,15 +51,6 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   // ✅ Render Post types
   if ('type' in contribution) {
     const post = contribution as Post;
-    if (post.type === 'request') {
-      return (
-        <RequestCard
-          post={post}
-          user={user}
-          onUpdate={onEdit ? (p) => onEdit(p.id) : undefined}
-        />
-      );
-    }
     return (
       <PostCard
         post={post}


### PR DESCRIPTION
## Summary
- display request posts via `PostCard`

## Testing
- `npm test --silent --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm test --silent --prefix ethos-backend` *(fails: supertest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685735c4b508832faa9df3a1fd0f4507