### PR TITLE
Fix manual swipe scaling on ActiveQuestBoard

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -121,7 +121,7 @@ const ActiveQuestBoard: React.FC = () => {
     return () => {
       el.removeEventListener('scroll', handleScroll);
     };
-  }, []);
+  }, [quests]);
 
   const handleCreateSave = (quest: Quest) => {
     setQuests(q => [quest, ...q]);


### PR DESCRIPTION
## Summary
- update ActiveQuestBoard's scroll listener to attach after quests load so manual swipes update the active index

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68578baa50d0832fbf6e96e030da44e6