### PR TITLE
Add planner task type docs and dynamic tab labels

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -45,9 +45,11 @@ Boards may use a force-directed layout by setting their layout to `map-graph`. Q
 
 Tasks may optionally declare a `taskType`:
 
-- `file` – represents a single file in the repo
-- `folder` – groups subtasks and usually contains a main file
-- `abstract` – a generic task without a direct file mapping
+- `file` – represents a single file in the repo and unlocks line‑level editing and diff history.
+- `folder` – groups subtasks and shows a folder browser where you can create files or subfolders.
+- `planner` – a markdown document for jotting down notes or outlining sub‑tasks.
 
-The inspector sidebar lets you change the task type. Changing from `file` to `folder` automatically creates a file subtask and reassigns existing children to it. Converting a folder back to a file removes the intermediate node and promotes its children.
+The inspector sidebar lets you change the task type. Changing from `file` to `folder` automatically creates a file subtask and reassigns existing children to it. Converting a folder back to a file removes the intermediate node and promotes its children. When a node is set to **planner** the content field becomes a text editor for documentation.
+
+Tab labels reflect the selected type: selecting **file** shows a *File* tab, **folder** shows a *Folder* tab, and **planner** displays a *Planner* tab.
 

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -668,7 +668,7 @@ const PostCard: React.FC<PostCardProps> = ({
             onClick={() => setShowBrowser(true)}
             className="text-accent underline text-xs mt-1"
           >
-            View File/Folder
+            View {post.taskType === 'file' ? 'File' : post.taskType === 'folder' ? 'Folder' : 'Planner'}
           </button>
           {showBrowser && (
             <GitFileBrowser

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -53,7 +53,10 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   const tabs = [
     { value: 'status', label: 'Status' },
     ...(showLogs ? [{ value: 'logs', label: 'Logs' }] : []),
-    { value: 'file', label: 'File/Folder' },
+    {
+      value: 'file',
+      label: type === 'file' ? 'File' : type === 'folder' ? 'Folder' : 'Planner',
+    },
   ];
 
   const handleAddSubtask = () => {

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -46,7 +46,7 @@ export const STATUS_OPTIONS = [
 ] as const;
 
 export const TASK_TYPE_OPTIONS = [
-  { value: 'abstract', label: 'Abstract' },
+  { value: 'abstract', label: 'Planner' },
   { value: 'file', label: 'File' },
   { value: 'folder', label: 'Folder' },
 ] as const;


### PR DESCRIPTION
## Summary
- describe `planner` task type in quest-map docs
- rename "Abstract" select label to "Planner"
- show File/Folder/Planner label based on task type
- display dynamic label in PostCard file viewer button

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68577b7f8654832f95bf71f13c62bb7d