### PR TITLE
Improve summary tag links

### DIFF
--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -37,6 +37,12 @@ export interface SummaryTagData {
   type: SummaryTagType;
   label: string;
   link?: string;
+  /** Optional username displayed after the label */
+  username?: string;
+  /** Link for the username, typically the user profile */
+  usernameLink?: string;
+  /** Separate link for the label itself (e.g. post detail page) */
+  detailLink?: string;
 }
 
 const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> = {
@@ -74,15 +80,37 @@ const colors: Record<SummaryTagType, string> = {
 };
 
 
-const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({ type, label, link, className }) => {
+const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
+  type,
+  label,
+  link,
+  className,
+  username,
+  usernameLink,
+  detailLink,
+}) => {
   const Icon = icons[type] || FaStickyNote;
   const colorClass = colors[type] || colors.type;
+
+  if (username && usernameLink && detailLink) {
+    return (
+      <span className={clsx(TAG_BASE, colorClass, className)}>
+        <Icon className="w-3 h-3" />
+        <Link to={detailLink} className="underline">
+          {label}
+        </Link>{' '}
+        <Link to={usernameLink}>@{username}</Link>
+      </span>
+    );
+  }
+
   const content = (
     <>
       <Icon className="w-3 h-3" />
       {label}
     </>
   );
+
   if (link) {
     return (
       <Link to={link} className={clsx(TAG_BASE, colorClass, className)}>
@@ -90,6 +118,7 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({ type, l
       </Link>
     );
   }
+
   return <span className={clsx(TAG_BASE, colorClass, className)}>{content}</span>;
 };
 

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -88,6 +88,9 @@ export interface SummaryTagData {
     | 'solved';
   label: string;
   link?: string;
+  username?: string;
+  usernameLink?: string;
+  detailLink?: string;
 }
 
 /**
@@ -132,8 +135,10 @@ export const buildSummaryTags = (
       const user = post.author?.username || post.authorId;
       tags.push({
         type: 'request',
-        label: `Request: @${user}`,
-        link: ROUTES.POST(post.id),
+        label: 'Request:',
+        detailLink: ROUTES.POST(post.id),
+        username: user,
+        usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
       });
     }
     return tags;
@@ -152,8 +157,10 @@ export const buildSummaryTags = (
     // Link log tags to the author's public profile for quick context
     tags.push({
       type: 'log',
-      label: `Log: @${user}`,
-      link: ROUTES.PUBLIC_PROFILE(post.authorId)
+      label: 'Log:',
+      detailLink: ROUTES.POST(post.id),
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
   } else if (post.type === 'commit') {
     tags.push({ type: 'commit', label: 'Commit' });
@@ -170,8 +177,10 @@ export const buildSummaryTags = (
     const user = post.author?.username || post.authorId;
     tags.push({
       type: 'log',
-      label: `Log: @${user}`,
-      link: ROUTES.PUBLIC_PROFILE(post.authorId)
+      label: 'Log:',
+      detailLink: ROUTES.POST(post.id),
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
   }
 


### PR DESCRIPTION
## Summary
- update `SummaryTag` to support detail and profile links
- allow `buildSummaryTags` to provide separate links for user profile and post details

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_685795460dd8832fbcf3511ed70a40f3