### PR TITLE
Improve request visibility and controls

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -59,7 +59,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [showReplyPanel, setShowReplyPanel] = useState(false);
   const [repostLoading, setRepostLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  const [completed, setCompleted] = useState(false);
+  const [completed, setCompleted] = useState(post.tags?.includes('archived') ?? false);
   const navigate = useNavigate();
   const { selectedBoard, appendToBoard } = useBoardContext() || {};
   const isTimelineBoard = isTimeline ?? selectedBoard === 'timeline-board';
@@ -147,6 +147,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       try {
         const reqPost = await requestHelp(post.id);
         appendToBoard?.('quest-board', reqPost);
+        appendToBoard?.('timeline-board', reqPost);
         setHelpRequested(true);
       } catch (err) {
         console.error('[ReactionControls] Failed to request help:', err);
@@ -158,6 +159,16 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       } catch (err) {
         console.error('[ReactionControls] Failed to cancel help request:', err);
       }
+    }
+  };
+
+  const handleMarkComplete = async () => {
+    if (!user || user.id !== post.authorId || completed) return;
+    try {
+      await archivePost(post.id);
+      setCompleted(true);
+    } catch (err) {
+      console.error('[ReactionControls] Failed to mark request complete:', err);
     }
   };
 
@@ -197,6 +208,16 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
             disabled={loading || !user}
           >
             <FaHandsHelping /> {helpRequested ? 'Cancel Help' : 'Request Help'}
+          </button>
+        )}
+
+        {post.type === 'request' && user?.id === post.authorId && (
+          <button
+            className={clsx('flex items-center gap-1', completed && 'text-green-600')}
+            onClick={handleMarkComplete}
+            disabled={completed}
+          >
+            {completed ? <FaCheckSquare /> : <FaRegCheckSquare />} Complete
           </button>
         )}
 

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -7,7 +7,8 @@ import {
   FaStickyNote,
   FaStar,
   FaCommentAlt,
-  FaUser
+  FaUser,
+  FaHandsHelping
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import { TAG_BASE } from '../../constants/styles';
@@ -21,7 +22,8 @@ export type SummaryTagType =
   | 'category'
   | 'status'
   | 'free_speech'
-  | 'type';
+  | 'type'
+  | 'request';
 
 export interface SummaryTagData {
   type: SummaryTagType;
@@ -39,6 +41,7 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
   status: FaStickyNote,
   free_speech: FaCommentAlt,
   type: FaUser,
+  request: FaHandsHelping,
 };
 
 const colors: Record<SummaryTagType, string> = {
@@ -53,6 +56,7 @@ const colors: Record<SummaryTagType, string> = {
   status: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
   free_speech: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
   type: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  request: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
 };
 
 

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -96,6 +96,26 @@ export const buildSummaryTags = (
     return tags;
   }
 
+  if (post.type === 'request') {
+    if (post.questId && title) {
+      tags.push({
+        type: 'request',
+        label: `Request: ${title}`,
+        link: ROUTES.QUEST(post.questId),
+      });
+      if (post.nodeId) {
+        tags.push({ type: 'task', label: `Task: ${post.nodeId}`, link: ROUTES.POST(post.id) });
+      }
+      if (post.status && post.status !== 'To Do') {
+        tags.push({ type: 'status', label: post.status });
+      }
+    } else {
+      const user = post.author?.username || post.authorId;
+      tags.push({ type: 'request', label: `Request: @${user}` });
+    }
+    return tags;
+  }
+
   if (!multipleSources && title) {
     tags.push({ type: 'quest', label: `Quest: ${title}`, link: (questId || post.questId) ? ROUTES.QUEST(questId || post.questId!) : undefined });
   }


### PR DESCRIPTION
## Summary
- show request posts instantly on the timeline board
- allow users to mark their requests complete
- display new `request` summary tags

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `cd ethos-backend && npm test` *(fails: missing modules 'supertest' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68575098dad0832f9d8cd540f339db54