### PR TITLE
Fix BoardContext loop

### DIFF
--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   type ReactNode,
   useMemo,
+  useCallback,
 } from 'react';
 import { useAuth } from './AuthContext';
 import { fetchBoards as fetchBoardsAPI, updateBoard } from '../api/board';
@@ -26,9 +27,12 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const [loading, setLoading] = useState<boolean>(true);
   const [, setBoardMetaState] = useState<{ id: string; title: string; layout: string } | null>(null);
 
-  const setBoardMeta = (meta: { id: string; title: string; layout: string }) => {
-    setBoardMetaState(meta);
-  };
+  const setBoardMeta = useCallback(
+    (meta: { id: string; title: string; layout: string }) => {
+      setBoardMetaState(meta);
+    },
+    []
+  );
 
   useEffect(() => {
     if (authLoading) return;


### PR DESCRIPTION
## Summary
- fix infinite loop in `setBoardMeta` by wrapping in `useCallback`
- run frontend tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685762639054832f8742a8a28fc6f050