### PR TITLE
Implement subtask linking in QuickTaskForm

### DIFF
--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { addPost } from '../../api/post';
+import { linkPostToQuest } from '../../api/quest';
 import { Input, Select, Button } from '../ui';
 import { TASK_TYPE_OPTIONS, STATUS_OPTIONS } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
@@ -9,6 +10,7 @@ interface QuickTaskFormProps {
   questId: string;
   status?: string;
   boardId: string;
+  parentId?: string;
   onSave?: (post: Post) => void;
   onCancel: () => void;
 }
@@ -17,6 +19,7 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
   questId,
   status,
   boardId,
+  parentId,
   onSave,
   onCancel,
 }) => {
@@ -40,7 +43,9 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
         status: taskStatus,
         taskType,
         boardId,
+        ...(parentId ? { replyTo: parentId } : {}),
       });
+      await linkPostToQuest(questId, { postId: newPost.id, parentId });
       appendToBoard?.(boardId, newPost);
       onSave?.(newPost);
     } catch (err) {

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -92,6 +92,7 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
           <QuickTaskForm
             questId={questId}
             boardId={`log-${questId}`}
+            parentId={linkedNodeId}
             onSave={(p) => {
               setItems((prev) => [...prev, p]);
               setShowForm(false);

--- a/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
+++ b/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
@@ -32,6 +32,7 @@ const TaskKanbanBoard: React.FC<TaskKanbanBoardProps> = ({ questId, linkedNodeId
         <QuickTaskForm
           questId={questId}
           boardId={`task-${linkedNodeId}`}
+          parentId={linkedNodeId}
           onSave={(p) => {
             setTasks((prev) => [...prev, p]);
             setShowForm(false);

--- a/ethos-frontend/tests/QuickTaskFormPersist.test.tsx
+++ b/ethos-frontend/tests/QuickTaskFormPersist.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TaskKanbanBoard from '../src/components/quest/TaskKanbanBoard';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  fetchPostsByQuestId: jest.fn(),
+  addPost: jest.fn(),
+}));
+
+jest.mock('../src/api/quest', () => ({
+  __esModule: true,
+  linkPostToQuest: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ appendToBoard: jest.fn() }),
+}));
+
+import { fetchPostsByQuestId, addPost } from '../src/api/post';
+import { linkPostToQuest } from '../src/api/quest';
+
+describe('QuickTaskForm persistence', () => {
+  it('keeps new subtask after reload', async () => {
+    const newPost = {
+      id: 't1',
+      type: 'task',
+      content: 'Sub',
+      visibility: 'public',
+      questId: 'q1',
+      replyTo: 'n1',
+    } as any;
+
+    (fetchPostsByQuestId as jest.Mock).mockResolvedValueOnce([]);
+    (addPost as jest.Mock).mockResolvedValueOnce(newPost);
+    (fetchPostsByQuestId as jest.Mock).mockResolvedValueOnce([newPost]);
+
+    const { rerender } = render(
+      <TaskKanbanBoard questId="q1" linkedNodeId="n1" />,
+    );
+
+    fireEvent.click(screen.getByText('+ Add Task'));
+    fireEvent.change(screen.getByPlaceholderText('Task name'), { target: { value: 'Sub' } });
+    fireEvent.click(screen.getByText('Add'));
+
+    await waitFor(() => expect(addPost).toHaveBeenCalled());
+    expect(linkPostToQuest).toHaveBeenCalledWith('q1', { postId: 't1', parentId: 'n1' });
+    expect(screen.getByText('Sub')).toBeInTheDocument();
+
+    rerender(<TaskKanbanBoard questId="q1" linkedNodeId="n1" />);
+    await waitFor(() => expect(fetchPostsByQuestId).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Sub')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- support linking to a parent task in `QuickTaskForm`
- pass new `parentId` prop from `TaskKanbanBoard` and `StatusBoardPanel`
- add a regression test ensuring subtasks persist across reloads

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest --runInBand`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68584ec6d73c832f96745760d009baa7