### PR TITLE
Fix subtask persistence

### DIFF
--- a/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
+++ b/ethos-frontend/src/components/quest/TaskKanbanBoard.tsx
@@ -26,6 +26,16 @@ const TaskKanbanBoard: React.FC<TaskKanbanBoardProps> = ({ questId, linkedNodeId
       });
   }, [questId, linkedNodeId]);
 
+  const refresh = () => {
+    fetchPostsByQuestId(questId)
+      .then((posts) => {
+        setTasks(posts.filter((p) => p.type === 'task' && p.replyTo === linkedNodeId));
+      })
+      .catch((err) => {
+        console.error('[TaskKanbanBoard] failed to load tasks', err);
+      });
+  };
+
   return (
     <div className="space-y-2">
       {showForm && (
@@ -36,6 +46,7 @@ const TaskKanbanBoard: React.FC<TaskKanbanBoardProps> = ({ questId, linkedNodeId
           onSave={(p) => {
             setTasks((prev) => [...prev, p]);
             setShowForm(false);
+            refresh();
           }}
           onCancel={() => setShowForm(false)}
         />


### PR DESCRIPTION
## Summary
- refresh TaskKanbanBoard after saving a new subtask

## Testing
- `npm test --silent --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6858526c1c4c832fbd3629c91b9e6333