### PR TITLE
Enable single click to open quest node

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -236,7 +236,12 @@ const GraphNode: React.FC<GraphNodeProps> = ({
         <div
           style={{ marginLeft: depth * 16 }}
           className="mb-6 flex items-start space-x-2 cursor-pointer"
-          onClick={() => onSelect(node)}
+          onClick={() => {
+            onSelect(node);
+            window.dispatchEvent(
+              new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
+            );
+          }}
           onDoubleClick={() => {
             onSelect(node);
             window.dispatchEvent(

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
@@ -67,12 +67,16 @@ describe('PostCard request help', () => {
 
     const btn = await screen.findByText(/Request Help/i);
     await waitFor(() => expect(btn).not.toBeDisabled());
-    fireEvent.click(btn);
+    await act(async () => {
+      fireEvent.click(btn);
+    });
 
     await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
     expect(appendMock).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByText(/Cancel Help/i));
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Cancel Help/i));
+    });
     await waitFor(() => expect(updatePost).toHaveBeenCalledWith('t1', { helpRequest: false, needsHelp: false }));
   });
 

--- a/ethos-frontend/tests/GraphLayout.test.js
+++ b/ethos-frontend/tests/GraphLayout.test.js
@@ -148,7 +148,7 @@ describe.skip('GraphLayout node interaction', () => {
     expect(screen.getByText('Create Post')).toBeInTheDocument();
   });
 
-  it('dispatches event on node double click', () => {
+  it('dispatches event on node click', () => {
     const posts = [
       {
         id: 'p1',
@@ -168,7 +168,7 @@ describe.skip('GraphLayout node interaction', () => {
 
     render(React.createElement(GraphLayout, { items: posts, questId: 'q1' }));
 
-    fireEvent.doubleClick(screen.getAllByText('Task')[1]);
+    fireEvent.click(screen.getAllByText('Task')[1]);
 
     expect(listener).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- dispatch `questTaskOpen` on GraphNode click
- update GraphLayout test to expect single click
- fix PostCard.requestHelp test by adding `act`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574fb3b358832fae945fb5fc99a063