### PR TITLE
Add quick task form to Kanban columns

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -16,6 +16,7 @@ import { useBoardContext } from '../../contexts/BoardContext';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import { Spinner } from '../ui';
+import QuickTaskForm from '../post/QuickTaskForm';
 
 type GridLayoutProps = {
   items: Post[];
@@ -30,6 +31,8 @@ type GridLayoutProps = {
   initialExpanded?: boolean;
   /** Board ID for context */
   boardId?: string;
+  /** Quest ID when rendering quest tasks */
+  questId?: string;
 };
 
 const defaultKanbanColumns = ['To Do', 'In Progress', 'Blocked', 'Done'];
@@ -122,6 +125,8 @@ const GridLayout: React.FC<GridLayoutProps> = ({
    */
   const { selectedBoard, updateBoardItem, removeItemFromBoard } =
     useBoardContext();
+
+  const [columnForm, setColumnForm] = useState<string | null>(null);
 
   useEffect(() => {
     if (layout === 'horizontal') {
@@ -251,7 +256,28 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               key={col}
               className="min-w-[280px] w-[320px] flex-shrink-0 bg-surface border border-secondary rounded-lg p-4 shadow-sm"
             >
-              <h3 className="text-sm font-bold text-secondary mb-4">{col}</h3>
+              <div className="flex justify-between items-center mb-2">
+                <h3 className="text-sm font-bold text-secondary">{col}</h3>
+                {editable && (
+                  <button
+                    className="text-xs text-accent underline"
+                    onClick={() => setColumnForm(columnForm === col ? null : col)}
+                  >
+                    {columnForm === col ? '- Cancel' : '+ Add Item'}
+                  </button>
+                )}
+              </div>
+              {columnForm === col && questId && boardId && (
+                <div className="mb-2">
+                  <QuickTaskForm
+                    questId={questId}
+                    status={col}
+                    boardId={boardId}
+                    onSave={() => setColumnForm(null)}
+                    onCancel={() => setColumnForm(null)}
+                  />
+                </div>
+              )}
               <DroppableColumn id={col}>
                 {grouped[col].map((item) => (
                   <DraggableCard

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -462,7 +462,12 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="text-sm text-primary">
         {post.type === 'task' ? (
           <>
-            <div className="font-semibold">{post.content}</div>
+            <div
+              className="font-semibold cursor-pointer"
+              onClick={() => navigate(ROUTES.POST(post.id))}
+            >
+              {post.content}
+            </div>
             {post.details && (
               isLong ? (
                 <>

--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { addPost } from '../../api/post';
+import { Input, Select, Button } from '../ui';
+import { TASK_TYPE_OPTIONS } from '../../constants/options';
+import { useBoardContext } from '../../contexts/BoardContext';
+import type { Post } from '../../types/postTypes';
+
+interface QuickTaskFormProps {
+  questId: string;
+  status: string;
+  boardId: string;
+  onSave?: (post: Post) => void;
+  onCancel: () => void;
+}
+
+const QuickTaskForm: React.FC<QuickTaskFormProps> = ({ questId, status, boardId, onSave, onCancel }) => {
+  const [title, setTitle] = useState('');
+  const [taskType, setTaskType] = useState<'file' | 'folder'>('file');
+  const [submitting, setSubmitting] = useState(false);
+  const { appendToBoard } = useBoardContext() || {};
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title) return;
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const newPost = await addPost({
+        type: 'task',
+        content: title,
+        visibility: 'public',
+        questId,
+        status,
+        taskType,
+        boardId,
+      });
+      appendToBoard?.(boardId, newPost);
+      onSave?.(newPost);
+    } catch (err) {
+      console.error('[QuickTaskForm] Failed to create task:', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border border-secondary rounded p-2 bg-background">
+      <Input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Task name"
+        required
+      />
+      <Select
+        value={taskType}
+        onChange={(e) => setTaskType(e.target.value as 'file' | 'folder')}
+        options={TASK_TYPE_OPTIONS.filter((o) => o.value !== 'abstract')}
+      />
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" variant="contrast" disabled={submitting}>
+          {submitting ? 'Adding...' : 'Add'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default QuickTaskForm;


### PR DESCRIPTION
## Summary
- implement `QuickTaskForm` for lightweight task creation
- enable per-column task creation in `GridLayout`
- make task titles clickable in `PostCard`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685839c90728832f8511451d9f628087