### PR TITLE
Update node slug format

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -9,8 +9,7 @@ A node ID has three parts:
 ```
 Q:<quest-slug>:<segment><number>
 ```
-
-- `<quest-slug>` – a lowercase slug made from the quest title (`Ethos` → `ethos`).
+- `<quest-slug>` – the quest title in lowercase with underscores for spaces (`Demo Quest` → `demo_quest`).
 - `<segment>` – one letter describing the post type:
   - `T` – task or quest node
   - `L` – log entry

--- a/ethos-backend/dist/src/utils/nodeIdUtils.js
+++ b/ethos-backend/dist/src/utils/nodeIdUtils.js
@@ -1,7 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateNodeId = void 0;
-const slugify = (str) => str.toLowerCase().replace(/[^a-z0-9]+/g, '').replace(/^-+|-+$/g, '');
+const slugify = (str) => str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, '')
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/^_+|_+$/g, '');
 const zeroPad = (num) => num.toString().padStart(2, '0');
 const typeMap = {
     quest: 'T',

--- a/ethos-backend/dist/tests/posts.test.js
+++ b/ethos-backend/dist/tests/posts.test.js
@@ -83,7 +83,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: null,
-                nodeId: 'Q:firstquest:T00',
+                nodeId: 'Q:first_quest:T00',
             },
         ];
         postsStore.read.mockReturnValue(posts);
@@ -114,7 +114,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: null,
-                nodeId: 'Q:firstquest:T00',
+                nodeId: 'Q:first_quest:T00',
             },
             {
                 id: 't2',
@@ -125,7 +125,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q2',
                 replyTo: null,
-                nodeId: 'Q:secondquest:T00',
+                nodeId: 'Q:second_quest:T00',
             },
         ];
         postsStore.read.mockReturnValue(posts);
@@ -156,7 +156,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: null,
-                nodeId: 'Q:firstquest:T00',
+                nodeId: 'Q:first_quest:T00',
             },
             {
                 id: 'p2',
@@ -167,7 +167,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: null,
-                nodeId: 'Q:firstquest:T01',
+                nodeId: 'Q:first_quest:T01',
             },
             {
                 id: 'l1',
@@ -178,7 +178,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: 'p1',
-                nodeId: 'Q:firstquest:T00:L00',
+                nodeId: 'Q:first_quest:T00:L00',
             },
         ];
         postsStore.read.mockReturnValue(posts);
@@ -208,7 +208,7 @@ describe('post routes', () => {
                 timestamp: '',
                 questId: 'q1',
                 replyTo: null,
-                nodeId: 'Q:firstquest:T00',
+                nodeId: 'Q:first_quest:T00',
             },
         ];
         postsStore.read.mockReturnValue(posts);

--- a/ethos-backend/src/utils/nodeIdUtils.ts
+++ b/ethos-backend/src/utils/nodeIdUtils.ts
@@ -5,7 +5,13 @@ export type NodeIdParams = {
   parentPost?: { id: string; nodeId?: string } | null;
 };
 
-const slugify = (str: string): string => str.toLowerCase().replace(/[^a-z0-9]+/g, '').replace(/^-+|-+$/g, '');
+const slugify = (str: string): string =>
+  str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, '')
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/^_+|_+$/g, '');
 const zeroPad = (num: number): string => num.toString().padStart(2, '0');
 
 const typeMap: Record<string, string> = {

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -95,7 +95,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: null,
-        nodeId: 'Q:firstquest:T00',
+        nodeId: 'Q:first_quest:T00',
       },
     ];
 
@@ -131,7 +131,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: null,
-        nodeId: 'Q:firstquest:T00',
+        nodeId: 'Q:first_quest:T00',
       },
       {
         id: 't2',
@@ -142,7 +142,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q2',
         replyTo: null,
-        nodeId: 'Q:secondquest:T00',
+        nodeId: 'Q:second_quest:T00',
       },
     ];
 
@@ -178,7 +178,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: null,
-        nodeId: 'Q:firstquest:T00',
+        nodeId: 'Q:first_quest:T00',
       },
       {
         id: 'p2',
@@ -189,7 +189,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: null,
-        nodeId: 'Q:firstquest:T01',
+        nodeId: 'Q:first_quest:T01',
       },
       {
         id: 'l1',
@@ -200,7 +200,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: 'p1',
-        nodeId: 'Q:firstquest:T00:L00',
+        nodeId: 'Q:first_quest:T00:L00',
       },
     ];
 
@@ -235,7 +235,7 @@ describe('post routes', () => {
         timestamp: '',
         questId: 'q1',
         replyTo: null,
-        nodeId: 'Q:firstquest:T00',
+        nodeId: 'Q:first_quest:T00',
       },
     ];
 

--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -14,7 +14,8 @@ export default {
     'react-markdown': '<rootDir>/tests/__mocks__/react-markdown.tsx',
     'remark-gfm': '<rootDir>/tests/__mocks__/remark-gfm.ts',
     '.*/hooks/usePermissions$': '<rootDir>/tests/__mocks__/usePermissions.ts',
-    '.*/hooks/useGit$': '<rootDir>/tests/__mocks__/useGit.ts'
+    '.*/hooks/useGit$': '<rootDir>/tests/__mocks__/useGit.ts',
+    'react-force-graph-2d': '<rootDir>/tests/__mocks__/react-force-graph-2d.tsx'
   },
   testMatch: [
     '<rootDir>/src/api/quest.test.ts',

--- a/ethos-frontend/tests/__mocks__/react-force-graph-2d.tsx
+++ b/ethos-frontend/tests/__mocks__/react-force-graph-2d.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+const ForceGraph2D = React.forwardRef<HTMLDivElement, any>((props, ref) => (
+  <div ref={ref} {...props} />
+));
+export default ForceGraph2D;
+export const ForceGraphMethods = {} as any;


### PR DESCRIPTION
## Summary
- ensure quest slug uses underscores
- document new slug format
- adjust tests to underscore slugs
- mock `react-force-graph-2d` for Jest

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857b1c8c948832f926c8feb63429f4a