### PR TITLE
Add team board route and collaborator avatars

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -28,6 +28,7 @@ const Quest = lazy(() => import('./pages/quest/[id]'));
 const Post = lazy(() => import('./pages/post/[id]'));
 const Board = lazy(() => import('./pages/board/[id]'));
 const BoardType = lazy(() => import('./pages/board/[boardType]'));
+const TeamBoard = lazy(() => import('./pages/board/team-[questId]'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
@@ -75,6 +76,7 @@ const App: React.FC = () => {
                     <Route path={ROUTES.POST()} element={<Post />} />
                     <Route path="/board/quests" element={<Navigate to={ROUTES.BOARD('quest-board')} replace />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />
+                    <Route path={ROUTES.TEAM_BOARD()} element={<TeamBoard />} />
                     <Route path={ROUTES.BOARD_TYPE()} element={<BoardType />} />
                     <Route path={ROUTES.FLAGGED_QUESTS} element={<FlaggedQuests />} />
                     <Route path={ROUTES.BANNED_QUESTS} element={<BannedQuests />} />

--- a/ethos-frontend/src/components/quest/TeamPanel.tsx
+++ b/ethos-frontend/src/components/quest/TeamPanel.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import CollaberatorControls from '../controls/CollaberatorControls';
 import { updateQuestById, fetchQuestById } from '../../api/quest';
 import { updatePost } from '../../api/post';
+import { AvatarStack } from '../ui';
+import { ROUTES } from '../../constants/routes';
 import type { CollaberatorRoles, Post } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
 
@@ -45,6 +48,21 @@ const TeamPanel: React.FC<TeamPanelProps> = ({ questId, node }) => {
 
   return (
     <div className="space-y-2">
+      {quest && (
+        <div className="flex items-center justify-between">
+          <AvatarStack
+            users={(quest.collaborators || [])
+              .filter(c => c.userId)
+              .map(c => ({ avatarUrl: (c as any).avatarUrl, username: c.username }))}
+          />
+          <Link
+            to={ROUTES.TEAM_BOARD(quest.id)}
+            className="text-xs text-blue-600 underline"
+          >
+            View All
+          </Link>
+        </div>
+      )}
       <CollaberatorControls value={roles} onChange={setRoles} />
       <button
         onClick={handleSave}

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -59,6 +59,13 @@ export const ROUTES = {
     BOARD: (id = ':id') => `/boards/${id}`,
 
     /**
+     * Quest team page listing collaborators
+     * @param questId - Quest ID
+     * @returns Route like `/board/team-abc123`
+     */
+    TEAM_BOARD: (questId = ':questId') => `/board/team-${questId}`,
+
+    /**
      * Listing page for a board type
      * @param boardType - board category
      * @returns A route string like `/board/quests`

--- a/ethos-frontend/src/pages/board/team-[questId].tsx
+++ b/ethos-frontend/src/pages/board/team-[questId].tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchQuestById } from '../../api/quest';
+import { fetchUserById } from '../../api/auth';
+import { Spinner, AvatarStack } from '../../components/ui';
+
+interface Collaborator {
+  userId: string;
+  username?: string;
+  roles?: string[];
+  avatarUrl?: string;
+}
+
+const TeamBoardPage: React.FC = () => {
+  const { questId } = useParams<{ questId: string }>();
+  const [loading, setLoading] = useState(true);
+  const [title, setTitle] = useState('');
+  const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
+
+  useEffect(() => {
+    if (!questId) return;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const quest = await fetchQuestById(questId);
+        setTitle(quest.title);
+        const filled = (quest.collaborators || []).filter(c => c.userId);
+        const enriched: Collaborator[] = await Promise.all(
+          filled.map(async c => {
+            try {
+              const u = await fetchUserById(c.userId!);
+              return { ...c, username: u.username || c.username, avatarUrl: u.avatarUrl };
+            } catch {
+              return { ...c };
+            }
+          })
+        );
+        setCollaborators(enriched);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [questId]);
+
+  if (loading) return <Spinner />;
+
+  return (
+    <main className="max-w-4xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Team for {title}</h1>
+      {collaborators.length === 0 ? (
+        <p className="text-secondary">No collaborators yet.</p>
+      ) : (
+        <ul className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+          {collaborators.map((c) => (
+            <li key={c.userId} className="border rounded-lg p-4 bg-surface space-y-2">
+              <AvatarStack users={[{ avatarUrl: c.avatarUrl, username: c.username }]} max={1} />
+              <div className="text-sm font-semibold">@{c.username || c.userId}</div>
+              {c.roles && c.roles.length > 0 && (
+                <div className="text-xs text-secondary">Roles: {c.roles.join(', ')}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+};
+
+export default TeamBoardPage;


### PR DESCRIPTION
## Summary
- show current collaborators in `TeamPanel` via `AvatarStack`
- add link to a new team board page
- add constant and route for quest team board
- implement `TeamBoardPage` to display collaborator profiles

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_685797c7b264832f8eef7036911e1a26