### PR TITLE
Update review summary tags to include username

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -70,7 +70,11 @@ describe('PostListItem', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByText('Review: Quest B')).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, element) =>
+        element?.textContent === 'Review: Quest B @u1'
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it('renders generic review tag when quest title missing', () => {
@@ -86,6 +90,10 @@ describe('PostListItem', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, element) =>
+        element?.textContent === 'Review @u1'
+      ).length
+    ).toBeGreaterThan(0);
   });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -115,10 +115,13 @@ export const buildSummaryTags = (
   const multipleSources = (post.linkedItems || []).length > 1;
 
   if (post.type === 'review') {
+    const user = post.author?.username || post.authorId;
     tags.push({
       type: 'review',
       label: title ? `Review: ${title}` : 'Review',
-      link: post.id ? ROUTES.POST(post.id) : undefined,
+      detailLink: post.id ? ROUTES.POST(post.id) : undefined,
+      username: user,
+      usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
     if (post.subtype) tags.push({ type: 'category', label: post.subtype });
     return tags;
@@ -238,7 +241,9 @@ export const getPostSummary = (post: PostWithQuestTitle, questTitle?: string): s
   const multipleSources = (post.linkedItems || []).length > 1;
 
   if (post.type === 'review') {
+    const user = post.author?.username || post.authorId;
     if (title) parts.push(`(Review: ${title})`);
+    parts.push(`(@${user})`);
     if (post.subtype) parts.push(`(${post.subtype})`);
     return parts.join(' ').trim();
   }


### PR DESCRIPTION
## Summary
- show the reviewer's username in summary tags
- update getPostSummary accordingly
- adjust post list item tests for new tag format

## Testing
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68581ca16ef4832f83372fd8678059c2