### PR TITLE
Add rating support for review posts

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -130,6 +130,7 @@ router.post(
       taskType = 'abstract',
       helpRequest = false,
       needsHelp = undefined,
+      rating,
     } = req.body;
 
     const finalStatus =
@@ -165,6 +166,7 @@ router.post(
       linkedItems,
       questId,
       ...(type === 'task' ? { taskType } : {}),
+      ...(type === 'review' && rating ? { rating: Math.min(5, Math.max(0, Number(rating))) } : {}),
       status: finalStatus,
       helpRequest: type === 'request' || helpRequest,
       needsHelp: type === 'request' ? needsHelp ?? true : undefined,
@@ -225,6 +227,10 @@ router.patch(
   const originalType = post.type;
 
   Object.assign(post, req.body);
+
+  if (post.type === 'review' && typeof post.rating === 'number') {
+    post.rating = Math.min(5, Math.max(0, post.rating));
+  }
 
   if (post.type === 'task') {
     post.title = post.content;

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -61,6 +61,9 @@ export interface DBPost {
   questNodeTitle?: string;
   nodeId?: string;
 
+  /** Optional rating value for review posts */
+  rating?: number;
+
   reactionCounts?: ReactionCountMap;
 }
 

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
 import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { addPost } from '../../api/post';
 import { Button, Select, Label, FormSection, Input, MarkdownEditor } from '../ui';
@@ -61,6 +62,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [helpRequest, setHelpRequest] = useState(boardId === 'quest-board');
+  const [rating, setRating] = useState(0);
 
 const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
@@ -102,6 +104,12 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       }
     }
 
+    if (type === 'review' && rating === 0) {
+      alert('Please provide a rating.');
+      setIsSubmitting(false);
+      return;
+    }
+
     const autoLinkItems = [...linkedItems];
     if (questIdFromBoard && !autoLinkItems.some((l) => l.itemId === questIdFromBoard)) {
       autoLinkItems.push({ itemId: questIdFromBoard, itemType: 'quest' });
@@ -136,6 +144,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
         ...(requiresQuestRoles(type) && { collaborators }),
         ...(type === 'commit' && initialGitFilePath ? { gitFilePath: initialGitFilePath } : {}),
         ...(type === 'commit' && initialLinkedNodeId ? { linkedNodeId: initialLinkedNodeId } : {}),
+        ...(type === 'review' && rating ? { rating } : {}),
       };
 
     try {
@@ -253,6 +262,31 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
               onChange={(e) => setTitle(e.target.value)}
               required={type !== 'free_speech'}
             />
+            {type === 'review' && (
+              <div className="mt-2">
+                <Label>Rating</Label>
+                <div className="flex space-x-1">
+                  {[1, 2, 3, 4, 5].map((n) => {
+                    const full = rating >= n;
+                    const half = !full && rating >= n - 0.5;
+                    return (
+                      <button
+                        type="button"
+                        key={n}
+                        onClick={(e) => {
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          const isHalf = e.clientX - rect.left < rect.width / 2;
+                          setRating(isHalf ? n - 0.5 : n);
+                        }}
+                        className="text-xl focus:outline-none text-yellow-400"
+                      >
+                        {full ? <FaStar /> : half ? <FaStarHalfAlt /> : <FaRegStar />}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
           </>
         )}
 

--- a/ethos-frontend/src/components/post/PostCard.review.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.review.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({}),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('PostCard review rating', () => {
+  it('renders rating stars for review posts', () => {
+    const post: Post = {
+      id: 'r1',
+      authorId: 'u1',
+      type: 'review',
+      content: 'Great quest',
+      rating: 4.5,
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as unknown as Post;
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByLabelText('Rating: 4.5')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
@@ -32,6 +33,20 @@ const makeHeader = (content: string): string => {
   // TODO: replace with AI-generated summaries
   return text.length <= 50 ? text : text.slice(0, 50) + '…';
 };
+
+const renderStars = (count: number) => (
+  <span aria-label={`Rating: ${count}`} className="text-yellow-500 flex">
+    {[1, 2, 3, 4, 5].map((n) => {
+      const full = count >= n;
+      const half = !full && count >= n - 0.5;
+      return (
+        <span key={n} className="mr-0.5">
+          {full ? <FaStar /> : half ? <FaStarHalfAlt /> : <FaRegStar />}
+        </span>
+      );
+    })}
+  </span>
+);
 
 interface PostCardProps {
   post: Post;
@@ -364,14 +379,15 @@ const PostCard: React.FC<PostCardProps> = ({
       >
         <div className="flex justify-between text-sm text-secondary">
           <div className="flex flex-wrap items-center gap-2">
-            {summaryTags.map((tag, idx) => (
-              <React.Fragment key={idx}>
-                <SummaryTag {...tag} />
-              </React.Fragment>
-            ))}
-            {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
-              <StatusBadge status={post.status} />
-            )}
+          {summaryTags.map((tag, idx) => (
+            <React.Fragment key={idx}>
+              <SummaryTag {...tag} />
+            </React.Fragment>
+          ))}
+          {post.type === 'review' && post.rating && renderStars(post.rating)}
+          {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
+            <StatusBadge status={post.status} />
+          )}
             <span>{timestamp}</span>
           </div>
         </div>
@@ -417,6 +433,7 @@ const PostCard: React.FC<PostCardProps> = ({
               <SummaryTag {...tag} />
             </React.Fragment>
           ))}
+          {post.type === 'review' && post.rating && renderStars(post.rating)}
           {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
             <StatusBadge status={post.status} />
           )}

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import type { Post } from '../../types/postTypes';
@@ -6,6 +7,20 @@ import { getDisplayTitle, buildSummaryTags } from '../../utils/displayUtils';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import SummaryTag from '../ui/SummaryTag';
+
+const renderStars = (count: number) => (
+  <span aria-label={`Rating: ${count}`} className="text-yellow-500 flex">
+    {[1, 2, 3, 4, 5].map((n) => {
+      const full = count >= n;
+      const half = !full && count >= n - 0.5;
+      return (
+        <span key={n} className="mr-0.5">
+          {full ? <FaStar /> : half ? <FaStarHalfAlt /> : <FaRegStar />}
+        </span>
+      );
+    })}
+  </span>
+);
 
 interface PostListItemProps {
   post: Post;
@@ -36,6 +51,7 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
           {summaryTags.map((tag, idx) => (
             <SummaryTag key={idx} {...tag} />
           ))}
+          {post.type === 'review' && post.rating && renderStars(post.rating)}
         </div>
       </div>
     </div>

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -27,6 +27,9 @@ export interface Post {
   questNodeTitle?: string;
   nodeId?: string;
 
+  /** Optional rating value for review posts */
+  rating?: number;
+
   tags: PostTag[];
   status?: QuestTaskStatus;
   /** Optional classification for task posts */


### PR DESCRIPTION
## Summary
- include optional rating field in DBPost and Post types
- allow review posts to store rating on creation and update
- show star ratings on post cards and list items
- add rating input to CreatePost form when creating review posts
- test rating rendering on post cards

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68583daf60ec832fae88266d1f4450f4