### PR TITLE
Fix request help behavior and controls

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -507,6 +507,9 @@ router.post(
       needsHelp: true,
     };
 
+    original.helpRequest = true;
+    original.needsHelp = true;
+
     posts.push(requestPost);
     postsStore.write(posts);
     const users = usersStore.read();

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -319,6 +319,8 @@ describe('post routes', () => {
     expect(store).toHaveLength(2);
     expect(store[1].type).toBe('request');
     expect((store[1].linkedItems as any[])[0].itemId).toBe('t1');
+    expect(store[0].helpRequest).toBe(true);
+    expect(store[0].needsHelp).toBe(true);
   });
 
   it('POST /:id/request-help creates request post', async () => {
@@ -345,6 +347,8 @@ describe('post routes', () => {
     expect(store).toHaveLength(2);
     expect(store[1].type).toBe('request');
     expect((store[1].linkedItems as any[])[0].itemId).toBe('p2');
+    expect(store[0].helpRequest).toBe(true);
+    expect(store[0].needsHelp).toBe(true);
   });
 
   it('rejects non-request posts on quest board', async () => {

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -20,12 +20,18 @@ jest.mock('../../api/post', () => ({
       linkedItems: [],
     })
   ),
+  updateReaction: jest.fn(() => Promise.resolve()),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
 const appendMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ appendToBoard: appendMock }),
+  useBoardContext: () => ({ appendToBoard: appendMock, selectedBoard: null }),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -58,7 +64,9 @@ describe('PostCard request help', () => {
       </BrowserRouter>
     );
 
-    fireEvent.click(screen.getByText(/Request Help/i));
+    const btn = await screen.findByText(/Request Help/i);
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    fireEvent.click(btn);
 
     await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
     expect(appendMock).toHaveBeenCalled();

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -7,7 +7,7 @@ import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest, unacceptRequest, archivePost } from '../../api/post';
+import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, acceptRequest, unacceptRequest, archivePost } from '../../api/post';
 import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
@@ -118,21 +118,11 @@ const PostCard: React.FC<PostCardProps> = ({
     }
   };
 
-  const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
   const [accepting, setAccepting] = useState(false);
   const [accepted, setAccepted] = useState(
     !!user && post.tags?.includes(`pending:${user.id}`)
   );
 
-  const handleRequestHelp = async () => {
-    try {
-      const reqPost = await requestHelp(post.id);
-      appendToBoard?.('quest-board', reqPost);
-      setHelpRequested(true);
-    } catch (err) {
-      console.error('[PostCard] Failed to request help:', err);
-    }
-  };
 
   const handleAccept = async () => {
     try {
@@ -740,19 +730,7 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {post.type !== 'request' && post.type !== 'free_speech' && (
-        <label className="flex items-center gap-1 text-xs mt-1">
-          <input
-            type="checkbox"
-            checked={helpRequested}
-            onChange={() => !helpRequested && handleRequestHelp()}
-          />
-          Request Help
-          {helpRequested && (
-            <span className="ml-1 text-secondary">tracking</span>
-          )}
-        </label>
-      )}
+
 
       {(initialReplies > 0 || replies.length > 0) && (
         <button


### PR DESCRIPTION
## Summary
- persist `helpRequest` flags when requesting help
- adjust `ReactionControls` to show request help and limit repost to free speech
- remove old request help checkbox from `PostCard`
- update request help tests

## Testing
- `npm test` *(fails: Missing script)*
- `cd ethos-backend && npm test` *(fails: supertest not found)*
- `cd ../ethos-frontend && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574949753c832f8e427a6230ebb486