### PR TITLE
Add summary tag links

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -159,9 +159,7 @@ const PostCard: React.FC<PostCardProps> = ({
     const user = post.author?.username || post.authorId;
     summaryTags = [{ type: 'request', label: `Request: @${user}` }];
   }
-  const showAuthor =
-    !isQuestBoardRequest &&
-    !summaryTags.some(t => t.type === 'log' || t.type === 'free_speech');
+  const showAuthor = !isQuestBoardRequest;
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 
@@ -365,7 +363,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            {post.type !== 'log' && !isQuestBoardRequest && (
+            {!isQuestBoardRequest && (
               <PostTypeBadge
                 type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
               />
@@ -431,7 +429,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
-          {post.type !== 'log' && !isQuestBoardRequest && (
+          {!isQuestBoardRequest && (
             <PostTypeBadge
               type={['task', 'issue'].includes(post.type) ? 'log' : post.type}
             />

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -111,7 +111,11 @@ export const buildSummaryTags = (
       }
     } else {
       const user = post.author?.username || post.authorId;
-      tags.push({ type: 'request', label: `Request: @${user}` });
+      tags.push({
+        type: 'request',
+        label: `Request: @${user}`,
+        link: ROUTES.POST(post.id),
+      });
     }
     return tags;
   }
@@ -150,7 +154,11 @@ export const buildSummaryTags = (
 
   if (post.type === 'free_speech') {
     const user = post.author?.username || post.authorId;
-    tags.push({ type: 'free_speech', label: `Free Speech: @${user}` });
+    tags.push({
+      type: 'free_speech',
+      label: `Free Speech: @${user}`,
+      link: ROUTES.PUBLIC_PROFILE(post.authorId),
+    });
   }
 
   // Remove duplicate entries by label in case of redundant inputs


### PR DESCRIPTION
## Summary
- show author button and badges even when summary tag has user info
- link more summary tags to request post or user profile
- ensure free speech tags link to user profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685778400ad8832f9cfe282fbedd7dee