### PR TITLE
Improve request post UI in timeline

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -103,6 +103,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const isQuestBoardRequest =
     post.type === 'request' && selectedBoard === 'quest-board';
+  const isTimelineRequest = post.type === 'request' && selectedBoard === 'timeline-board';
 
   const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value;
@@ -412,7 +413,7 @@ const PostCard: React.FC<PostCardProps> = ({
           </h3>
         )}
         <ReactionControls post={post} user={user} onUpdate={onUpdate} replyOverride={replyOverride} />
-        {post.type === 'request' && !isQuestBoardRequest && (
+        {post.type === 'request' && !isQuestBoardRequest && !isTimelineRequest && (
           <button
             className="text-accent underline text-xs ml-2"
             onClick={handleAccept}


### PR DESCRIPTION
## Summary
- update ReactionControls to support Next button and completion checkbox for requests
- hide Accept action in PostCard for timeline requests

## Testing
- `npm run lint` in `ethos-frontend`
- `npm test -- -w=1` in `ethos-frontend`
- `npm test -- -w=1` in `ethos-backend` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68574692da00832f8489d73232b6bc52