### PR TITLE
Refactor node inspector tabs

### DIFF
--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -4,8 +4,7 @@ import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import LogThreadPanel from './LogThreadPanel';
 import FileEditorPanel from './FileEditorPanel';
-import StatusBoardPanel from './StatusBoardPanel';
-import TeamPanel from './TeamPanel';
+import TaskKanbanBoard from './TaskKanbanBoard';
 import { Select } from '../ui';
 import { updatePost } from '../../api/post';
 import { TASK_TYPE_OPTIONS } from '../../constants/options';
@@ -27,14 +26,14 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   showLogs = true,
 }) => {
   const [type, setType] = useState<string>(node?.taskType || 'abstract');
-  const [activeTab, setActiveTab] = useState<'status' | 'logs' | 'team' | 'file'>('status');
+  const [activeTab, setActiveTab] = useState<'logs' | 'file'>('logs');
 
   useEffect(() => {
     setType(node?.taskType || 'abstract');
   }, [node?.taskType]);
 
   useEffect(() => {
-    setActiveTab('status');
+    setActiveTab('logs');
   }, [node?.id]);
 
   const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -52,9 +51,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   if (!node) return <div className="p-2 text-sm">Select a task</div>;
 
   const tabs = [
-    { value: 'status', label: 'Status' },
     ...(showLogs ? [{ value: 'logs', label: 'Logs' }] : []),
-    { value: 'team', label: 'Team' },
     {
       value: 'file',
       label: type === 'file' ? 'File' : type === 'folder' ? 'Folder' : 'Planner',
@@ -71,21 +68,26 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     case 'logs':
       panel = <LogThreadPanel questId={questId} node={node} user={user} />;
       break;
-    case 'team':
-      panel = <TeamPanel questId={questId} node={node} />;
-      break;
     case 'file':
       panel = (
-        <FileEditorPanel
-          questId={questId}
-          filePath={node.gitFilePath || 'file.txt'}
-          content={node.content}
-        />
+        <div className="space-y-2">
+          <TaskKanbanBoard
+            questId={questId}
+            linkedNodeId={node.id}
+            user={user}
+          />
+          {type === 'file' && (
+            <FileEditorPanel
+              questId={questId}
+              filePath={node.gitFilePath || 'file.txt'}
+              content={node.content}
+            />
+          )}
+        </div>
       );
       break;
-    case 'status':
     default:
-      panel = <StatusBoardPanel questId={questId} linkedNodeId={node.id} />;
+      panel = null;
   }
 
   return (

--- a/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
+++ b/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import GridLayout from '../layout/GridLayout';
+import { fetchPostsByQuestId } from '../../api/post';
+import QuickTaskForm from '../post/QuickTaskForm';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+interface TaskKanbanBoardProps {
+  questId: string;
+  linkedNodeId: string;
+  user?: User;
+}
+
+const TaskKanbanBoard: React.FC<TaskKanbanBoardProps> = ({ questId, linkedNodeId, user }) => {
+  const [tasks, setTasks] = useState<Post[]>([]);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    if (!questId) return;
+    fetchPostsByQuestId(questId)
+      .then((posts) => {
+        setTasks(posts.filter((p) => p.type === 'task' && p.replyTo === linkedNodeId));
+      })
+      .catch((err) => {
+        console.error('[TaskKanbanBoard] failed to load tasks', err);
+      });
+  }, [questId, linkedNodeId]);
+
+  return (
+    <div className="space-y-2">
+      {showForm && (
+        <QuickTaskForm
+          questId={questId}
+          boardId={`task-${linkedNodeId}`}
+          onSave={(p) => {
+            setTasks((prev) => [...prev, p]);
+            setShowForm(false);
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+      <div className="text-right">
+        <button onClick={() => setShowForm((p) => !p)} className="text-xs text-accent underline">
+          {showForm ? '- Cancel' : '+ Add Task'}
+        </button>
+      </div>
+      <GridLayout
+        questId={questId}
+        items={tasks}
+        user={user}
+        layout="kanban"
+        compact
+        editable
+        boardId={`task-${linkedNodeId}`}
+      />
+    </div>
+  );
+};
+
+export default TaskKanbanBoard;


### PR DESCRIPTION
## Summary
- simplify `QuestNodeInspector` sidebar
- show only Logs and dynamic File/Folder/Planner tab
- include a draggable kanban board for node tasks

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858409b416c832fab89cc778f4d52e1