### PR TITLE
Fix quest map edge persistence

### DIFF
--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -137,6 +137,14 @@ export const linkPostToQuest = async (
   return res.data;
 };
 
+export const updateQuestTaskGraph = async (
+  questId: string,
+  edges: TaskEdge[],
+): Promise<{ success: boolean; edges: TaskEdge[] }> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${questId}/map`, { edges });
+  return res.data;
+};
+
 /**
  * Fetch quests linked to a board  
  * @function fetchQuestsByBoardId  


### PR DESCRIPTION
## Summary
- add backend route to persist quest map edges
- add API helper to patch quest map
- trigger edge updates from graph layouts
- update quest cards to save task graph changes

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685841574b18832fb2802842eca3f417