### PR TITLE
Simplify quest board requests

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: 'quest-board' }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+const post: Post = {
+  id: 'p1',
+  authorId: 'u1',
+  type: 'request',
+  content: 'Help me',
+  status: 'In Progress',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+} as unknown as Post;
+
+it('hides status controls and shows only request tag', () => {
+  render(
+    <BrowserRouter>
+      <PostCard post={post} user={{ id: 'u1' }} />
+    </BrowserRouter>
+  );
+
+  expect(screen.getByText('Request: @u1')).toBeInTheDocument();
+  expect(screen.queryByText('In Progress')).toBeNull();
+  expect(screen.queryByRole('combobox')).toBeNull();
+});

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -162,8 +162,14 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || (post.type === 'task' ? post.content : '');
-  const summaryTags = buildSummaryTags(post, questTitle, questId);
-  const showAuthor = !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
+  let summaryTags = buildSummaryTags(post, questTitle, questId);
+  if (isQuestBoardRequest) {
+    const user = post.author?.username || post.authorId;
+    summaryTags = [{ type: 'request', label: `Request: @${user}` }];
+  }
+  const showAuthor =
+    !isQuestBoardRequest &&
+    !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -381,12 +387,12 @@ const PostCard: React.FC<PostCardProps> = ({
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            {post.type !== 'log' && (
+            {post.type !== 'log' && !isQuestBoardRequest && (
               <PostTypeBadge
                 type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
               />
             )}
-            {post.status && post.status !== 'To Do' && (
+            {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
               <StatusBadge status={post.status} />
             )}
             {showAuthor && (
@@ -441,7 +447,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-          {post.type !== 'log' && (
+          {post.type !== 'log' && !isQuestBoardRequest && (
             <PostTypeBadge
               type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
             />


### PR DESCRIPTION
## Summary
- only show `Request: @user` label for quest board requests
- hide status badge and dropdown on quest board requests
- add unit test covering quest board behavior

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685760b26018832fa07dd3bea015b401