### PR TITLE
Improve quest board display

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchActiveQuests } from '../../api/quest';
 import { fetchRecentPosts, fetchPostById } from '../../api/post';
-import QuestSummaryCard from './QuestSummaryCard';
 import QuestCard from './QuestCard';
 import { Spinner } from '../ui';
 import { ROUTES } from '../../constants/routes';
@@ -20,7 +19,6 @@ const ActiveQuestBoard: React.FC = () => {
   const [quests, setQuests] = useState<QuestWithLog[]>([]);
   const [loading, setLoading] = useState(false);
   const [index, setIndex] = useState(0);
-  const [expanded, setExpanded] = useState<QuestWithLog | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -113,21 +111,7 @@ const ActiveQuestBoard: React.FC = () => {
                 idx === index ? '' : 'opacity-80'
               }`}
             >
-              <div className="w-full">
-                <QuestSummaryCard quest={q} />
-                <div className="text-right mt-1">
-                  <button
-                    type="button"
-                    className="text-xs underline"
-                    onClick={() => {
-                      setExpanded(q);
-                      setIndex(idx);
-                    }}
-                  >
-                    {expanded?.id === q.id ? 'Collapse' : 'Expand'}
-                  </button>
-                </div>
-              </div>
+              <QuestCard quest={q} />
             </div>
           ))}
         </div>
@@ -151,11 +135,6 @@ const ActiveQuestBoard: React.FC = () => {
         )}
       </div>
 
-      {expanded && (
-        <div className="mt-4">
-          <QuestCard quest={expanded} defaultExpanded />
-        </div>
-      )}
 
       {showSeeAll && (
         <div className="text-right">

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -60,6 +60,16 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const [joinRequested, setJoinRequested] = useState(false);
   const navigate = useNavigate();
 
+  const rankTag = questData.tags?.find(t => t.toLowerCase().startsWith('rank:'));
+  const rewardTag = questData.tags?.find(t => t.toLowerCase().startsWith('reward:'));
+  const roleTags = questData.tags?.filter(t => t.toLowerCase().startsWith('role:')) || [];
+
+  const rank = rankTag ? rankTag.split(':')[1] : 'Unrated';
+  const reward = rewardTag ? rewardTag.split(':')[1] : 'Unknown';
+  const roles = roleTags.map(t => t.split(':')[1]).join(', ');
+  const desc = questData.description || '';
+  const shortDesc = desc.length > 120 ? desc.slice(0, 117) + '…' : desc;
+
   const tabOptions = [
     { value: 'status', label: 'Status' },
     { value: 'logs', label: 'Logs' },
@@ -488,6 +498,16 @@ const QuestCard: React.FC<QuestCardProps> = ({
   return (
     <div className="border border-secondary rounded-lg shadow bg-surface p-6 text-primary">
       {renderHeader()}
+      {!expanded && (
+        <div className="text-sm text-secondary space-y-1 mb-2">
+          {shortDesc && <p>{shortDesc}</p>}
+          <div className="text-xs space-y-0.5">
+            <div>Rank: {rank}</div>
+            <div>Reward: {reward}</div>
+            {roles && <div>Roles Needed: {roles}</div>}
+          </div>
+        </div>
+      )}
       <div className="text-xs text-secondary space-y-1 mb-2">
         {showLinkEditor && (
           <div className="mt-2">

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -40,11 +40,11 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
   }, {});
 
   return (
-    <div className="flex overflow-auto space-x-4">
+    <div className="flex overflow-auto space-x-2">
       {STATUS_OPTIONS.map(({ value }) => (
         <div
           key={value}
-          className="min-w-[200px] w-[240px] flex-shrink-0 bg-surface border border-secondary rounded-lg p-3 space-y-2"
+          className="min-w-[80px] w-28 flex-shrink-0 bg-surface border border-secondary rounded-lg p-2 space-y-2"
         >
           <h4 className="text-sm font-semibold flex items-center gap-1">
             <span>{statusIcons[value] || '➡️'}</span>
@@ -56,9 +56,11 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
             grouped[value].map((issue) => (
               <div
                 key={issue.id}
-                className="text-xs border border-secondary rounded p-2 bg-background space-y-1"
+                className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
               >
-                <div className="font-semibold">{issue.content}</div>
+                <div className="font-semibold truncate">
+                  {issue.content.length > 15 ? `${issue.content.slice(0, 12)}…` : issue.content}
+                </div>
                 {issue.status && <StatusBadge status={issue.status} />}
               </div>
             ))


### PR DESCRIPTION
## Summary
- show QuestCard components directly in ActiveQuestBoard
- display quest summary info when QuestCard is collapsed
- shrink StatusBoardPanel columns and truncate task titles

## Testing
- `npm test --prefix ethos-frontend` *(fails: Jest failed to parse files)*

------
https://chatgpt.com/codex/tasks/task_e_68573fb9fa18832f8acd871fe328911f