### PR TITLE
Shorten expanded QuestCard height

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -309,7 +309,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             </button>
           </div>
         </div>
-        <div className="h-96 overflow-auto" data-testid="quest-map-canvas">
+        <div className="h-80 overflow-auto" data-testid="quest-map-canvas">
           {canvas}
         </div>
       </div>
@@ -556,9 +556,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
         )}
       </div>
       {expanded && (
-        <div className="flex flex-col md:flex-row gap-4 max-h-[480px] overflow-y-auto">
+        <div className="flex flex-col md:flex-row gap-4 max-h-[420px] overflow-y-auto">
           <div
-            className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[480px]"
+            className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
             style={{ width: leftWidth }}
           >
             {renderMap()}
@@ -567,7 +567,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
             onMouseDown={handleDividerMouseDown}
           />
-          <div className="flex-1 md:pl-4 overflow-auto max-h-[480px]">{renderRightPanel()}</div>
+          <div className="flex-1 md:pl-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- reduce height of quest map canvas
- shrink expanded QuestCard container

## Testing
- `npm run lint` *(fails: 'useEffect' defined but never used)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575fdc9420832f8cf34e9679a41f0f