### PR TITLE
Update add button label for timeline and post history boards

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -397,6 +397,8 @@ const Board: React.FC<BoardProps> = ({
                 ? '+ Add Quest'
                 : board?.id === 'quest-board'
                 ? '+ Add Request'
+                : ['timeline-board', 'my-posts'].includes(board?.id || '')
+                ? '+ Add Post'
                 : '+ Add Item'}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- adjust `Board` component label logic so timeline and post history boards use "Add Post" rather than "Add Item"

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68583cdee618832fb90cf0b2e7e6159c