### PR TITLE
fix board context confusion when scrolling boards

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -452,6 +452,7 @@ const Board: React.FC<BoardProps> = ({
           loadingMore={loadingMore}
           contributions={items}
           questId={quest?.id || ''}
+          boardId={board?.id}
           initialExpanded={initialExpanded}
           headerOnly={isQuestBoard || headerOnly}
           editable={editable}

--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -24,6 +24,8 @@ interface ContributionCardProps {
   headerOnly?: boolean;
   /** Expand replies when rendering PostCard */
   initialShowReplies?: boolean;
+  /** Board ID where this contribution is rendered */
+  boardId?: string;
 }
 
 const ContributionCard: React.FC<ContributionCardProps> = ({
@@ -36,6 +38,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   showStatusControl = true,
   headerOnly = false,
   initialShowReplies = false,
+  boardId,
 }) => {
   if (!contribution) return null;
 
@@ -46,7 +49,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
     return null;
   }
 
-  const sharedProps = { user, compact, onEdit, onDelete, showStatusControl, headerOnly, initialShowReplies };
+  const sharedProps = { user, compact, onEdit, onDelete, showStatusControl, headerOnly, initialShowReplies, boardId };
 
   // ✅ Render Post types
   if ('type' in contribution) {
@@ -57,6 +60,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
         questId={questId}
         {...sharedProps}
         headerOnly={headerOnly}
+        boardId={boardId}
       />
     );
   }

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -44,6 +44,8 @@ interface ReactionControlsProps {
   replyOverride?: { label: string; onClick: () => void };
   /** Treat reply action as coming from the timeline board */
   isTimeline?: boolean;
+  /** Board ID used for context-specific actions */
+  boardId?: string;
 }
 
 const ReactionControls: React.FC<ReactionControlsProps> = ({
@@ -52,6 +54,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   onUpdate,
   replyOverride,
   isTimeline,
+  boardId,
 }) => {
   const [reactions, setReactions] = useState({ like: false, heart: false });
   const [counts, setCounts] = useState({ like: 0, heart: 0, repost: 0 });
@@ -64,8 +67,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [completed, setCompleted] = useState(post.tags?.includes('archived') ?? false);
   const navigate = useNavigate();
   const { selectedBoard, appendToBoard } = useBoardContext() || {};
-  const isTimelineBoard = isTimeline ?? selectedBoard === 'timeline-board';
-  const isQuestRequest = selectedBoard === 'quest-board' && post.type === 'request';
+  const ctxBoardId = boardId || selectedBoard;
+  const isTimelineBoard = isTimeline ?? ctxBoardId === 'timeline-board';
+  const isQuestRequest = ctxBoardId === 'quest-board' && post.type === 'request';
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
 
   useEffect(() => {

--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -31,6 +31,7 @@ interface GraphLayoutProps {
   onSelectNode?: (n: Post) => void;
   onScrollEnd?: () => void;
   loadingMore?: boolean;
+  boardId?: string;
 }
 
 interface NodeChild {
@@ -64,6 +65,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   onSelectNode,
   onScrollEnd,
   loadingMore = false,
+  boardId,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -348,6 +350,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
             registerNode={(id, el) => {
               nodeRefs.current[id] = el;
             }}
+            boardId={boardId}
           />
         ))}
         {loadingMore && (

--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -33,6 +33,7 @@ interface GraphNodeProps {
   diffLoading: boolean;
   registerNode?: (id: string, el: HTMLDivElement | null) => void;
   onRemoveEdge?: (edge: TaskEdge) => void;
+  boardId?: string;
 }
 
 const GraphNode: React.FC<GraphNodeProps> = ({
@@ -51,6 +52,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   diffLoading,
   registerNode,
   onRemoveEdge,
+  boardId,
 }) => {
   const isFolder = node.type === 'quest' || node.tags.includes('quest');
   const icon = isFolder ? '📁' : '📄';
@@ -267,6 +269,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             user={user}
             compact={compact}
             showStatusControl={showStatus}
+            boardId={boardId}
           />
           <span
             data-testid={`move-${node.id}`}

--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -28,6 +28,8 @@ type GridLayoutProps = {
   loadingMore?: boolean;
   /** Expand replies for all posts */
   initialExpanded?: boolean;
+  /** Board ID for context */
+  boardId?: string;
 };
 
 const defaultKanbanColumns = ['To Do', 'In Progress', 'Blocked', 'Done'];
@@ -62,6 +64,7 @@ const DraggableCard: React.FC<{
         onEdit={onEdit}
         onDelete={onDelete}
         initialShowReplies={initialExpanded}
+        boardId={boardId}
       />
     </div>
   );
@@ -89,6 +92,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   onDelete,
   loadingMore = false,
   initialExpanded = false,
+  boardId,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [index, setIndex] = useState(0);
@@ -296,6 +300,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                 onEdit={onEdit}
                 onDelete={onDelete}
                 initialShowReplies={initialExpanded}
+                boardId={boardId}
               />
             </div>
           ))}
@@ -369,6 +374,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                   onEdit={onEdit}
                   onDelete={onDelete}
                   initialShowReplies={initialExpanded}
+                  boardId={boardId}
                 />
               ))}
             </div>
@@ -435,6 +441,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               onEdit={onEdit}
               onDelete={onDelete}
               initialShowReplies={initialExpanded}
+              boardId={boardId}
             />
           ))}
           {loadingMore && <Spinner />}
@@ -477,6 +484,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
             onEdit={onEdit}
             onDelete={onDelete}
             initialShowReplies={initialExpanded}
+            boardId={boardId}
           />
         </div>
       ))}

--- a/ethos-frontend/src/components/layout/ListLayout.tsx
+++ b/ethos-frontend/src/components/layout/ListLayout.tsx
@@ -17,6 +17,8 @@ interface ListLayoutProps {
   headerOnly?: boolean;
   /** Expand replies for all posts */
   initialExpanded?: boolean;
+  /** Board ID for context */
+  boardId?: string;
 }
 
 const ListLayout: React.FC<ListLayoutProps> = ({
@@ -30,6 +32,7 @@ const ListLayout: React.FC<ListLayoutProps> = ({
   loadingMore = false,
   headerOnly = false,
   initialExpanded = false,
+  boardId,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -69,6 +72,7 @@ const ListLayout: React.FC<ListLayoutProps> = ({
           questId={questId}
           headerOnly={headerOnly}
           initialShowReplies={initialExpanded}
+          boardId={boardId}
         />
       ))}
       {loadingMore && <Spinner />}

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -55,6 +55,8 @@ interface PostCardProps {
   initialShowReplies?: boolean;
   /** Show detailed view including reply chain */
   showDetails?: boolean;
+  /** Board ID where this post is being rendered */
+  boardId?: string;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -72,6 +74,7 @@ const PostCard: React.FC<PostCardProps> = ({
   className = '',
   initialShowReplies = false,
   showDetails = false,
+  boardId,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [replies, setReplies] = useState<Post[]>([]);
@@ -100,18 +103,20 @@ const PostCard: React.FC<PostCardProps> = ({
     appendToBoard,
   } = useBoardContext() || {};
 
+  const ctxBoardId = boardId || selectedBoard;
+
   const isQuestBoardRequest =
-    post.type === 'request' && selectedBoard === 'quest-board';
-  const isTimelineRequest = post.type === 'request' && selectedBoard === 'timeline-board';
+    post.type === 'request' && ctxBoardId === 'quest-board';
+  const isTimelineRequest = post.type === 'request' && ctxBoardId === 'timeline-board';
 
   const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value;
     const optimistic = { ...post, status: newStatus };
-    if (selectedBoard) updateBoardItem(selectedBoard, optimistic);
+    if (ctxBoardId) updateBoardItem(ctxBoardId, optimistic);
     onUpdate?.(optimistic);
     try {
       const updated = await updatePost(post.id, { status: newStatus });
-      if (selectedBoard) updateBoardItem(selectedBoard, updated);
+      if (ctxBoardId) updateBoardItem(ctxBoardId, updated);
       onUpdate?.(updated);
     } catch (err) {
       console.error('[PostCard] Failed to update status:', err);
@@ -388,7 +393,13 @@ const PostCard: React.FC<PostCardProps> = ({
             {titleText}
           </h3>
         )}
-        <ReactionControls post={post} user={user} onUpdate={onUpdate} replyOverride={replyOverride} />
+        <ReactionControls
+          post={post}
+          user={user}
+          onUpdate={onUpdate}
+          replyOverride={replyOverride}
+          boardId={ctxBoardId || undefined}
+        />
         {post.type === 'request' && !isQuestBoardRequest && !isTimelineRequest && (
           <button
             className="text-accent underline text-xs ml-2"
@@ -638,6 +649,7 @@ const PostCard: React.FC<PostCardProps> = ({
         user={user}
         onUpdate={onUpdate}
         replyOverride={replyOverride}
+        boardId={ctxBoardId || undefined}
       />
       {post.type === 'request' && !isQuestBoardRequest && (
         <button

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -245,6 +245,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
           showStatus={false}
           onSelectNode={setSelectedNode}
           showInspector={false}
+          boardId={`map-${quest.id}`}
         />
       );
 
@@ -375,6 +376,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 user={user}
                 layout="vertical"
                 editable={canEdit}
+                boardId={`log-${quest.id}`}
               />
               <div className="text-right mt-2">
                 {canEdit ? (
@@ -421,6 +423,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 layout="kanban"
                 editable={canEdit}
                 compact
+                boardId={`log-${quest.id}`}
               />
               <div className="text-right mt-2">
                 {canEdit ? (
@@ -475,6 +478,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
               edges={questData.taskGraph}
               condensed
               showInspector={false}
+              boardId={`map-${quest.id}`}
             />
           </>
         );


### PR DESCRIPTION
## Summary
- prevent board context leakage by tagging posts with their boardId
- plumb boardId through post and layout components
- update quest card layouts to pass boardId

## Testing
- `npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom not found)*
- `npm --prefix ethos-backend test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68576ee111c8832f8d3d855d41495932