### PR TITLE
Implement title casing

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { fetchBoard, fetchBoardItems } from '../../api/board';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSocketListener } from '../../hooks/useSocket';
-import { getDisplayTitle } from '../../utils/displayUtils';
+import { getDisplayTitle, toTitleCase } from '../../utils/displayUtils';
 import { getRenderableBoardItems } from '../../utils/boardUtils';
 import { useBoardContext } from '../../contexts/BoardContext';
 import type { BoardItem } from '../../contexts/BoardContextTypes';
@@ -291,7 +291,7 @@ const Board: React.FC<BoardProps> = ({
       {/* Board Header */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <h2 className="text-xl font-semibold text-primary dark:text-primary">
-          {forcedTitle || board.title || 'Board'}
+          {toTitleCase(forcedTitle || board.title || 'Board')}
         </h2>
 
         <div className="flex gap-2 flex-wrap items-center">

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Spinner } from '../ui';
 import Select from '../ui/Select';
 import { addQuest, fetchAllQuests } from '../../api/quest';
+import { toTitleCase } from '../../utils/displayUtils';
 import { fetchAllPosts } from '../../api/post';
 import type { LinkedItem, Post } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
@@ -142,7 +143,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
     ...(itemTypes.includes('quest')
       ? quests.map((q) => ({
           value: `quest:${q.id}`,
-          label: `🧭 Quest: ${q.title}`,
+          label: `🧭 Quest: ${toTitleCase(q.title)}`,
           nodeId: q.title,
           type: 'quest',
         }))

--- a/ethos-frontend/src/components/mod/ModReviewPanel.tsx
+++ b/ethos-frontend/src/components/mod/ModReviewPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { Quest } from '../../types/questTypes';
 import { moderateQuest } from '../../api/quest';
 import { Select, Button } from '../ui';
+import { toTitleCase } from '../../utils/displayUtils';
 
 interface ModReviewPanelProps {
   quest: Quest;
@@ -39,7 +40,7 @@ const ModReviewPanel: React.FC<ModReviewPanelProps> = ({ quest, onUpdated }) => 
 
   return (
     <div className="space-y-2 border p-3 rounded bg-surface dark:bg-background">
-      <div className="font-semibold">{quest.title}</div>
+      <div className="font-semibold">{toTitleCase(quest.title)}</div>
       <div className="flex gap-2">
         <Select value={visibility} onChange={e => setVisibility(e.target.value as Quest['visibility'])} options={visibilityOptions} />
         <Select value={approval} onChange={e => setApproval(e.target.value as Quest['approvalStatus'])} options={approvalOptions} />

--- a/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestBoard.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import type { Quest } from '../../types/questTypes';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
+import { toTitleCase } from '../../utils/displayUtils';
 import { Spinner } from '../ui';
 
 interface QuestWithScore extends Quest {
@@ -84,7 +85,7 @@ const FeaturedQuestBoard: React.FC = () => {
             >
               <div className="p-4 border rounded bg-surface dark:bg-background w-full">
                 <Link to={ROUTES.QUEST(q.id)} className="font-semibold text-blue-600 underline">
-                  {q.title}
+                  {toTitleCase(q.title)}
                 </Link>
                 {typeof q.popularity === 'number' && (
                   <div className="text-sm text-secondary mt-1">Score: {q.popularity}</div>

--- a/ethos-frontend/src/components/quest/FeaturedQuestsBanner.tsx
+++ b/ethos-frontend/src/components/quest/FeaturedQuestsBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import type { Quest } from '../../types/questTypes';
+import { toTitleCase } from '../../utils/displayUtils';
 
 interface FeaturedQuestsBannerProps {
   /** Array of public quest objects */
@@ -32,7 +33,7 @@ const FeaturedQuestsBanner: React.FC<FeaturedQuestsBannerProps> = ({ quests }) =
             className="block hover:shadow-lg transition-shadow"
           >
             <div className="h-full border border-secondary rounded-md bg-surface dark:bg-background p-4 flex flex-col">
-              <h3 className="font-semibold text-primary text-lg mb-1">{q.title}</h3>
+              <h3 className="font-semibold text-primary text-lg mb-1">{toTitleCase(q.title)}</h3>
               <div className="text-sm text-secondary mb-2">@{q.authorId}</div>
               <span className="text-xs font-medium text-secondary mb-2">
                 {statusLabel(q)}

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -4,7 +4,7 @@ import type { Quest } from '../../types/questTypes';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import { Button, SummaryTag } from '../ui';
-import { POST_TYPE_LABELS } from '../../utils/displayUtils';
+import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
 import { ROUTES } from '../../constants/routes';
 import GraphLayout from '../layout/GraphLayout';
 import GridLayout from '../layout/GridLayout';
@@ -173,7 +173,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             to={ROUTES.QUEST(quest.id)}
             className="text-xl font-bold text-primary underline"
           >
-            {questData.title}
+            {toTitleCase(questData.title)}
           </Link>
         </div>
         <div className="flex items-center gap-2 text-sm text-secondary">

--- a/ethos-frontend/src/components/quest/QuestSummaryCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestSummaryCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
+import { toTitleCase } from '../../utils/displayUtils';
 import type { Quest } from '../../types/questTypes';
 import Button from '../ui/Button';
 
@@ -22,7 +23,7 @@ const QuestSummaryCard: React.FC<QuestSummaryCardProps> = ({ quest }) => {
 
   return (
     <div className="border border-secondary rounded bg-surface p-4 space-y-2 shadow">
-      <h3 className="text-lg font-bold text-primary">{quest.title}</h3>
+      <h3 className="text-lg font-bold text-primary">{toTitleCase(quest.title)}</h3>
       {shortDesc && <p className="text-sm text-secondary">{shortDesc}</p>}
       <div className="text-xs text-secondary space-y-0.5">
         <div>Rank: {rank}</div>

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Post } from '../../types/postTypes';
 import { Button, AvatarStack, SummaryTag } from '../ui';
-import { POST_TYPE_LABELS } from '../../utils/displayUtils';
+import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
 import { FaUserPlus, FaUserCheck } from 'react-icons/fa';
 import { useAuth } from '../../contexts/AuthContext';
 import { acceptRequest, unacceptRequest } from '../../api/post';
@@ -51,7 +51,9 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
           <SummaryTag type="quest" label={post.questNodeTitle || post.questTitle || 'Quest'} />
         )}
       </div>
-      {post.title && <h3 className="font-semibold text-lg">{post.title}</h3>}
+      {post.title && (
+        <h3 className="font-semibold text-lg">{toTitleCase(post.title)}</h3>
+      )}
       {post.content && <p className="text-sm text-primary">{post.content}</p>}
       <div className="flex items-center gap-2 text-xs text-secondary">
         <AvatarStack users={collaboratorUsers} />

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -10,6 +10,7 @@ import { usePermissions } from '../../hooks/usePermissions';
 import Board from '../../components/board/Board';
 import BoardSearchFilter from '../../components/board/BoardSearchFilter';
 import { Spinner } from '../../components/ui';
+import { toTitleCase } from '../../utils/displayUtils';
 
 import { fetchQuestById } from '../../api/quest';
 
@@ -134,7 +135,7 @@ const BoardPage: React.FC = () => {
         <div className="flex-1">
           <div className="bg-board-bg rounded-xl shadow-lg p-6 space-y-6">
             <div className="flex justify-between items-center">
-              <h1 className="text-3xl font-bold text-primary dark:text-primary">{boardData.title}</h1>
+              <h1 className="text-3xl font-bold text-primary dark:text-primary">{toTitleCase(boardData.title)}</h1>
               {editable && (
                 <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
                   Edit Board

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -1,6 +1,9 @@
 import type { Post, PostType } from '../types/postTypes';
 import { ROUTES } from '../constants/routes';
 
+export const toTitleCase = (str: string): string =>
+  str.replace(/\b([a-z])/g, (c) => c.toUpperCase());
+
 export const POST_TYPE_LABELS: Record<PostType, string> = {
   free_speech: 'Free Speech',
   request: 'Request',
@@ -68,7 +71,8 @@ export const getDisplayTitle = (post: Post): string => {
   }
 
   const content = post.content?.trim() || '';
-  return content.length > 50 ? content.slice(0, 50) + '…' : content;
+  const text = content.length > 50 ? content.slice(0, 50) + '…' : content;
+  return toTitleCase(text);
 };
 
 export interface SummaryTagData {


### PR DESCRIPTION
## Summary
- add `toTitleCase` helper
- use new helper across UI components to display capitalized titles

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest' and 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68579488374c832fa4c757a0034dfa65