### PR TITLE
Add log tags for issue posts

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -377,7 +377,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            <PostTypeBadge type={post.type} />
+            <PostTypeBadge type={['task', 'issue'].includes(post.type) ? 'log' : post.type} />
             {post.status && <StatusBadge status={post.status} />}
             {showAuthor && (
               <button
@@ -431,7 +431,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-          <PostTypeBadge type={post.type} />
+          <PostTypeBadge type={['task', 'issue'].includes(post.type) ? 'log' : post.type} />
           {!isQuestBoardRequest && post.status && <StatusBadge status={post.status} />}
           {!isQuestBoardRequest &&
             canEdit &&

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -114,6 +114,16 @@ export const buildSummaryTags = (
     });
   }
 
+  // Include author log reference on task and issue posts for quick context
+  if (['task', 'issue'].includes(post.type)) {
+    const user = post.author?.username || post.authorId;
+    tags.push({
+      type: 'log',
+      label: `Log: @${user}`,
+      link: ROUTES.PUBLIC_PROFILE(post.authorId)
+    });
+  }
+
   if (post.status && ['task', 'issue'].includes(post.type)) {
     tags.push({ type: 'status', label: post.status });
   }


### PR DESCRIPTION
## Summary
- show log author tags on tasks and issues
- display log badge for tasks and issues in PostCard

## Testing
- `npm test` *(fails: Cannot find module 'supertest', jest environment issues)*
- `npm run lint` *(fails: Cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685751032b40832f81196e8289100391