### PR TITLE
Add full QuestCard expansion

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { fetchActiveQuests } from '../../api/quest';
 import { fetchRecentPosts, fetchPostById } from '../../api/post';
 import QuestSummaryCard from './QuestSummaryCard';
-import QuestStatusList from './QuestStatusList';
+import QuestCard from './QuestCard';
 import { Spinner } from '../ui';
 import { ROUTES } from '../../constants/routes';
 import { BOARD_PREVIEW_LIMIT } from '../../constants/pagination';
@@ -152,8 +152,8 @@ const ActiveQuestBoard: React.FC = () => {
       </div>
 
       {expanded && (
-        <div className="border rounded-lg p-4 bg-surface">
-          <QuestStatusList quest={expanded} />
+        <div className="mt-4">
+          <QuestCard quest={expanded} defaultExpanded />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- allow ActiveQuestBoard to expand quests using full QuestCard

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68573b882938832f89222d50490981aa