### PR TITLE
Fix quest formatting on timeline board

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -67,13 +67,40 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
 
   // 🧭 Render Quest
   if ('headPostId' in contribution) {
+    const quest = contribution as Quest;
+
+    // Display quests on the timeline board like regular posts for consistency
+    if (boardId === 'timeline-board') {
+      const headPost = (quest as any).headPost as Post | undefined;
+      const postLike = headPost ?? ({
+        id: quest.headPostId,
+        type: 'quest',
+        authorId: quest.authorId,
+        content: quest.title,
+        visibility: 'public',
+        timestamp: quest.createdAt || '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      } as Post);
+
+      return (
+        <PostCard
+          post={postLike}
+          questId={quest.id}
+          questTitle={quest.title}
+          {...sharedProps}
+        />
+      );
+    }
+
     return (
       <QuestCard
-        quest={contribution as Quest}
+        quest={quest}
         user={user}
         compact={compact}
-        onEdit={onEdit ? () => onEdit((contribution as Quest).id) : undefined}
-        onDelete={onDelete ? (quest) => onDelete(quest.id) : undefined}
+        onEdit={onEdit ? () => onEdit(quest.id) : undefined}
+        onDelete={onDelete ? (q) => onDelete(q.id) : undefined}
       />
     );
   }

--- a/ethos-frontend/tests/TimelineQuestFormatting.test.tsx
+++ b/ethos-frontend/tests/TimelineQuestFormatting.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ContributionCard from '../src/components/contribution/ContributionCard';
+import type { Quest } from '../src/types/questTypes';
+
+const quest: Quest = {
+  id: 'q1',
+  authorId: 'u1',
+  title: 'Timeline Quest',
+  visibility: 'public',
+  approvalStatus: 'approved',
+  status: 'active',
+  headPostId: 'p1',
+  linkedPosts: [],
+  collaborators: [],
+  gitRepo: { repoId: '', repoUrl: '' },
+};
+
+describe('Timeline quest formatting', () => {
+  it('renders quest using PostCard formatting on timeline board', () => {
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={quest} boardId="timeline-board" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Quest: Timeline Quest')).toBeInTheDocument();
+    expect(screen.queryByText(/Expand/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- show quests like posts on Recent Activity timeline
- add regression test for timeline quest formatting

## Testing
- `npm test --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6857aa239dac832fa65a26a12585473e