### PR TITLE
Add carousel transitions to quest boards

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -280,7 +280,14 @@ const GridLayout: React.FC<GridLayoutProps> = ({
           {items.map((item, idx) => (
             <div
               key={item.id}
-              className={`snap-center flex-shrink-0 transition-all ${idx === index ? 'w-full sm:w-[640px]' : 'w-64 sm:w-[300px] opacity-80'}`}
+              className={
+                'snap-center flex-shrink-0 w-64 sm:w-[300px] transition-transform duration-300 ' +
+                (idx === index
+                  ? 'scale-100'
+                  : Math.abs(idx - index) === 1
+                  ? 'scale-95 opacity-80'
+                  : 'scale-90 opacity-50')
+              }
             >
               <ContributionCard
                 contribution={item}
@@ -321,7 +328,11 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                       key={idx}
                       type="button"
                       onClick={() => setIndex(actual)}
-                      className={`mx-1 w-2 h-2 rounded-full ${isActive ? 'bg-accent' : 'bg-background'} ${isEdge && !isActive ? 'opacity-50' : ''} focus:outline-none`}
+                      className={
+                        'mx-1 w-2 h-2 rounded-full transition-all ' +
+                        (isActive ? 'bg-accent opacity-100' : 'bg-secondary/40 opacity-70') +
+                        (isEdge && !isActive ? ' scale-75' : '')
+                      }
                     />
                   );
                 });

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -115,9 +115,14 @@ const ActiveQuestBoard: React.FC = () => {
           {quests.map((q, idx) => (
             <div
               key={q.id}
-              className={`snap-center flex-shrink-0 w-[90%] sm:w-[850px] transition-opacity ${
-                idx === index ? '' : 'opacity-80'
-              }`}
+              className={
+                'snap-center flex-shrink-0 w-[90%] sm:w-[850px] transition-transform duration-300 ' +
+                (idx === index
+                  ? 'scale-100'
+                  : Math.abs(idx - index) === 1
+                  ? 'scale-95 opacity-80'
+                  : 'scale-90 opacity-50')
+              }
             >
               <QuestCard quest={q} />
             </div>
@@ -154,9 +159,11 @@ const ActiveQuestBoard: React.FC = () => {
                 key={idx}
                 type="button"
                 onClick={() => setIndex(actual)}
-                className={`mx-1 w-4 h-1 rounded transition-transform duration-200 ${
-                  isActive ? 'bg-accent scale-x-125' : 'bg-background'
-                } ${isEdge && !isActive ? 'opacity-50' : ''}`}
+                className={
+                  'mx-1 w-2 h-2 rounded-full transition-all ' +
+                  (isActive ? 'bg-accent opacity-100' : 'bg-secondary/40 opacity-70') +
+                  (isEdge && !isActive ? ' scale-75' : '')
+                }
               />
             );
           });


### PR DESCRIPTION
## Summary
- tweak `ActiveQuestBoard` to scale adjacent cards
- add similar scaling effect for horizontal `GridLayout`

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68575dfe6988832f82cc70c9c18c3806