### PR TITLE
Simplify quest board request posts

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -162,8 +162,14 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || (post.type === 'task' ? post.content : '');
-  const summaryTags = buildSummaryTags(post, questTitle, questId);
-  const showAuthor = !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
+  let summaryTags = buildSummaryTags(post, questTitle, questId);
+  if (isQuestBoardRequest) {
+    const user = post.author?.username || post.authorId;
+    summaryTags = [{ type: 'request', label: `Request: @${user}` }];
+  }
+  const showAuthor =
+    !isQuestBoardRequest &&
+    !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -381,12 +387,12 @@ const PostCard: React.FC<PostCardProps> = ({
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            {post.type !== 'log' && (
+            {post.type !== 'log' && !isQuestBoardRequest && (
               <PostTypeBadge
                 type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
               />
             )}
-            {post.status && post.status !== 'To Do' && (
+            {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
               <StatusBadge status={post.status} />
             )}
             {showAuthor && (
@@ -441,7 +447,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-          {post.type !== 'log' && (
+          {post.type !== 'log' && !isQuestBoardRequest && (
             <PostTypeBadge
               type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
             />


### PR DESCRIPTION
## Summary
- show only "Request: @user" tag when viewing quest board requests
- hide post type and status labels on quest board requests

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685760b26018832fa07dd3bea015b401