### PR TITLE
Handle request card tweaks

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -59,7 +59,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
         post={post}
         questId={questId}
         {...sharedProps}
-        headerOnly={headerOnly}
+        headerOnly={headerOnly || post.type === 'request'}
         boardId={boardId}
       />
     );

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -242,6 +242,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               replyOverride.onClick();
             } else if (post.type === 'commit') {
               navigate(ROUTES.POST(post.id));
+            } else if (post.type === 'request') {
+              navigate(ROUTES.POST(post.id) + '?reply=1');
             } else if (isTimelineBoard) {
               navigate(ROUTES.POST(post.id) + '?reply=1');
             } else {

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -153,7 +153,7 @@ const PostCard: React.FC<PostCardProps> = ({
     : 'Unknown time';
 
   const content = post.renderedContent || post.content;
-  const titleText = post.title || (post.type === 'task' ? post.content : '');
+  const titleText = post.title || makeHeader(post.content);
   let summaryTags = buildSummaryTags(post, questTitle, questId);
   if (isQuestBoardRequest) {
     const user = post.author?.username || post.authorId;
@@ -260,7 +260,10 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const renderLinkSummary = () => {
-    if (!showDetails && (!post.linkedItems || post.linkedItems.length === 0)) {
+    if (
+      post.type === 'request' ||
+      (!showDetails && (!post.linkedItems || post.linkedItems.length === 0))
+    ) {
       return null;
     }
     return (


### PR DESCRIPTION
## Summary
- show header on request posts even when title missing
- hide `Expand Details` on request posts
- open post detail on request reply button
- render requests using header-only view

## Testing
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685773154c44832fafd36c29f7dcbf4a