### PR TITLE
Update quest card layout and log functionality

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -55,7 +55,7 @@ Tab labels reflect the selected type: selecting **file** shows a *File* tab, **f
 
 ## Expanded Quest Card Layout
 
-When a quest card is expanded, the left side shows the status, log and file tabs while the right panel renders the quest map. The map defaults to the force‑directed graph but can switch to a folder layout when the selected task is a folder. Clicking nodes navigates between tasks and dragging allows attaching or detaching subtasks.
+When a quest card is expanded, the **left panel** renders the quest map while the **right side** displays the Status, Log and File tabs. The map defaults to the force‑directed graph but can switch to a folder layout when the selected task is a folder. Clicking nodes navigates between tasks and dragging allows attaching or detaching subtasks.
 
 The status board lists both issues and subtasks for the active node. Use the *All*, *Issues*, and *Tasks* buttons to filter the board.
 

--- a/ethos-frontend/src/components/quest/LogThreadPanel.tsx
+++ b/ethos-frontend/src/components/quest/LogThreadPanel.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '../ui';
 import { fetchPostsByQuestId } from '../../api/post';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
+import CreatePost from '../post/CreatePost';
 
 interface LogThreadPanelProps {
   questId: string;
@@ -17,10 +18,10 @@ const LogThreadPanel: React.FC<LogThreadPanelProps> = ({ questId, node, user, on
   const [entries, setEntries] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [showForm, setShowForm] = useState(false);
 
   const handleAddLog = () => {
-    // Placeholder handler for adding a log entry
-    console.log('Add log for node', node?.id);
+    setShowForm(true);
   };
 
   useEffect(() => {
@@ -50,6 +51,18 @@ const LogThreadPanel: React.FC<LogThreadPanelProps> = ({ questId, node, user, on
   if (entries.length === 0)
     return (
       <div className="space-y-2">
+        {showForm && (
+          <CreatePost
+            initialType="log"
+            questId={questId}
+            replyTo={node}
+            onSave={(p) => {
+              setEntries((prev) => [...prev, p]);
+              setShowForm(false);
+            }}
+            onCancel={() => setShowForm(false)}
+          />
+        )}
         <div className="text-right">
           <button onClick={handleAddLog} className="text-xs text-accent underline">
             + Add Log
@@ -61,6 +74,18 @@ const LogThreadPanel: React.FC<LogThreadPanelProps> = ({ questId, node, user, on
 
   return (
     <div className="space-y-2">
+      {showForm && (
+        <CreatePost
+          initialType="log"
+          questId={questId}
+          replyTo={node}
+          onSave={(p) => {
+            setEntries((prev) => [...prev, p]);
+            setShowForm(false);
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
       <div className="text-right">
         <button onClick={handleAddLog} className="text-xs text-accent underline">
           + Add Log

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -561,17 +561,17 @@ const QuestCard: React.FC<QuestCardProps> = ({
       </div>
         {expanded && (
           <div className="flex flex-col md:flex-row gap-4 max-h-[420px] overflow-y-auto">
-            <div className="flex-1 md:pr-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
             <div
-              className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
-              onMouseDown={handleDividerMouseDown}
-            />
-            <div
-              className="overflow-auto md:pl-4 md:border-l md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
+              className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
               style={{ width: mapWidth }}
             >
               {renderMap()}
             </div>
+            <div
+              className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
+              onMouseDown={handleDividerMouseDown}
+            />
+            <div className="flex-1 md:pl-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
           </div>
         )}
     </div>


### PR DESCRIPTION
## Summary
- swap expanded quest card panels so the map is on the left
- document the new panel order in `quest-map.md`
- allow creating log entries in `LogThreadPanel`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest' from tests)*

------
https://chatgpt.com/codex/tasks/task_e_68578a733ec0832faadf748c69a351d7