### PR TITLE
Add summary tag for reviews with multiple links

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -54,4 +54,22 @@ describe('PostListItem', () => {
 
     expect(screen.getByText('Quest: Quest A')).toBeInTheDocument();
   });
+
+  it('renders review summary tag', () => {
+    const reviewPost: Post = {
+      ...basePost,
+      id: 'r1',
+      type: 'review',
+      questId: 'q2',
+      questTitle: 'Quest B',
+    } as Post;
+
+    render(
+      <BrowserRouter>
+        <PostListItem post={reviewPost} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('Review: Quest B')).toBeInTheDocument();
+  });
 });

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
-import { getDisplayTitle } from '../../utils/displayUtils';
+import { getDisplayTitle, buildSummaryTags } from '../../utils/displayUtils';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import SummaryTag from '../ui/SummaryTag';
@@ -17,10 +17,7 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
   const header = getDisplayTitle(post);
-  const questTag =
-    post.questId && post.questTitle
-      ? { type: 'quest' as const, label: `Quest: ${post.questTitle}`, link: ROUTES.QUEST(post.questId) }
-      : null;
+  const summaryTags = buildSummaryTags(post);
 
   return (
     <div
@@ -35,7 +32,11 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
           {header}
           <span className="text-xs text-secondary ml-2">{timestamp}</span>
         </div>
-        {questTag && <SummaryTag {...questTag} />}
+        <div className="flex flex-wrap gap-1 ml-2">
+          {summaryTags.map((tag, idx) => (
+            <SummaryTag key={idx} {...tag} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -115,7 +115,7 @@ export const buildSummaryTags = (
   const multipleSources = (post.linkedItems || []).length > 1;
 
   if (post.type === 'review') {
-    if (!multipleSources && title) {
+    if (title) {
       tags.push({ type: 'review', label: `Review: ${title}`, link: post.id ? ROUTES.POST(post.id) : undefined });
     }
     if (post.subtype) tags.push({ type: 'category', label: post.subtype });


### PR DESCRIPTION
## Summary
- allow review summary tags even when multiple links are present
- keep summary tag rendering for PostListItem

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857aa849e40832f9092fa96edb5bd65