### PR TITLE
Show username in summary tags

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -72,3 +72,20 @@ Posts and quests are annotated with small tags that reuse the same color palette
 | free_speech | `bg-gray-100 text-gray-700` / `dark:bg-gray-700 dark:text-gray-200` |
 
 All tags share the `TAG_BASE` style which sets padding, font size and border radius.
+
+### Tag summary format
+
+Summary tags combine the quest title with the post's node ID and author handle.
+For task-oriented posts the username appears alongside the node ID:
+
+```
+[Quest: Demo Quest] [Task - Q:demo:T01:@alice]
+[Quest: Demo Quest] [Issue - Q:demo:T01:I00:@bob]
+[Quest: Demo Quest] [Commit - Q:demo:T01:C00:@carol]
+```
+Logs and other post types show the author with a `Log` label. These concise tags
+help identify who created each node at a glance.
+
+If a log, issue or commit references more than one task the node ID is omitted
+to avoid confusion. Likewise, when a post spans multiple quests the `Quest`
+prefix is not shown.

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -149,25 +149,58 @@ export const buildSummaryTags = (
   }
 
   if (!multipleSources && title) {
-    tags.push({ type: 'quest', label: `Quest: ${title}`, link: (questId || post.questId) ? ROUTES.QUEST(questId || post.questId!) : undefined });
+    tags.push({
+      type: 'quest',
+      label: `Quest: ${title}`,
+      link: (questId || post.questId) ? ROUTES.QUEST(questId || post.questId!) : undefined,
+    });
   }
 
   if (post.type === 'task' && post.nodeId) {
-    tags.push({ type: 'task', label: `Task: ${post.nodeId}`, link: ROUTES.POST(post.id) });
-  } else if (post.type === 'issue' && post.nodeId) {
-    tags.push({ type: 'issue', label: `Issue: ${post.nodeId}`, link: ROUTES.POST(post.id) });
+    const user = post.author?.username || post.authorId;
+    tags.push({
+      type: 'task',
+      label: `Task - ${post.nodeId}:@${user}`,
+      detailLink: ROUTES.POST(post.id),
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
+    });
+  } else if (post.type === 'issue') {
+    const user = post.author?.username || post.authorId;
+    const label = post.nodeId && !multipleSources
+      ? `Issue - ${post.nodeId}:@${user}`
+      : `Issue: @${user}`;
+    tags.push({
+      type: 'issue',
+      label,
+      detailLink: ROUTES.POST(post.id),
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
+    });
   } else if (post.type === 'log' || post.type === 'quest_log') {
     const user = post.author?.username || post.authorId;
-    // Link log tags to the author's public profile for quick context
+    const label = post.nodeId && !multipleSources
+      ? `Log - ${post.nodeId}:@${user}`
+      : `Log: @${user}`;
     tags.push({
       type: 'log',
-      label: 'Log:',
+      label,
       detailLink: ROUTES.POST(post.id),
       username: user,
       usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
   } else if (post.type === 'commit') {
-    tags.push({ type: 'commit', label: 'Commit' });
+    const user = post.author?.username || post.authorId;
+    const label = post.nodeId && !multipleSources
+      ? `Commit - ${post.nodeId}:@${user}`
+      : `Commit: @${user}`;
+    tags.push({
+      type: 'commit',
+      label,
+      detailLink: ROUTES.POST(post.id),
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
+    });
   } else if (post.type === 'meta_system') {
     tags.push({ type: 'meta_system', label: 'System' });
   } else if (post.type === 'meta_announcement') {
@@ -176,17 +209,6 @@ export const buildSummaryTags = (
     tags.push({ type: 'solved', label: 'Solved' });
   }
 
-  // Include author log reference on task and issue posts for quick context
-  if (['task', 'issue'].includes(post.type)) {
-    const user = post.author?.username || post.authorId;
-    tags.push({
-      type: 'log',
-      label: 'Log:',
-      detailLink: ROUTES.POST(post.id),
-      username: user,
-      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
-    });
-  }
 
   if (post.status && ['task', 'issue'].includes(post.type)) {
     tags.push({ type: 'status', label: post.status });
@@ -215,6 +237,7 @@ export const buildSummaryTags = (
 export const getPostSummary = (post: PostWithQuestTitle, questTitle?: string): string => {
   const parts: string[] = [];
   const title = questTitle || post.questTitle;
+  const multipleSources = (post.linkedItems || []).length > 1;
 
   if (post.type === 'review') {
     if (title) parts.push(`(Review: ${title})`);
@@ -225,14 +248,29 @@ export const getPostSummary = (post: PostWithQuestTitle, questTitle?: string): s
   if (title) parts.push(`(Quest: ${title})`);
 
   if (post.type === 'task' && post.nodeId) {
-    parts.push(`(Task: ${post.nodeId})`);
-  } else if (post.type === 'issue' && post.nodeId) {
-    parts.push(`(Issue: ${post.nodeId})`);
+    const user = post.author?.username || post.authorId;
+    parts.push(`(Task - ${post.nodeId}:@${user})`);
+  } else if (post.type === 'issue') {
+    const user = post.author?.username || post.authorId;
+    if (post.nodeId && !multipleSources) {
+      parts.push(`(Issue - ${post.nodeId}:@${user})`);
+    } else {
+      parts.push(`(Issue: @${user})`);
+    }
   } else if (post.type === 'log' || post.type === 'quest_log') {
     const user = post.author?.username || post.authorId;
-    parts.push(`(Log: @${user})`);
+    if (post.nodeId && !multipleSources) {
+      parts.push(`(Log - ${post.nodeId}:@${user})`);
+    } else {
+      parts.push(`(Log: @${user})`);
+    }
   } else if (post.type === 'commit') {
-    parts.push('(Commit)');
+    const user = post.author?.username || post.authorId;
+    if (post.nodeId && !multipleSources) {
+      parts.push(`(Commit - ${post.nodeId}:@${user})`);
+    } else {
+      parts.push(`(Commit: @${user})`);
+    }
   } else if (post.type === 'meta_system') {
     parts.push('(System)');
   } else if (post.type === 'meta_announcement') {


### PR DESCRIPTION
## Summary
- include node ID and usernames in summary labels
- describe multi-quest behavior in design doc
- omit quest tag when post references multiple quests

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `ethos-backend` *(fails: cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm run lint` in `ethos-frontend` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_68579d7bd30c832fb2dedba955162dce