### PR TITLE
Use quest author username for summary

### DIFF
--- a/ethos-backend/src/types/enriched.ts
+++ b/ethos-backend/src/types/enriched.ts
@@ -20,6 +20,8 @@ export interface EnrichedPost extends Post {
 }
 
 export interface EnrichedQuest extends Omit<Quest, 'collaborators'> {
+  /** Basic author reference */
+  author?: { id: string; username?: string };
   headPost?: Post; // Head/intro post
   linkedPostsResolved?: Post[]; // All posts linked
 

--- a/ethos-backend/src/utils/enrich.ts
+++ b/ethos-backend/src/utils/enrich.ts
@@ -206,8 +206,10 @@ export const enrichQuest = (
   });
 
   const headPostDB = posts.find((p) => p.id === quest.headPostId);
+  const authorUser = users.find((u) => u.id === quest.authorId);
   return {
     ...normalizedQuest,
+    author: authorUser ? { id: authorUser.id, username: authorUser.username } : { id: quest.authorId },
     headPost: headPostDB ? normalizePost(headPostDB) : undefined,
     logs,
     tasks,

--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -82,8 +82,8 @@ export const updateQuestById = async (id: string, updates: Partial<Quest>): Prom
  * @function fetchQuestById  
  * @was getQuestById  
  */
-export const fetchQuestById = async (id: string): Promise<Quest> => {
-  const res = await axiosWithAuth.get(`${BASE_URL}/${id}`);
+export const fetchQuestById = async (id: string): Promise<EnrichedQuest> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/${id}?enrich=true`);
   return res.data;
 };
 

--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -34,8 +34,8 @@ const Banner: React.FC<BannerProps> = ({ user, quest, creatorName }) => {
   const tags = user?.tags || quest?.collaborators || [];
 
   const creatorDisplay =
-    quest && (creatorName || quest.authorId)
-      ? `Created by @${creatorName || quest.authorId}`
+    quest && (creatorName || quest.author?.username || quest.authorId)
+      ? `Created by @${creatorName || quest.author?.username || quest.authorId}`
       : null;
 
   return (

--- a/ethos-frontend/src/hooks/useQuest.ts
+++ b/ethos-frontend/src/hooks/useQuest.ts
@@ -31,7 +31,7 @@ function isQuest(obj: unknown): obj is Quest {
  * Custom hook for quest-related data operations.
  */
 export const useQuest = (questId?: string) => {
-  const [quest, setQuest] = useState<Quest | null>(null);
+  const [quest, setQuest] = useState<EnrichedQuest | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(!!questId);
 

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -41,6 +41,10 @@ const QuestPage: React.FC = () => {
   // Fetch quest creator name once quest is loaded
   useEffect(() => {
     if (!quest) return;
+    if (quest.author && quest.author.username) {
+      setCreatorName(quest.author.username);
+      return;
+    }
     fetchUserById(quest.authorId)
       .then((u) => setCreatorName(u.username || u.id))
       .catch(() => setCreatorName(quest.authorId));

--- a/ethos-frontend/src/types/questTypes.ts
+++ b/ethos-frontend/src/types/questTypes.ts
@@ -50,6 +50,8 @@ export interface TaskEdge {
  * Used for rendering UIs or dashboards.
  */
 export interface EnrichedQuest extends Quest {
+  /** Basic author reference */
+  author?: { id: string; username?: string };
   /** Resolved post objects (instead of just headPostId) */
   headPost?: Post;
 


### PR DESCRIPTION
## Summary
- add author field to EnrichedQuest types
- include author username in enriched quest data
- request enriched quest in fetchQuestById
- show creator username on quest pages and banners
- adjust useQuest to store EnrichedQuest

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b17e9a8c832f8777f88781debe85