### PR TITLE
Improve quest card UI and status board

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -53,3 +53,9 @@ The inspector sidebar lets you change the task type. Changing from `file` to `fo
 
 Tab labels reflect the selected type: selecting **file** shows a *File* tab, **folder** shows a *Folder* tab, and **planner** displays a *Planner* tab.
 
+## Expanded Quest Card Layout
+
+When a quest card is expanded, the left side shows the status, log and file tabs while the right panel renders the quest map. The map defaults to the force‑directed graph but can switch to a folder layout when the selected task is a folder. Clicking nodes navigates between tasks and dragging allows attaching or detaching subtasks.
+
+The status board lists both issues and subtasks for the active node. Use the *All*, *Issues*, and *Tasks* buttons to filter the board.
+

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -45,14 +45,14 @@ const QuestCard: React.FC<QuestCardProps> = ({
   onCancel,
   defaultExpanded = false,
 }) => {
-  const [mapMode, setMapMode] = useState<'folder' | 'graph'>('folder');
+  const [mapMode, setMapMode] = useState<'folder' | 'graph'>('graph');
   const [activeTab, setActiveTab] = useState<'status' | 'logs' | 'file' | 'map' | 'files'>('status');
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [questData, setQuestData] = useState<Quest>(quest);
   const [logs, setLogs] = useState<Post[]>([]);
   const [selectedNode, setSelectedNode] = useState<Post | null>(null);
   const [rootNode, setRootNode] = useState<Post | null>(null);
-  const [leftWidth, setLeftWidth] = useState(240);
+  const [mapWidth, setMapWidth] = useState(240);
   const [showTaskForm, setShowTaskForm] = useState(false);
   const [showLogForm, setShowLogForm] = useState(false);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
@@ -111,10 +111,10 @@ const QuestCard: React.FC<QuestCardProps> = ({
 
   const handleDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     const startX = e.clientX;
-    const startWidth = leftWidth;
+    const startWidth = mapWidth;
     const onMove = (ev: MouseEvent) => {
       const newWidth = Math.min(400, Math.max(240, startWidth + ev.clientX - startX));
-      setLeftWidth(newWidth);
+      setMapWidth(newWidth);
     };
     const onUp = () => {
       document.removeEventListener('mousemove', onMove);
@@ -559,21 +559,21 @@ const QuestCard: React.FC<QuestCardProps> = ({
           <LinkViewer items={questData.linkedPosts} />
         )}
       </div>
-      {expanded && (
-        <div className="flex flex-col md:flex-row gap-4 max-h-[420px] overflow-y-auto">
-          <div
-            className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
-            style={{ width: leftWidth }}
-          >
-            {renderMap()}
+        {expanded && (
+          <div className="flex flex-col md:flex-row gap-4 max-h-[420px] overflow-y-auto">
+            <div className="flex-1 md:pr-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
+            <div
+              className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
+              onMouseDown={handleDividerMouseDown}
+            />
+            <div
+              className="overflow-auto md:pl-4 md:border-l md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
+              style={{ width: mapWidth }}
+            >
+              {renderMap()}
+            </div>
           </div>
-          <div
-            className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
-            onMouseDown={handleDividerMouseDown}
-          />
-          <div className="flex-1 md:pl-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
-        </div>
-      )}
+        )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- swap panels in `QuestCard` so the map appears on the right
- default map view to graph mode
- allow resizing the right map panel
- expand `StatusBoardPanel` to include tasks and filter buttons
- document the new expanded quest card layout

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm test --prefix ethos-backend` *(fails: supertest/bcryptjs missing)*

------
https://chatgpt.com/codex/tasks/task_e_68577fea9318832f8edf90089cd502a9