### PR TITLE
Add timestamps to PostCard header

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -9,15 +9,18 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   requestHelp: jest.fn(() =>
     Promise.resolve({
-      id: 'r1',
-      authorId: 'u1',
-      type: 'request',
-      content: 'Task',
-      visibility: 'public',
-      timestamp: '',
-      tags: [],
-      collaborators: [],
-      linkedItems: [],
+      request: {
+        id: 'r1',
+        authorId: 'u1',
+        type: 'request',
+        content: 'Task',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      },
+      subRequests: [],
     })
   ),
   updatePost: jest.fn(() => Promise.resolve({})),
@@ -71,7 +74,9 @@ describe('PostCard request help', () => {
       fireEvent.click(btn);
     });
 
-    await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('t1'));
+    await waitFor(() =>
+      expect(requestHelp).toHaveBeenCalledWith('t1', 'task')
+    );
     expect(appendMock).toHaveBeenCalled();
 
     await act(async () => {

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -361,12 +361,15 @@ const PostCard: React.FC<PostCardProps> = ({
         <div className="flex justify-between text-sm text-secondary">
           <div className="flex flex-wrap items-center gap-2">
             {summaryTags.map((tag, idx) => (
-              <SummaryTag key={idx} {...tag} />
+              <React.Fragment key={idx}>
+                <SummaryTag {...tag} />
+                {idx === 1 && <span>{timestamp}</span>}
+              </React.Fragment>
             ))}
             {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
               <StatusBadge status={post.status} />
             )}
-            <span>{timestamp}</span>
+            {summaryTags.length < 2 && <span>{timestamp}</span>}
           </div>
         </div>
         {titleText && (
@@ -407,11 +410,15 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="flex justify-between text-sm text-secondary">
         <div className="flex flex-wrap items-center gap-2">
           {summaryTags.map((tag, idx) => (
-            <SummaryTag key={idx} {...tag} />
+            <React.Fragment key={idx}>
+              <SummaryTag {...tag} />
+              {idx === 1 && <span>{timestamp}</span>}
+            </React.Fragment>
           ))}
           {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
             <StatusBadge status={post.status} />
           )}
+          {summaryTags.length < 2 && <span>{timestamp}</span>}
           {!isQuestBoardRequest &&
             canEdit &&
             ['task', 'request', 'issue'].includes(post.type) &&


### PR DESCRIPTION
## Summary
- show timestamp after the second summary link in `PostCard`
- update request help test for new API shape

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_68579b9b0740832fa1ced52c012815c8