### PR TITLE
Adjust post details layout

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -49,6 +49,8 @@ interface ReactionControlsProps {
   isTimeline?: boolean;
   /** Board ID used for context-specific actions */
   boardId?: string;
+  /** Notify parent when reply panel toggles */
+  onReplyToggle?: (open: boolean) => void;
 }
 
 const ReactionControls: React.FC<ReactionControlsProps> = ({
@@ -58,6 +60,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   replyOverride,
   isTimeline,
   boardId,
+  onReplyToggle,
 }) => {
   const [reactions, setReactions] = useState({ like: false, heart: false });
   const [counts, setCounts] = useState({ like: 0, heart: 0, repost: 0 });
@@ -268,7 +271,11 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
             } else if (isTimelineBoard) {
               navigate(ROUTES.POST(post.id) + '?reply=1');
             } else {
-              setShowReplyPanel(prev => !prev);
+              setShowReplyPanel(prev => {
+                const next = !prev;
+                onReplyToggle?.(next);
+                return next;
+              });
             }
           }}
         >
@@ -296,7 +303,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
       </div>
 
-      {showReplyPanel && !replyOverride && (
+      {showReplyPanel && !replyOverride && !onReplyToggle && (
         <div className="mt-3">
           <CreatePost
             replyTo={post}

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -95,6 +95,8 @@ const PostCard: React.FC<PostCardProps> = ({
   const [asCommit, setAsCommit] = useState(false);
   const [showBrowser, setShowBrowser] = useState(false);
   const [headPostId, setHeadPostId] = useState<string | null>(null);
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [linkExpanded, setLinkExpanded] = useState(false);
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();
@@ -269,6 +271,8 @@ const PostCard: React.FC<PostCardProps> = ({
         items={post.linkedItems || []}
         post={post}
         showReplyChain={showDetails}
+        open={linkExpanded}
+        onToggle={() => setLinkExpanded(o => !o)}
       />
     );
   };
@@ -516,7 +520,32 @@ const PostCard: React.FC<PostCardProps> = ({
       </div>
 
       {renderCommitDiff()}
+
+      <ReactionControls
+        post={post}
+        user={user}
+        onUpdate={onUpdate}
+        replyOverride={replyOverride}
+        boardId={ctxBoardId || undefined}
+        onReplyToggle={
+          post.linkedItems && post.linkedItems.length > 0 ? setShowReplyForm : undefined
+        }
+      />
+
       {renderLinkSummary()}
+
+      {showReplyForm && (
+        <div className="mt-2">
+          <CreatePost
+            replyTo={post}
+            onSave={(r) => {
+              onUpdate?.(r);
+              setShowReplyForm(false);
+            }}
+            onCancel={() => setShowReplyForm(false)}
+          />
+        </div>
+      )}
 
       {['request','quest','task','log','commit','issue', 'meta_system'].includes(post.type) && (
         <div className="text-xs text-secondary space-y-1">
@@ -610,13 +639,6 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      <ReactionControls
-        post={post}
-        user={user}
-        onUpdate={onUpdate}
-        replyOverride={replyOverride}
-        boardId={ctxBoardId || undefined}
-      />
       {post.type === 'request' && !isQuestBoardRequest && (
         <button
           className="text-accent underline text-xs ml-2"

--- a/ethos-frontend/src/components/ui/LinkViewer.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.tsx
@@ -14,10 +14,16 @@ interface LinkViewerProps {
   post?: Post;
   /** Fetch and show reply chain */
   showReplyChain?: boolean;
+  /** Controlled open state */
+  open?: boolean;
+  /** Toggle handler when using controlled open state */
+  onToggle?: () => void;
 }
 
-const LinkViewer: React.FC<LinkViewerProps> = ({ items, post, showReplyChain }) => {
-  const [open, setOpen] = useState(false);
+const LinkViewer: React.FC<LinkViewerProps> = ({ items, post, showReplyChain, open: openProp, onToggle }) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const controlled = openProp !== undefined;
+  const open = controlled ? openProp : internalOpen;
   const [resolved, setResolved] = useState<LinkedItem[]>(items);
   const [chain, setChain] = useState<Post[]>([]);
 
@@ -104,7 +110,13 @@ const LinkViewer: React.FC<LinkViewerProps> = ({ items, post, showReplyChain }) 
   return (
     <div className="text-xs text-primary dark:text-primary">
       <button
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          if (controlled) {
+            onToggle?.();
+          } else {
+            setInternalOpen(o => !o);
+          }
+        }}
         className="flex items-center gap-1 text-blue-600 underline"
       >
         {open ? <FaCompress /> : <FaExpand />} {open ? 'Collapse Details' : 'Expand Details'}


### PR DESCRIPTION
## Summary
- add `onReplyToggle` prop to `ReactionControls`
- manage link detail expansion in `PostCard` and show reply form beneath expanded links
- allow external open control for `LinkViewer`

## Testing
- `npm run --silent build --prefix ethos-frontend` *(fails: Cannot find module 'react' or its type declarations)*
- `npm test --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68581c7a40a8832f91fc3261d29ed868