### PR TITLE
Refactor: remove redundant badges

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -12,7 +12,6 @@ import {
   FaHandsHelping,
   FaExpand,
   FaCompress,
-  FaStepForward,
   FaCheckSquare,
   FaRegCheckSquare,
 } from 'react-icons/fa';

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -381,8 +381,14 @@ const PostCard: React.FC<PostCardProps> = ({
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            <PostTypeBadge type={['task', 'issue'].includes(post.type) ? 'log' : post.type} />
-            {post.status && <StatusBadge status={post.status} />}
+            {post.type !== 'log' && (
+              <PostTypeBadge
+                type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
+              />
+            )}
+            {post.status && post.status !== 'To Do' && (
+              <StatusBadge status={post.status} />
+            )}
             {showAuthor && (
               <button
                 type="button"
@@ -435,8 +441,14 @@ const PostCard: React.FC<PostCardProps> = ({
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-          <PostTypeBadge type={['task', 'issue'].includes(post.type) ? 'log' : post.type} />
-          {!isQuestBoardRequest && post.status && <StatusBadge status={post.status} />}
+          {post.type !== 'log' && (
+            <PostTypeBadge
+              type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
+            />
+          )}
+          {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
+            <StatusBadge status={post.status} />
+          )}
           {!isQuestBoardRequest &&
             canEdit &&
             ['task', 'request', 'issue'].includes(post.type) &&

--- a/ethos-frontend/tests/GraphLayoutAbstractEdge.test.tsx
+++ b/ethos-frontend/tests/GraphLayoutAbstractEdge.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 
-let dragHandler: any;
+let dragHandler: unknown;
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -36,7 +36,7 @@ jest.mock('@dnd-kit/core', () => ({
   }),
   useDroppable: () => ({ setNodeRef: jest.fn(), isOver: false }),
   useSensor: jest.fn(),
-  useSensors: (...s: any[]) => s,
+  useSensors: (...s: unknown[]) => s,
   PointerSensor: jest.fn(),
   closestCenter: jest.fn(),
 }), { virtual: true });


### PR DESCRIPTION
## Summary
- avoid showing PostTypeBadge for logs
- hide status badge when status is `To Do`
- clean up unused icon import
- fix types in GraphLayoutAbstractEdge test

## Testing
- `npm run lint`
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_685759f66ae0832f9a403fdb7b6593b7