### PR TITLE
Add avatar stack and join toggle for request cards

### DIFF
--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import type { Post } from '../../types/postTypes';
-import { PostTypeBadge, Button } from '../ui';
+import { PostTypeBadge, Button, AvatarStack, SummaryTag } from '../ui';
+import { FaUserPlus, FaUserCheck } from 'react-icons/fa';
+import { useAuth } from '../../contexts/AuthContext';
+import { acceptRequest, unacceptRequest } from '../../api/post';
 import CreatePost from '../post/CreatePost';
 
 interface RequestCardProps {
@@ -11,25 +14,60 @@ interface RequestCardProps {
 
 const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) => {
   const [showReply, setShowReply] = useState(false);
-  const collaboratorCount = post.collaborators?.filter(c => c.userId).length || 0;
+  const { user } = useAuth();
+  const collaboratorUsers = (post as any).enrichedCollaborators || [];
+  const collaboratorCount = collaboratorUsers.filter((c: any) => c.userId).length || 0;
+  const [joining, setJoining] = useState(false);
+  const [joined, setJoined] = useState(
+    !!user && post.tags?.includes(`pending:${user.id}`)
+  );
+
+  const handleJoin = async () => {
+    if (!user) return;
+    try {
+      setJoining(true);
+      if (joined) {
+        const res = await unacceptRequest(post.id);
+        onUpdate?.(res.post);
+        setJoined(false);
+      } else {
+        const res = await acceptRequest(post.id);
+        onUpdate?.(res.post);
+        setJoined(true);
+      }
+    } catch (err) {
+      console.error('[RequestCard] Failed to join:', err);
+    } finally {
+      setJoining(false);
+    }
+  };
 
   return (
     <div className={"border border-secondary rounded bg-surface p-4 space-y-2 " + (className || '')}>
       <div className="flex items-center gap-2 text-sm text-secondary">
         <PostTypeBadge type="request" />
-        {post.questId && <PostTypeBadge type="quest" />}
+        {post.questId && (
+          <SummaryTag type="quest" label={post.questNodeTitle || post.questTitle || 'Quest'} />
+        )}
       </div>
       {post.title && <h3 className="font-semibold text-lg">{post.title}</h3>}
       {post.content && <p className="text-sm text-primary">{post.content}</p>}
-      <div className="text-xs text-secondary">
-        {collaboratorCount} collaborators approved
+      <div className="flex items-center gap-2 text-xs text-secondary">
+        <AvatarStack users={collaboratorUsers} />
+        <span>{collaboratorCount} collaborators</span>
       </div>
       <div className="flex gap-2">
         <Button variant="ghost" size="sm" onClick={() => setShowReply(r => !r)}>
           {showReply ? 'Cancel' : 'Reply'}
         </Button>
-        <Button variant="primary" size="sm">
-          {post.questId ? 'Join' : 'Apply'}
+        <Button variant="primary" size="sm" onClick={handleJoin} disabled={joining}>
+          {joining ? (
+            '...' 
+          ) : joined ? (
+            <><FaUserCheck className="inline mr-1" /> Joined</>
+          ) : (
+            <><FaUserPlus className="inline mr-1" /> {post.questId ? 'Join' : 'Apply'}</>
+          )}
         </Button>
       </div>
       {showReply && (

--- a/ethos-frontend/src/components/ui/AvatarStack.tsx
+++ b/ethos-frontend/src/components/ui/AvatarStack.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { FaUser } from 'react-icons/fa';
+
+export interface AvatarUser {
+  avatarUrl?: string;
+  username?: string;
+}
+
+interface AvatarStackProps {
+  users: AvatarUser[];
+  max?: number;
+}
+
+const AvatarStack: React.FC<AvatarStackProps> = ({ users, max = 3 }) => {
+  const displayed = users.slice(0, max);
+  const leftover = users.length - displayed.length;
+
+  return (
+    <div className="flex items-center">
+      <div className="flex -space-x-2">
+        {displayed.map((u, idx) => (
+          u.avatarUrl ? (
+            <img
+              key={idx}
+              src={u.avatarUrl}
+              alt={u.username || 'avatar'}
+              className="w-6 h-6 rounded-full border-2 border-surface"
+            />
+          ) : (
+            <div
+              key={idx}
+              className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center border-2 border-surface text-gray-600"
+            >
+              <FaUser className="w-3 h-3" />
+            </div>
+          )
+        ))}
+        {leftover > 0 && (
+          <div className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center border-2 border-surface text-xs text-primary">
+            +{leftover}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AvatarStack;

--- a/ethos-frontend/src/components/ui/index.tsx
+++ b/ethos-frontend/src/components/ui/index.tsx
@@ -16,3 +16,4 @@ export { default as Footer } from './Footer';
 export { default as Spinner } from './Spinner';
 export { default as MarkdownRenderer } from './MarkdownRenderer';
 export { default as MarkdownEditor } from './MarkdownEditor';
+export { default as AvatarStack } from './AvatarStack';


### PR DESCRIPTION
## Summary
- add `AvatarStack` UI component for overlapping profile icons
- update request card to use avatar stack and join/apply toggle button

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685773e3f2bc832fb20b43c6c412bc54