### PR TITLE
Standardize post tags

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -55,3 +55,20 @@ In dark mode the variables automatically switch to their `*-Dark` counterparts.
 4. Restart the development server so Tailwind picks up the config changes.
 
 Following these steps keeps your design system consistent across components and CSS.
+
+## Tag Styles
+
+Posts and quests are annotated with small tags that reuse the same color palette as `PostTypeBadge` components. The tag styles are implemented in `SummaryTag.tsx` and provide consistent background and text colors.
+
+| Tag Type | Light / Dark Classes |
+| -------- | ------------------- |
+| quest | `bg-green-100 text-green-800` / `dark:bg-green-800 dark:text-green-200` |
+| task | `bg-purple-100 text-purple-800` / `dark:bg-purple-800 dark:text-purple-200` |
+| issue | `bg-orange-100 text-orange-800` / `dark:bg-orange-800 dark:text-orange-200` |
+| log | `bg-blue-100 text-blue-800` / `dark:bg-blue-800 dark:text-blue-200` |
+| review | `bg-teal-100 text-teal-800` / `dark:bg-teal-800 dark:text-teal-200` |
+| status | `bg-yellow-100 text-yellow-800` / `dark:bg-yellow-800 dark:text-yellow-200` |
+| category | `bg-indigo-100 text-indigo-800` / `dark:bg-indigo-800 dark:text-indigo-200` |
+| free_speech | `bg-gray-100 text-gray-700` / `dark:bg-gray-700 dark:text-gray-200` |
+
+All tags share the `TAG_BASE` style which sets padding, font size and border radius.

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -151,6 +151,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const content = post.renderedContent || post.content;
   const titleText = post.title || (post.type === 'task' ? post.content : '');
   const summaryTags = buildSummaryTags(post, questTitle, questId);
+  const showAuthor = !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -351,19 +352,21 @@ const PostCard: React.FC<PostCardProps> = ({
             ))}
             <PostTypeBadge type={post.type} />
             {post.status && <StatusBadge status={post.status} />}
-            <button
-              type="button"
-              onClick={() =>
-                navigate(
-                  post.authorId === user?.id
-                    ? ROUTES.PROFILE
-                    : ROUTES.PUBLIC_PROFILE(post.authorId)
-                )
-              }
-              className="text-accent underline"
-            >
-              @{post.author?.username || post.authorId}
-            </button>
+            {showAuthor && (
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(
+                    post.authorId === user?.id
+                      ? ROUTES.PROFILE
+                      : ROUTES.PUBLIC_PROFILE(post.authorId)
+                  )
+                }
+                className="text-accent underline"
+              >
+                @{post.author?.username || post.authorId}
+              </button>
+            )}
             <span>{timestamp}</span>
           </div>
         </div>
@@ -412,19 +415,21 @@ const PostCard: React.FC<PostCardProps> = ({
               />
             </div>
           )}
-          <button
-            type="button"
-            onClick={() =>
-              navigate(
-                post.authorId === user?.id
-                  ? ROUTES.PROFILE
-                  : ROUTES.PUBLIC_PROFILE(post.authorId)
-              )
-            }
-            className="text-accent underline"
-          >
-            @{post.author?.username || post.authorId}
-          </button>
+          {showAuthor && (
+            <button
+              type="button"
+              onClick={() =>
+                navigate(
+                  post.authorId === user?.id
+                    ? ROUTES.PROFILE
+                    : ROUTES.PUBLIC_PROFILE(post.authorId)
+                )
+              }
+              className="text-accent underline"
+            >
+              @{post.author?.username || post.authorId}
+            </button>
+          )}
           <span>{timestamp}</span>
         </div>
         <ActionMenu

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -41,9 +41,22 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
   type: FaUser,
 };
 
+const colors: Record<SummaryTagType, string> = {
+  quest: 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
+  task: 'bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-200',
+  issue: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
+  log: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200',
+  review: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-200',
+  category: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
+  status: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
+  free_speech: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
+  type: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+};
+
 
 const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({ type, label, link, className }) => {
   const Icon = icons[type] || FaStickyNote;
+  const colorClass = colors[type] || colors.type;
   const content = (
     <>
       <Icon className="w-3 h-3" />
@@ -52,12 +65,12 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({ type, l
   );
   if (link) {
     return (
-      <Link to={link} className={clsx(TAG_BASE, className)}>
+      <Link to={link} className={clsx(TAG_BASE, colorClass, className)}>
         {content}
       </Link>
     );
   }
-  return <span className={clsx(TAG_BASE, className)}>{content}</span>;
+  return <span className={clsx(TAG_BASE, colorClass, className)}>{content}</span>;
 };
 
 export default SummaryTag;

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -107,8 +107,6 @@ export const buildSummaryTags = (
   } else if (post.type === 'log') {
     const user = post.author?.username || post.authorId;
     tags.push({ type: 'log', label: `Log: @${user}`, link: ROUTES.POST(post.id) });
-  } else if (post.type) {
-    tags.push({ type: 'type', label: post.type.charAt(0).toUpperCase() + post.type.slice(1), link: ROUTES.POST(post.id) });
   }
 
   if (post.status && ['task', 'issue'].includes(post.type)) {


### PR DESCRIPTION
## Summary
- color-code SummaryTag component
- remove generic type tag for posts
- hide author label when redundant
- document tag colors in design system

## Testing
- `npm --prefix ethos-frontend test` *(fails: Jest config errors)*
- `npm --prefix ethos-backend test` *(fails: missing dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68574020865c832f90ac6ab54abc8a51