### PR TITLE
Remove expanded quest card details

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -53,9 +53,4 @@ The inspector sidebar lets you change the task type. Changing from `file` to `fo
 
 Tab labels reflect the selected type: selecting **file** shows a *File* tab, **folder** shows a *Folder* tab, and **planner** displays a *Planner* tab.
 
-## Expanded Quest Card Layout
-
-When a quest card is expanded, the **left panel** renders the quest map while the **right side** displays the Status, Log and File tabs. The map defaults to the force‑directed graph but can switch to a folder layout when the selected task is a folder. Clicking nodes navigates between tasks and dragging allows attaching or detaching subtasks.
-
-The status board lists both issues and subtasks for the active node. Use the *All*, *Issues*, and *Tasks* buttons to filter the board.
 


### PR DESCRIPTION
## Summary
- remove the "Expanded Quest Card Layout" section from quest map docs

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68578bc47e8c832f8f71bf9d91facf29