### PR TITLE
Swap expanded quest panel layout

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -561,17 +561,19 @@ const QuestCard: React.FC<QuestCardProps> = ({
       </div>
         {expanded && (
           <div className="flex flex-col md:flex-row gap-4 max-h-[420px] overflow-y-auto">
-            <div
-              className="overflow-auto md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 max-h-[420px]"
-              style={{ width: mapWidth }}
-            >
-              {renderMap()}
+            <div className="flex-1 md:pr-4 md:border-r md:border-gray-300 dark:md:border-gray-700 overflow-auto max-h-[420px]">
+              {renderRightPanel()}
             </div>
             <div
               className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize"
               onMouseDown={handleDividerMouseDown}
             />
-            <div className="flex-1 md:pl-4 overflow-auto max-h-[420px]">{renderRightPanel()}</div>
+            <div
+              className="overflow-auto md:pl-4 max-h-[420px]"
+              style={{ width: mapWidth }}
+            >
+              {renderMap()}
+            </div>
           </div>
         )}
     </div>


### PR DESCRIPTION
## Summary
- flip layout so the right panel appears on the left when a quest is expanded

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68578bf1f83c832fb9e6491fb4985174