### PR TITLE
Add task detail modal

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
+import TaskDetailModal from '../quest/TaskDetailModal';
 import {
   updateReaction,
   addRepost,
@@ -285,11 +286,13 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </div>
       )}
 
-      {expanded && post.type === 'task' && (
-        <div className="mt-3 text-sm text-gray-600 dark:text-gray-400">
-          {post.questId && <div>Quest ID: {post.questId}</div>}
-          {post.status && <div>Status: {post.status}</div>}
-        </div>
+      {expanded && post.type === 'task' && post.questId && (
+        <TaskDetailModal
+          task={post}
+          questId={post.questId}
+          user={user}
+          onClose={() => setExpanded(false)}
+        />
       )}
 
       {expanded && post.type === 'commit' && (

--- a/ethos-frontend/src/components/quest/TaskDetailModal.tsx
+++ b/ethos-frontend/src/components/quest/TaskDetailModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import QuestNodeInspector from './QuestNodeInspector';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+interface TaskDetailModalProps {
+  task: Post;
+  questId: string;
+  user?: User;
+  onClose: () => void;
+}
+
+const TaskDetailModal: React.FC<TaskDetailModalProps> = ({ task, questId, user, onClose }) => {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-surface p-4 rounded w-full max-w-xl max-h-full overflow-auto">
+        <div className="text-right mb-2">
+          <button className="text-accent underline text-sm" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <QuestNodeInspector questId={questId} node={task} user={user} />
+      </div>
+    </div>
+  );
+};
+
+export default TaskDetailModal;

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useBoard } from '../hooks/useBoard';
 import { useSocketListener } from '../hooks/useSocket';


### PR DESCRIPTION
## Summary
- implement TaskDetailModal for quest tasks
- show TaskDetailModal when expanding a task in ReactionControls
- fix unused imports in Profile page

## Testing
- `npm run lint --prefix ethos-frontend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68575f4f4b70832f9abec749c7238671