### PR TITLE
Add user search endpoint and UI autocomplete

### DIFF
--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -4,6 +4,20 @@ import { usersStore } from '../models/stores';
 
 const router = express.Router();
 
+// GET /api/users?search= - search by username
+router.get('/', authOptional, (
+  req: Request<{}, any, any, { search?: string }>,
+  res: Response
+): void => {
+  const { search } = req.query;
+  let users = usersStore.read().map(u => ({ id: u.id, username: u.username }));
+  if (search) {
+    const term = search.toLowerCase();
+    users = users.filter(u => u.username.toLowerCase().includes(term));
+  }
+  res.json(users);
+});
+
 // GET /api/users/:id - fetch public profile
 router.get('/:id', authOptional, (req: Request<{ id: string }>, res: Response): void => {
   const user = usersStore.read().find(u => u.id === req.params.id);

--- a/ethos-frontend/src/api/auth.ts
+++ b/ethos-frontend/src/api/auth.ts
@@ -126,3 +126,19 @@ export const fetchUserById = async (userId: string): Promise<User> => {
   const res = await axiosWithAuth.get(`/users/${userId}`);
   return res.data;
 };
+
+/**
+ * @function searchUsers
+ * 🔍 Fetch users matching the query string
+ * @param query - Username search term
+ * @returns Array of minimal user records
+ */
+export const searchUsers = async (
+  query: string
+): Promise<{ id: string; username: string }[]> => {
+  const params = new URLSearchParams();
+  if (query) params.set('search', query);
+  const url = `/users${params.toString() ? `?${params.toString()}` : ''}`;
+  const res = await axiosWithAuth.get(url);
+  return res.data;
+};

--- a/ethos-frontend/src/components/controls/CollaberatorControls.tsx
+++ b/ethos-frontend/src/components/controls/CollaberatorControls.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { CollaberatorRoles } from '../../types/postTypes';
+import { searchUsers } from '../../api/auth';
 
 const ALL_ROLES = [
   'Leader',
@@ -21,17 +22,37 @@ type Props = {
 
 const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
   const [username, setUsername] = useState('');
+  const [selectedUser, setSelectedUser] = useState<{ id: string; username: string } | null>(null);
+  const [suggestions, setSuggestions] = useState<{ id: string; username: string }[]>([]);
   const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (username.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    const t = setTimeout(() => {
+      searchUsers(username.trim())
+        .then(setSuggestions)
+        .catch(() => setSuggestions([]));
+    }, 300);
+    return () => clearTimeout(t);
+  }, [username]);
 
   const addCollaborator = () => {
     if (!username.trim()) return;
+    const id =
+      selectedUser?.id ||
+      suggestions.find(s => s.username === username)?.id ||
+      crypto.randomUUID();
     const newCollaborator: CollaberatorRoles = {
-      userId: crypto.randomUUID(),
+      userId: id,
       username,
       roles: selectedRoles,
     };
     onChange([...value, newCollaborator]);
     setUsername('');
+    setSelectedUser(null);
     setSelectedRoles([]);
   };
 
@@ -54,13 +75,35 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
             Collaborator Username
           </label>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            className="w-full px-3 py-2 border rounded-md text-sm"
-            placeholder="e.g. alice, bob123"
-          />
+          <div className="relative">
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => {
+                setUsername(e.target.value);
+                setSelectedUser(null);
+              }}
+              className="w-full px-3 py-2 border rounded-md text-sm"
+              placeholder="e.g. alice, bob123"
+            />
+            {suggestions.length > 0 && (
+              <ul className="absolute z-10 mt-1 bg-surface border border-secondary rounded shadow w-full text-sm max-h-40 overflow-y-auto">
+                {suggestions.map((u) => (
+                  <li
+                    key={u.id}
+                    className="px-2 py-1 cursor-pointer hover:bg-background"
+                    onClick={() => {
+                      setUsername(u.username);
+                      setSelectedUser(u);
+                      setSuggestions([]);
+                    }}
+                  >
+                    @{u.username}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- add `/api/users?search=` query endpoint
- expose `searchUsers` in frontend API
- enhance `CollaberatorControls` with live username suggestions

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685797c4756c832f87277bbfebe92552