### PR TITLE
Limit height of QuestCard

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -543,9 +543,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
         )}
       </div>
       {expanded && (
-        <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex flex-col md:flex-row gap-4 max-h-[610px] overflow-y-auto">
           <div
-            className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700"
+            className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[610px]"
             style={{ width: leftWidth }}
           >
             {renderMap()}
@@ -554,7 +554,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
             onMouseDown={handleDividerMouseDown}
           />
-          <div className="flex-1 md:pl-4 overflow-auto">{renderRightPanel()}</div>
+          <div className="flex-1 md:pl-4 overflow-auto max-h-[610px]">{renderRightPanel()}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- cap height of expanded QuestCard so it feels more like a mini display

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68574a16c478832f8143910da3cfcb2d