### PR TITLE
Refine quest board request cards

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -47,6 +47,8 @@ const Board: React.FC<BoardProps> = ({
   const [items, setItems] = useState<Post[]>([]);
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
 
+  const isQuestBoard = (boardId || boardProp?.id || board?.id) === 'quest-board';
+
   const { canEditBoard } = usePermissions();
   const { setSelectedBoard, appendToBoard, boards } = useBoardContext();
   const [filterText, setFilterText] = useState('');
@@ -450,7 +452,7 @@ const Board: React.FC<BoardProps> = ({
           contributions={items}
           questId={quest?.id || ''}
           initialExpanded={initialExpanded}
-          headerOnly={headerOnly}
+          headerOnly={isQuestBoard || headerOnly}
           editable={editable}
           {...(resolvedStructure === 'graph' ||
             resolvedStructure === 'graph-condensed' ||


### PR DESCRIPTION
## Summary
- simplify quest board request cards
- hide status controls, author name, and accept link on quest board
- add Mark Complete option to archive requests
- render quest board in header-only mode automatically

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest config issues)*
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_68573db0f338832f9f2f5028770f2cd9