### PR TITLE
Move timestamp to reaction row

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -55,6 +55,8 @@ interface ReactionControlsProps {
   boardId?: string;
   /** Notify parent when reply panel toggles */
   onReplyToggle?: (open: boolean) => void;
+  /** Optional timestamp to display */
+  timestamp?: string;
 }
 
 const ReactionControls: React.FC<ReactionControlsProps> = ({
@@ -65,6 +67,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   isTimeline,
   boardId,
   onReplyToggle,
+  timestamp,
 }) => {
   const [reactions, setReactions] = useState({ like: false, heart: false });
   const [counts, setCounts] = useState({ like: 0, heart: 0, repost: 0 });
@@ -333,6 +336,10 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           <button className="flex items-center gap-1" onClick={() => setExpanded(prev => !prev)}>
             {expanded ? <FaCompress /> : <FaExpand />} {expanded ? 'Collapse View' : 'Expand View'}
           </button>
+        )}
+
+        {timestamp && (
+          <span className="ml-auto text-xs text-secondary">{timestamp}</span>
         )}
 
       </div>

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -413,6 +413,7 @@ const PostCard: React.FC<PostCardProps> = ({
           onUpdate={onUpdate}
           replyOverride={replyOverride}
           boardId={ctxBoardId || undefined}
+          timestamp={timestamp}
         />
         {post.type === 'request' &&
           !isQuestBoardRequest &&
@@ -426,7 +427,6 @@ const PostCard: React.FC<PostCardProps> = ({
               {accepting ? 'Pending…' : accepted ? 'Pending' : 'Accept'}
             </button>
           )}
-        <div className="text-xs text-secondary text-right">{timestamp}</div>
       </div>
     );
   }
@@ -452,7 +452,6 @@ const PostCard: React.FC<PostCardProps> = ({
           {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
             <StatusBadge status={post.status} />
           )}
-          <span>{timestamp}</span>
           {!isQuestBoardRequest &&
             canEdit &&
             ['task', 'request', 'issue'].includes(post.type) &&
@@ -572,6 +571,7 @@ const PostCard: React.FC<PostCardProps> = ({
         onUpdate={onUpdate}
         replyOverride={replyOverride}
         boardId={ctxBoardId || undefined}
+        timestamp={timestamp}
         onReplyToggle={
           post.linkedItems && post.linkedItems.length > 0 ? setShowReplyForm : undefined
         }


### PR DESCRIPTION
## Summary
- add optional `timestamp` prop to `ReactionControls`
- display timestamp next to reaction buttons
- pass `timestamp` from `PostCard` and remove header timestamp

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm test --prefix ethos-backend` *(fails: missing supertest, bcryptjs)*

------
https://chatgpt.com/codex/tasks/task_e_68585339ccdc832fb5d0ba29bb17ae02