### PR TITLE
Remove Expand Details from QuestCard

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -11,7 +11,6 @@ import MapGraphLayout from '../layout/MapGraphLayout';
 import CreatePost from '../post/CreatePost';
 import { fetchQuestById, updateQuestById } from '../../api/quest';
 import { fetchPostsByQuestId } from '../../api/post';
-import LinkViewer from '../ui/LinkViewer';
 import LinkControls from '../controls/LinkControls';
 import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowser from '../git/GitFileBrowser';
@@ -554,9 +553,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
               </button>
             </div>
           </div>
-        )}
-        {questData.linkedPosts && questData.linkedPosts.length > 0 && (
-          <LinkViewer items={questData.linkedPosts} />
         )}
       </div>
         {expanded && (


### PR DESCRIPTION
## Summary
- remove `LinkViewer` import and usage from `QuestCard`

## Testing
- `npm run lint --prefix ethos-frontend` *(fails: 3 errors)*
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_68578e6224dc832fb503631383205498