### PR TITLE
Display quest tag in activity list

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -38,4 +38,20 @@ describe('PostListItem', () => {
     fireEvent.click(screen.getByText(/hello world/));
     expect(navMock).toHaveBeenCalledWith(ROUTES.POST('p1'));
   });
+
+  it('renders quest tag when quest info is provided', () => {
+    const questPost: Post = {
+      ...basePost,
+      questId: 'q1',
+      questTitle: 'Quest A',
+    } as Post;
+
+    render(
+      <BrowserRouter>
+        <PostListItem post={questPost} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('Quest: Quest A')).toBeInTheDocument();
+  });
 });

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -5,6 +5,7 @@ import type { Post } from '../../types/postTypes';
 import { getDisplayTitle } from '../../utils/displayUtils';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
+import SummaryTag from '../ui/SummaryTag';
 
 interface PostListItemProps {
   post: Post;
@@ -16,6 +17,10 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
   const header = getDisplayTitle(post);
+  const questTag =
+    post.questId && post.questTitle
+      ? { type: 'quest' as const, label: `Quest: ${post.questTitle}`, link: ROUTES.QUEST(post.questId) }
+      : null;
 
   return (
     <div
@@ -30,6 +35,7 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
           {header}
           <span className="text-xs text-secondary ml-2">{timestamp}</span>
         </div>
+        {questTag && <SummaryTag {...questTag} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show quest context link in `PostListItem`
- cover new tag in `PostListItem` tests

## Testing
- `npm --prefix ethos-frontend run lint` *(fails: cannot find eslint-plugin-react-hooks)*
- `NODE_OPTIONS=--experimental-vm-modules npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68576551ff28832fb5657ce2d618c889