### PR TITLE
Fix request help toggle

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -507,6 +507,9 @@ router.post(
       needsHelp: true,
     };
 
+    original.helpRequest = true;
+    original.needsHelp = true;
+
     posts.push(requestPost);
     postsStore.write(posts);
     const users = usersStore.read();

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -319,6 +319,8 @@ describe('post routes', () => {
     expect(store).toHaveLength(2);
     expect(store[1].type).toBe('request');
     expect((store[1].linkedItems as any[])[0].itemId).toBe('t1');
+    expect(store[0].helpRequest).toBe(true);
+    expect(store[0].needsHelp).toBe(true);
   });
 
   it('POST /:id/request-help creates request post', async () => {
@@ -345,6 +347,8 @@ describe('post routes', () => {
     expect(store).toHaveLength(2);
     expect(store[1].type).toBe('request');
     expect((store[1].linkedItems as any[])[0].itemId).toBe('p2');
+    expect(store[0].helpRequest).toBe(true);
+    expect(store[0].needsHelp).toBe(true);
   });
 
   it('rejects non-request posts on quest board', async () => {

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -9,6 +9,7 @@ import {
   FaRegHeart,
   FaReply,
   FaRetweet,
+  FaHandsHelping,
   FaExpand,
   FaCompress,
 } from 'react-icons/fa';
@@ -21,6 +22,8 @@ import {
   fetchReactions,
   fetchRepostCount,
   fetchUserRepost,
+  updatePost,
+  requestHelp,
 } from '../../api/post';
 import type { Post, ReactionType, ReactionCountMap, Reaction } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
@@ -54,9 +57,10 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [repostLoading, setRepostLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const navigate = useNavigate();
-  const { selectedBoard } = useBoardContext() || {};
+  const { selectedBoard, appendToBoard } = useBoardContext() || {};
   const isTimelineBoard = isTimeline ?? selectedBoard === 'timeline-board';
   const isQuestRequest = selectedBoard === 'quest-board' && post.type === 'request';
+  const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -133,6 +137,26 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     }
   };
 
+  const handleRequestHelp = async () => {
+    if (!user?.id) return;
+    if (!helpRequested) {
+      try {
+        const reqPost = await requestHelp(post.id);
+        appendToBoard?.('quest-board', reqPost);
+        setHelpRequested(true);
+      } catch (err) {
+        console.error('[ReactionControls] Failed to request help:', err);
+      }
+    } else {
+      try {
+        await updatePost(post.id, { helpRequest: false, needsHelp: false });
+        setHelpRequested(false);
+      } catch (err) {
+        console.error('[ReactionControls] Failed to cancel help request:', err);
+      }
+    }
+  };
+
   return (
     <>
       <div className="flex gap-4 items-center text-sm text-gray-500 dark:text-gray-400">
@@ -152,13 +176,23 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           {reactions.heart ? <FaHeart /> : <FaRegHeart />} {counts.heart || ''}
         </button>
 
-        {!isQuestRequest && (
+        {!isQuestRequest && post.type === 'free_speech' && (
           <button
             className={clsx('flex items-center gap-1', userRepostId && 'text-indigo-600')}
             onClick={handleRepost}
             disabled={loading || repostLoading || !user}
           >
             <FaRetweet /> {counts.repost || ''}
+          </button>
+        )}
+
+        {!isQuestRequest && ['quest', 'task', 'issue'].includes(post.type) && (
+          <button
+            className={clsx('flex items-center gap-1', helpRequested && 'text-indigo-600')}
+            onClick={handleRequestHelp}
+            disabled={loading || !user}
+          >
+            <FaHandsHelping /> {helpRequested ? 'Cancel Help' : 'Request Help'}
           </button>
         )}
 

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
-import { requestHelp } from '../../api/post';
+import { requestHelp, updatePost } from '../../api/post';
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
@@ -20,12 +20,19 @@ jest.mock('../../api/post', () => ({
       linkedItems: [],
     })
   ),
+  updatePost: jest.fn(() => Promise.resolve({})),
+  updateReaction: jest.fn(() => Promise.resolve()),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
 const appendMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ appendToBoard: appendMock }),
+  useBoardContext: () => ({ appendToBoard: appendMock, selectedBoard: null }),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -58,10 +65,15 @@ describe('PostCard request help', () => {
       </BrowserRouter>
     );
 
-    fireEvent.click(screen.getByText(/Request Help/i));
+    const btn = await screen.findByText(/Request Help/i);
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    fireEvent.click(btn);
 
     await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
     expect(appendMock).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText(/Cancel Help/i));
+    await waitFor(() => expect(updatePost).toHaveBeenCalledWith('t1', { helpRequest: false, needsHelp: false }));
   });
 
   it('does not show checkbox for free speech posts', () => {

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -7,7 +7,7 @@ import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, requestHelp, acceptRequest, unacceptRequest, archivePost } from '../../api/post';
+import { fetchRepliesByPostId, updatePost, fetchPostsByQuestId, acceptRequest, unacceptRequest, archivePost } from '../../api/post';
 import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
@@ -118,21 +118,11 @@ const PostCard: React.FC<PostCardProps> = ({
     }
   };
 
-  const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
   const [accepting, setAccepting] = useState(false);
   const [accepted, setAccepted] = useState(
     !!user && post.tags?.includes(`pending:${user.id}`)
   );
 
-  const handleRequestHelp = async () => {
-    try {
-      const reqPost = await requestHelp(post.id);
-      appendToBoard?.('quest-board', reqPost);
-      setHelpRequested(true);
-    } catch (err) {
-      console.error('[PostCard] Failed to request help:', err);
-    }
-  };
 
   const handleAccept = async () => {
     try {
@@ -740,19 +730,7 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {post.type !== 'request' && post.type !== 'free_speech' && (
-        <label className="flex items-center gap-1 text-xs mt-1">
-          <input
-            type="checkbox"
-            checked={helpRequested}
-            onChange={() => !helpRequested && handleRequestHelp()}
-          />
-          Request Help
-          {helpRequested && (
-            <span className="ml-1 text-secondary">tracking</span>
-          )}
-        </label>
-      )}
+
 
       {(initialReplies > 0 || replies.length > 0) && (
         <button


### PR DESCRIPTION
## Summary
- make request help button toggleable
- update request help unit test accordingly

## Testing
- `npm test` *(fails: Missing script)*
- `cd ethos-backend && npm test` *(fails: supertest not found)*
- `cd ../ethos-frontend && npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68574949753c832f8e427a6230ebb486