### PR TITLE
Fix missing useState import in Profile page

### DIFF
--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useBoard } from '../hooks/useBoard';
 import { useSocketListener } from '../hooks/useSocket';


### PR DESCRIPTION
## Summary
- import `useState` in `ProfilePage` component

## Testing
- `npm install` inside `ethos-frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685761bda36c832fa192471f4ca29be4