### PR TITLE
Improve quest displays on boards

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -69,8 +69,8 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   if ('headPostId' in contribution) {
     const quest = contribution as Quest;
 
-    // Display quests on the timeline board like regular posts for consistency
-    if (boardId === 'timeline-board') {
+    // Display quests on timeline and post history boards like regular posts for consistency
+    if (boardId === 'timeline-board' || boardId === 'my-posts') {
       const headPost = (quest as any).headPost as Post | undefined;
       const postLike = headPost ?? ({
         id: quest.headPostId,

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -155,12 +155,16 @@ const QuestCard: React.FC<QuestCardProps> = ({
       const node = logs.find((p) => p.id === evt.detail.taskId);
       if (node) {
         setSelectedNode(node);
-        setActiveTab('status');
+        if (rootNode && node.id === rootNode.id) {
+          setActiveTab('logs');
+        } else {
+          setActiveTab('status');
+        }
       }
     };
     window.addEventListener('questTaskOpen', handleTaskOpen);
     return () => window.removeEventListener('questTaskOpen', handleTaskOpen);
-  }, [logs]);
+  }, [logs, rootNode]);
 
 
 


### PR DESCRIPTION
## Summary
- display quests as posts on "my-posts" board
- show Logs tab when root task node is opened

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_68583203883c832fac6af1e4c1dca841