### PR TITLE
Update ReactionControls for quest requests

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -56,6 +56,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const navigate = useNavigate();
   const { selectedBoard } = useBoardContext() || {};
   const isTimelineBoard = isTimeline ?? selectedBoard === 'timeline-board';
+  const isQuestRequest = selectedBoard === 'quest-board' && post.type === 'request';
 
   useEffect(() => {
     const fetchData = async () => {
@@ -151,13 +152,15 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           {reactions.heart ? <FaHeart /> : <FaRegHeart />} {counts.heart || ''}
         </button>
 
-        <button
-          className={clsx('flex items-center gap-1', userRepostId && 'text-indigo-600')}
-          onClick={handleRepost}
-          disabled={loading || repostLoading || !user}
-        >
-          <FaRetweet /> {counts.repost || ''}
-        </button>
+        {!isQuestRequest && (
+          <button
+            className={clsx('flex items-center gap-1', userRepostId && 'text-indigo-600')}
+            onClick={handleRepost}
+            disabled={loading || repostLoading || !user}
+          >
+            <FaRetweet /> {counts.repost || ''}
+          </button>
+        )}
 
         <button
           className={clsx(
@@ -189,6 +192,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
             ? 'Cancel'
             : 'Reply'}
         </button>
+
+        {isQuestRequest && (
+          <button className="flex items-center gap-1">
+            {post.questId ? 'Join' : 'Apply'}
+          </button>
+        )}
 
         {(post.type === 'task' || post.type === 'commit') && (
           <button className="flex items-center gap-1" onClick={() => setExpanded(prev => !prev)}>


### PR DESCRIPTION
## Summary
- tweak ReactionControls to detect request posts on quest board
- hide repost button for quest board requests
- show new Apply/Join text button next to Reply

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend` *(fails: Property `mockReturnValue` errors)*
- `npm test --prefix ethos-frontend` *(fails: ts-jest errors, unable to parse tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857361928f0832fa8539fe173092f8c