### PR TITLE
Fix thread reply ordering

### DIFF
--- a/ethos-backend/dist/src/routes/boardRoutes.js
+++ b/ethos-backend/dist/src/routes/boardRoutes.js
@@ -80,7 +80,14 @@ router.get('/thread/:postId', (req, res) => {
     const pageSize = parseInt(limit, 10) || constants_1.DEFAULT_PAGE_SIZE;
     const start = (pageNum - 1) * pageSize;
     const end = start + pageSize;
-    const replies = posts.filter(p => p.replyTo === postId).slice(start, end);
+    const replies = posts
+        .filter(p => p.replyTo === postId)
+        .sort((a, b) => {
+        const ta = a.timestamp || '';
+        const tb = b.timestamp || '';
+        return tb.localeCompare(ta);
+    })
+        .slice(start, end);
     const board = {
         id: `thread-${postId}`,
         title: 'Thread',

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -108,7 +108,14 @@ router.get(
     const start = (pageNum - 1) * pageSize;
     const end = start + pageSize;
 
-    const replies = posts.filter(p => p.replyTo === postId).slice(start, end);
+    const replies = posts
+      .filter(p => p.replyTo === postId)
+      .sort((a, b) => {
+        const ta = a.timestamp || '';
+        const tb = b.timestamp || '';
+        return tb.localeCompare(ta);
+      })
+      .slice(start, end);
 
     const board: BoardData = {
       id: `thread-${postId}`,


### PR DESCRIPTION
## Summary
- sort post thread replies by newest first so replies appear at the top

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68574703472c832f87bd68ccc5b22fdb