### PR TITLE
Fix board selection flicker

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -116,6 +116,7 @@ const Board: React.FC<BoardProps> = ({
       setItems((boardProp.enrichedItems || []) as Post[]);
       setLoading(false);
     } else {
+      if (boardId) setSelectedBoard(boardId); // set early to avoid flicker
       loadBoard();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- select board before asynchronous fetch completes to stabilize board-specific rendering

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685756fa2264832fa0a63e28bab76207