### PR TITLE
Fix log tag color and deduplicate tags

### DIFF
--- a/ethos-frontend/src/components/ReviewList.tsx
+++ b/ethos-frontend/src/components/ReviewList.tsx
@@ -73,7 +73,7 @@ const ReviewList: React.FC<ReviewListProps> = ({ type, questId, postId, classNam
               </div>
               {review.tags && review.tags.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-1">
-                  {review.tags.map(tag => (
+                  {Array.from(new Set(review.tags)).map((tag) => (
                     <span key={tag} className={TAG_BASE}>#{tag}</span>
                   ))}
                 </div>

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -548,7 +548,7 @@ const PostCard: React.FC<PostCardProps> = ({
         <MediaPreview media={post.mediaPreviews} />
         {post.tags && post.tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-1">
-            {post.tags.map(tag => (
+            {Array.from(new Set(post.tags)).map((tag) => (
               <span key={tag} className={TAG_BASE}>#{tag}</span>
             ))}
           </div>

--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -53,25 +53,19 @@ const Banner: React.FC<BannerProps> = ({ user, quest, creatorName }) => {
       {/* Right: Tags or Roles */}
       <div className="mt-4 sm:mt-0 flex flex-wrap justify-start sm:justify-end gap-2">
         {tags.length > 0 ? (
-          tags.map((tag, index) => {
-            if (typeof tag === 'string') {
-              return (
-                <span key={index} className={TAG_BASE}>
-                  #{tag}
-                </span>
-              );
-            } else {
-              // It's a CollaberatorRoles object
-              return (
-                <span
-                  key={index}
-                  className="text-xs font-medium bg-gray-200 dark:bg-gray-600 px-3 py-1 rounded-full text-indigo-700 dark:text-indigo-300"
-                >
-                  @{tag.username || tag.userId}
-                </span>
-              );
-            }
-          })
+          <>
+            {Array.from(new Set(tags.filter(t => typeof t === 'string') as string[])).map((tag) => (
+              <span key={tag} className={TAG_BASE}>#{tag}</span>
+            ))}
+            {(tags.filter(t => typeof t !== 'string') as any[]).map((tag, index) => (
+              <span
+                key={index}
+                className="text-xs font-medium bg-gray-200 dark:bg-gray-600 px-3 py-1 rounded-full text-indigo-700 dark:text-indigo-300"
+              >
+                @{tag.username || tag.userId}
+              </span>
+            ))}
+          </>
         ) : (
           <span className="text-xs text-gray-400 dark:text-gray-500 italic">
             {user ? 'No tags' : 'No collaborators'}

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -45,7 +45,9 @@ const colors: Record<SummaryTagType, string> = {
   quest: 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
   task: 'bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-200',
   issue: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
-  log: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200',
+  // Align log events with the same palette used for experience entries
+  // to maintain a consistent look across timelines and logs.
+  log: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-200',
   review: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-200',
   category: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
   status: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -106,7 +106,12 @@ export const buildSummaryTags = (
     tags.push({ type: 'issue', label: `Issue: ${post.nodeId}`, link: ROUTES.POST(post.id) });
   } else if (post.type === 'log') {
     const user = post.author?.username || post.authorId;
-    tags.push({ type: 'log', label: `Log: @${user}`, link: ROUTES.POST(post.id) });
+    // Link log tags to the author's public profile for quick context
+    tags.push({
+      type: 'log',
+      label: `Log: @${user}`,
+      link: ROUTES.PUBLIC_PROFILE(post.authorId)
+    });
   }
 
   if (post.status && ['task', 'issue'].includes(post.type)) {
@@ -118,7 +123,10 @@ export const buildSummaryTags = (
     tags.push({ type: 'free_speech', label: `Free Speech: @${user}` });
   }
 
-  return tags;
+  // Remove duplicate entries by label in case of redundant inputs
+  return tags.filter((t, idx) =>
+    tags.findIndex((o) => o.label === t.label && o.type === t.type) === idx
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary
- update log tag color to match experience tags
- link log tags to author profiles
- deduplicate tag lists across components

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6857463301b8832f852d9f8c09fb7953