### PR TITLE
Adjust board background

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -283,8 +283,8 @@ const Board: React.FC<BoardProps> = ({
     return <div className="text-error p-4">Board not found.</div>;
   }
 
-  const containerBg = 'bg-accent-muted';
-  const panelBg = 'bg-accent-muted';
+  const containerBg = 'bg-board-bg';
+  const panelBg = 'bg-board-bg';
 
   return (
     <div className={`space-y-4 p-6 rounded-xl shadow-lg max-w-5xl mx-auto ${containerBg}`}>

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -24,6 +24,7 @@
   --color-background: #f9fafb;
   --color-surface: #ffffff;
   --color-accent-muted: #f0f0f0;
+  --color-board-bg: #f3f4f6;
   --info-background: #bfdbfe;
   --bg-soft: var(--color-soft);
   --bg-soft-dark: #1f2937;
@@ -49,6 +50,7 @@
   --color-background: #1f2937;
   --color-surface: #374151;
   --color-accent-muted: #323c4e;
+  --color-board-bg: #324a38;
   --info-background: #1e40af;
   --bg-soft: var(--color-soft-dark);
   --bg-soft-dark: var(--color-soft-dark);

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -122,7 +122,7 @@ const BoardPage: React.FC = () => {
   const isTimeline = boardData.id === 'timeline-board';
 
   return (
-    <main className="max-w-7xl mx-auto p-4 space-y-8 bg-accent-muted">
+    <main className="max-w-7xl mx-auto p-4 space-y-8 bg-board-bg">
       <div className="flex flex-col md:flex-row gap-6">
         {!isTimeline && (
           <BoardSearchFilter
@@ -132,7 +132,7 @@ const BoardPage: React.FC = () => {
           />
         )}
         <div className="flex-1">
-          <div className="bg-accent-muted rounded-xl shadow-lg p-6 space-y-6">
+          <div className="bg-board-bg rounded-xl shadow-lg p-6 space-y-6">
             <div className="flex justify-between items-center">
               <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
               {editable && (

--- a/ethos-frontend/src/theme.ts
+++ b/ethos-frontend/src/theme.ts
@@ -14,6 +14,7 @@ export const colors: Record<string, Palette> = {
   background: { light: '#f9fafb', dark: '#1f2937' },
   surface: { light: '#ffffff', dark: '#374151' },
   accentMuted: { light: '#f0f0f0', dark: '#323c4e' },
+  boardBg: { light: '#f3f4f6', dark: '#324a38' },
   infoBackground: { light: '#bfdbfe', dark: '#1e40af' },
 };
 

--- a/ethos-frontend/tailwind.config.cjs
+++ b/ethos-frontend/tailwind.config.cjs
@@ -23,6 +23,7 @@ module.exports = {
           background: 'var(--color-background)',
           surface: 'var(--color-surface)',
           'accent-muted': 'var(--color-accent-muted)',
+          'board-bg': 'var(--color-board-bg)',
           'info-background': 'var(--info-background)',
         },
         borderRadius: {


### PR DESCRIPTION
## Summary
- adjust board color variables for light and dark theme
- add board color config to tailwind
- update board components to use the new color

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578efece14832f9928f4f5a81e7156