### PR TITLE
Remove unused quest board request header

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -353,24 +353,7 @@ const PostCard: React.FC<PostCardProps> = ({
   }
 
   if (headerOnly) {
-    const collaboratorCount = post.collaborators?.filter(c => c.userId).length || 0;
-    if (isQuestBoardRequest) {
-      return (
-        <div
-          id={post.id}
-          className={clsx(
-            'border border-secondary rounded bg-surface p-4 space-y-2 text-primary',
-            className
-          )}
-        >
-          {titleText && <h3 className="font-semibold text-lg">{titleText}</h3>}
-          <div className="text-sm text-secondary">{collaboratorCount} collaborators</div>
-          <Button variant="ghost" size="sm" onClick={handleComplete}>
-            Mark Complete
-          </Button>
-        </div>
-      );
-    }
+
 
     return (
       <div


### PR DESCRIPTION
## Summary
- remove quest board request markup in PostCard

## Testing
- `npm test --silent` (fails: Test environment jest-environment-jsdom cannot be found)
- `npm test --silent` in `ethos-backend` (fails to find modules)

------
https://chatgpt.com/codex/tasks/task_e_685764f88d64832fae1b4807bbd38677