### PR TITLE
Add sub-request posts for task help requests

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -205,8 +205,10 @@ export interface CollaberatorRoles {
   /**
    * Roles requested or assigned. When `userId` is omitted this
    * represents an open role that any user may request to fill.
-   */
+  */
   roles?: string[];
+  /** List of userIds that have applied for this role */
+  pending?: string[];
 }
 
 // types/api.ts

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -39,7 +39,7 @@ export interface DBPost {
   status?: QuestTaskStatus;
   /** Optional classification for task posts */
   taskType?: 'file' | 'folder' | 'abstract';
-  collaborators?: { userId: string; roles?: string[] }[];
+  collaborators?: { userId?: string; roles?: string[]; pending?: string[] }[];
   linkedItems?: LinkedItem[];
 
   systemGenerated?: boolean;
@@ -77,7 +77,7 @@ export interface DBQuest {
 
   headPostId: string;
   linkedPosts: LinkedItem[];
-  collaborators: { userId?: string; roles?: string[] }[];
+  collaborators: { userId?: string; roles?: string[]; pending?: string[] }[];
 
   gitRepo?: {
     repoId: string;

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -225,8 +225,20 @@ export const solvePost = async (postId: string): Promise<{ success: boolean }> =
 /**
  * 🤝 Request help for any post
  */
-export const requestHelp = async (postId: string): Promise<Post> => {
-  const res = await axiosWithAuth.post(`/posts/${postId}/request-help`);
+export interface RequestHelpResult {
+  request: Post;
+  subRequests: Post[];
+}
+
+export const requestHelp = async (
+  postId: string,
+  type?: string
+): Promise<RequestHelpResult> => {
+  const url =
+    type === 'task'
+      ? `/posts/tasks/${postId}/request-help`
+      : `/posts/${postId}/request-help`;
+  const res = await axiosWithAuth.post(url);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -151,10 +151,19 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     if (!user?.id) return;
     if (!helpRequested) {
       try {
-        const reqPost = await requestHelp(post.id);
+        const { request: reqPost, subRequests } = await requestHelp(
+          post.id,
+          post.type
+        );
         appendToBoard?.('quest-board', reqPost);
         appendToBoard?.('timeline-board', reqPost);
+        subRequests.forEach(sr => {
+          appendToBoard?.('quest-board', sr);
+          appendToBoard?.('timeline-board', sr);
+          onUpdate?.(sr);
+        });
         setHelpRequested(true);
+        onUpdate?.(reqPost);
       } catch (err) {
         console.error('[ReactionControls] Failed to request help:', err);
       }

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -91,9 +91,10 @@ export interface EnrichedPost extends Post {
  * Users associated with a post.
  */
 export interface CollaberatorRoles {
-  userId: string;
+  userId?: string;
   username?: string;
   roles?: string[];
+  pending?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- create sub-request posts for open roles when requesting help from tasks
- return new response shape from request-help endpoints
- track pending collaborators
- adapt requestHelp API and ReactionControls for new structure
- update tests for new behavior

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_685797c64710832f80f8b8d586b6f692