### PR TITLE
Fix MapGraphLayout build error

### DIFF
--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect, useRef, useState } from 'react';
-import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
+import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import type { TaskEdge } from '../../types/questTypes';


### PR DESCRIPTION
## Summary
- import `ForceGraphMethods` as a type

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend` *(fails: Property 'helpRequest' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685752860090832f8c0e138a632bffce