### PR TITLE
Add global quick task form for quest status

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -30,6 +30,8 @@ type GridLayoutProps = {
   initialExpanded?: boolean;
   /** Board ID for context */
   boardId?: string;
+  /** Quest ID when rendering quest tasks */
+  questId?: string;
 };
 
 const defaultKanbanColumns = ['To Do', 'In Progress', 'Blocked', 'Done'];
@@ -122,6 +124,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
    */
   const { selectedBoard, updateBoardItem, removeItemFromBoard } =
     useBoardContext();
+
 
   useEffect(() => {
     if (layout === 'horizontal') {
@@ -251,7 +254,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               key={col}
               className="min-w-[280px] w-[320px] flex-shrink-0 bg-surface border border-secondary rounded-lg p-4 shadow-sm"
             >
-              <h3 className="text-sm font-bold text-secondary mb-4">{col}</h3>
+              <h3 className="text-sm font-bold text-secondary mb-2">{col}</h3>
               <DroppableColumn id={col}>
                 {grouped[col].map((item) => (
                   <DraggableCard

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -462,7 +462,20 @@ const PostCard: React.FC<PostCardProps> = ({
       <div className="text-sm text-primary">
         {post.type === 'task' ? (
           <>
-            <div className="font-semibold">{post.content}</div>
+            <div
+              className="font-semibold cursor-pointer"
+              onClick={() => {
+                if (questId) {
+                  window.dispatchEvent(
+                    new CustomEvent('questTaskOpen', { detail: { taskId: post.id } })
+                  );
+                } else {
+                  navigate(ROUTES.POST(post.id));
+                }
+              }}
+            >
+              {post.content}
+            </div>
             {post.details && (
               isLong ? (
                 <>

--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { addPost } from '../../api/post';
+import { Input, Select, Button } from '../ui';
+import { TASK_TYPE_OPTIONS, STATUS_OPTIONS } from '../../constants/options';
+import { useBoardContext } from '../../contexts/BoardContext';
+import type { Post } from '../../types/postTypes';
+
+interface QuickTaskFormProps {
+  questId: string;
+  status?: string;
+  boardId: string;
+  onSave?: (post: Post) => void;
+  onCancel: () => void;
+}
+
+const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
+  questId,
+  status,
+  boardId,
+  onSave,
+  onCancel,
+}) => {
+  const [title, setTitle] = useState('');
+  const [taskType, setTaskType] = useState<'file' | 'folder'>('file');
+  const [taskStatus, setTaskStatus] = useState(status || 'To Do');
+  const [submitting, setSubmitting] = useState(false);
+  const { appendToBoard } = useBoardContext() || {};
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title) return;
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const newPost = await addPost({
+        type: 'task',
+        content: title,
+        visibility: 'public',
+        questId,
+        status: taskStatus,
+        taskType,
+        boardId,
+      });
+      appendToBoard?.(boardId, newPost);
+      onSave?.(newPost);
+    } catch (err) {
+      console.error('[QuickTaskForm] Failed to create task:', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border border-secondary rounded p-2 bg-background">
+      <Input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Task name"
+        required
+      />
+      <Select
+        value={taskType}
+        onChange={(e) => setTaskType(e.target.value as 'file' | 'folder')}
+        options={TASK_TYPE_OPTIONS.filter((o) => o.value !== 'abstract')}
+      />
+      {!status && (
+        <Select
+          value={taskStatus}
+          onChange={(e) => setTaskStatus(e.target.value)}
+          options={STATUS_OPTIONS.map(({ value, label }) => ({ value, label }))}
+        />
+      )}
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" variant="contrast" disabled={submitting}>
+          {submitting ? 'Adding...' : 'Add'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default QuickTaskForm;

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -19,6 +19,7 @@ import TaskPreviewCard from '../post/TaskPreviewCard';
 import FileEditorPanel from './FileEditorPanel';
 import StatusBoardPanel from './StatusBoardPanel';
 import LogThreadPanel from './LogThreadPanel';
+import QuickTaskForm from '../post/QuickTaskForm';
 
 
 /**
@@ -409,11 +410,10 @@ const QuestCard: React.FC<QuestCardProps> = ({
           panel = (
             <>
               {showTaskForm && (
-                <div className="mb-4">
-                  <CreatePost
-                    initialType="task"
+                <div className="mb-2">
+                  <QuickTaskForm
                     questId={quest.id}
-                    boardId={`map-${quest.id}`}
+                    boardId={`log-${quest.id}`}
                     onSave={(p) => {
                       setLogs((prev) => [...prev, p]);
                       setShowTaskForm(false);
@@ -422,16 +422,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                   />
                 </div>
               )}
-              <GridLayout
-                questId={quest.id}
-                items={logs}
-                user={user}
-                layout="kanban"
-                editable={canEdit}
-                compact
-                boardId={`log-${quest.id}`}
-              />
-              <div className="text-right mt-2">
+              <div className="text-right mb-2">
                 {canEdit ? (
                   <Button size="sm" variant="contrast" onClick={() => setShowTaskForm(true)}>
                     + Add Item
@@ -442,6 +433,15 @@ const QuestCard: React.FC<QuestCardProps> = ({
                   </Button>
                 )}
               </div>
+              <GridLayout
+                questId={quest.id}
+                items={logs}
+                user={user}
+                layout="kanban"
+                editable={canEdit}
+                compact
+                boardId={`log-${quest.id}`}
+              />
             </>
           );
         } else {
@@ -452,9 +452,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
         panel = (
           <>
             {showTaskForm && (
-              <div className="mb-4">
-                <CreatePost
-                  initialType="task"
+              <div className="mb-2">
+                <QuickTaskForm
                   questId={quest.id}
                   boardId={`map-${quest.id}`}
                   onSave={(p) => {

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -3,6 +3,7 @@ import { fetchPostsByQuestId } from '../../api/post';
 import type { Post } from '../../types/postTypes';
 import { STATUS_OPTIONS } from '../../constants/options';
 import StatusBadge from '../ui/StatusBadge';
+import QuickTaskForm from '../post/QuickTaskForm';
 
 interface StatusBoardPanelProps {
   questId: string;
@@ -19,11 +20,8 @@ const statusIcons: Record<string, string> = {
 const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNodeId }) => {
   const [items, setItems] = useState<Post[]>([]);
   const [filter, setFilter] = useState<'all' | 'issues' | 'tasks'>('all');
+  const [showForm, setShowForm] = useState(false);
 
-  const handleAddIssue = (status: string) => {
-    // Placeholder handler for adding an issue in the given status
-    console.log('Add issue for status', status);
-  };
 
   useEffect(() => {
     if (!questId) return;
@@ -55,65 +53,80 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
 
   return (
     <div>
-      <div className="flex gap-2 mb-2 text-xs">
+      <div className="flex justify-between items-start mb-2">
+        <div className="flex gap-2 text-xs">
+          <button
+            className={`px-2 py-0.5 rounded border ${
+              filter === 'all' ? 'bg-accent text-white border-accent' : 'border-secondary'
+            }`}
+            onClick={() => setFilter('all')}
+          >
+            All
+          </button>
+          <button
+            className={`px-2 py-0.5 rounded border ${
+              filter === 'issues' ? 'bg-accent text-white border-accent' : 'border-secondary'
+            }`}
+            onClick={() => setFilter('issues')}
+          >
+            Issues
+          </button>
+          <button
+            className={`px-2 py-0.5 rounded border ${
+              filter === 'tasks' ? 'bg-accent text-white border-accent' : 'border-secondary'
+            }`}
+            onClick={() => setFilter('tasks')}
+          >
+            Tasks
+          </button>
+        </div>
         <button
-          className={`px-2 py-0.5 rounded border ${
-            filter === 'all' ? 'bg-accent text-white border-accent' : 'border-secondary'
-          }`}
-          onClick={() => setFilter('all')}
+          className="text-xs text-accent underline"
+          onClick={() => setShowForm((p) => !p)}
         >
-          All
-        </button>
-        <button
-          className={`px-2 py-0.5 rounded border ${
-            filter === 'issues' ? 'bg-accent text-white border-accent' : 'border-secondary'
-          }`}
-          onClick={() => setFilter('issues')}
-        >
-          Issues
-        </button>
-        <button
-          className={`px-2 py-0.5 rounded border ${
-            filter === 'tasks' ? 'bg-accent text-white border-accent' : 'border-secondary'
-          }`}
-          onClick={() => setFilter('tasks')}
-        >
-          Tasks
+          {showForm ? '- Cancel' : '+ Add Item'}
         </button>
       </div>
+      {showForm && (
+        <div className="mb-2">
+          <QuickTaskForm
+            questId={questId}
+            boardId={`log-${questId}`}
+            onSave={(p) => {
+              setItems((prev) => [...prev, p]);
+              setShowForm(false);
+            }}
+            onCancel={() => setShowForm(false)}
+          />
+        </div>
+      )}
       <div className="flex overflow-auto space-x-2">
         {STATUS_OPTIONS.map(({ value }) => (
           <div
             key={value}
             className="min-w-[80px] w-28 flex-shrink-0 bg-surface border border-secondary rounded-lg p-2 space-y-2"
           >
-          <h4 className="text-sm font-semibold flex items-center gap-1">
-            <span>{statusIcons[value] || '➡️'}</span>
-            {value}
-          </h4>
-          {grouped[value].length === 0 ? (
-            <div className="text-xs text-secondary">No items</div>
-          ) : (
-            grouped[value].map((issue) => (
-              <div
-                key={issue.id}
-                className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
-              >
-                <div className="font-semibold truncate">
-                  {issue.content.length > 15 ? `${issue.content.slice(0, 12)}…` : issue.content}
+            <h4 className="text-sm font-semibold flex items-center gap-1">
+              <span>{statusIcons[value] || '➡️'}</span>
+              {value}
+            </h4>
+            {grouped[value].length === 0 ? (
+              <div className="text-xs text-secondary">No items</div>
+            ) : (
+              grouped[value].map((issue) => (
+                <div
+                  key={issue.id}
+                  className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
+                >
+                  <div className="font-semibold truncate">
+                    {issue.content.length > 15 ? `${issue.content.slice(0, 12)}…` : issue.content}
+                  </div>
+                  {issue.status && <StatusBadge status={issue.status} />}
                 </div>
-                {issue.status && <StatusBadge status={issue.status} />}
-              </div>
-            ))
-          )}
-          <button
-            onClick={() => handleAddIssue(value)}
-            className="text-xs text-accent underline"
-          >
-            + Add Issue
-          </button>
-        </div>
-      ))}
+              ))
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show quick task form in status panel and top of quest status boards
- support optional status selection in `QuickTaskForm`
- make task titles open quest views when inside a quest
- remove per-column add buttons from `GridLayout`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685839c90728832f8511451d9f628087