### PR TITLE
Enable open collaborator roles

### DIFF
--- a/ethos-frontend/src/components/controls/CollaberatorControls.tsx
+++ b/ethos-frontend/src/components/controls/CollaberatorControls.tsx
@@ -24,12 +24,16 @@ const CollaberatorControls: React.FC<Props> = ({ value, onChange }) => {
   const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
 
   const addCollaborator = () => {
-    if (!username.trim()) return;
-    const newCollaborator: CollaberatorRoles = {
-      userId: crypto.randomUUID(),
-      username,
-      roles: selectedRoles,
-    };
+    const trimmed = username.trim();
+    const newCollaborator: CollaberatorRoles = trimmed
+      ? {
+          userId: crypto.randomUUID(),
+          username: trimmed,
+          roles: selectedRoles,
+        }
+      : {
+          roles: selectedRoles,
+        };
     onChange([...value, newCollaborator]);
     setUsername('');
     setSelectedRoles([]);

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -91,8 +91,13 @@ export interface EnrichedPost extends Post {
  * Users associated with a post.
  */
 export interface CollaberatorRoles {
-  userId: string;
+  /** Optional user id when this role is filled by a user */
+  userId?: string;
   username?: string;
+  /**
+   * When `userId` is omitted this represents an open role
+   * available for anyone to claim.
+   */
   roles?: string[];
 }
 


### PR DESCRIPTION
## Summary
- allow adding collaborators without usernames
- document optional `userId` for `CollaberatorRoles`

## Testing
- `npm test` (frontend, fails: PostListItem.test.tsx)
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_685797c3cd50832fa40ce7ffe9e09cf5