### PR TITLE
Add toggles for board create buttons

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -383,8 +383,21 @@ const Board: React.FC<BoardProps> = ({
             </Button>
           )}
           {showCreate && user && (
-            <Button variant="contrast" onClick={() => setShowCreateForm(true)}>
-              {board?.id === 'quest-board' ? '+ Add Request' : '+ Add Item'}
+            <Button
+              variant="contrast"
+              onClick={() => setShowCreateForm((p) => !p)}
+            >
+              {showCreateForm
+                ? board?.boardType === 'quest'
+                  ? '- Cancel Quest'
+                  : board?.id === 'quest-board'
+                  ? '- Cancel Request'
+                  : '- Cancel Item'
+                : board?.boardType === 'quest'
+                ? '+ Add Quest'
+                : board?.id === 'quest-board'
+                ? '+ Add Request'
+                : '+ Add Item'}
             </Button>
           )}
           {editable && (

--- a/ethos-frontend/src/components/feed/TimelineFeed.tsx
+++ b/ethos-frontend/src/components/feed/TimelineFeed.tsx
@@ -75,8 +75,8 @@ const TimelineFeed: React.FC<TimelineFeedProps> = ({ boardId = 'timeline-board' 
         />
       )}
       <div className="text-right">
-        <Button variant="contrast" onClick={() => setShowForm(true)}>
-          + Add Post
+        <Button variant="contrast" onClick={() => setShowForm((p) => !p)}>
+          {showForm ? '- Cancel Post' : '+ Add Post'}
         </Button>
       </div>
       <div className="grid gap-4 overflow-auto max-h-[65vh] snap-y snap-mandatory p-2">

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -148,8 +148,12 @@ const ActiveQuestBoard: React.FC = () => {
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-semibold">🧭 Active Quests</h2>
         {user && (
-          <Button variant="contrast" size="sm" onClick={() => setShowCreate(true)}>
-            + Add Quest
+          <Button
+            variant="contrast"
+            size="sm"
+            onClick={() => setShowCreate((p) => !p)}
+          >
+            {showCreate ? '- Cancel Quest' : '+ Add Quest'}
           </Button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- toggle create forms on boards, active quests, and timeline feed
- update button text between `+ Add` and `- Cancel`

## Testing
- `npm test` *(fails: Unable to find element with the text /hello world/)*

------
https://chatgpt.com/codex/tasks/task_e_685798c9b2f8832fa52c9fbaa677feb1