### PR TITLE
Fix task expansion and timestamp

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -21,6 +21,7 @@ import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
 import QuestNodeInspector from '../quest/QuestNodeInspector';
 import QuestCard from '../quest/QuestCard';
+import TaskGraphSidePanel from '../quest/TaskGraphSidePanel';
 import { fetchQuestById } from '../../api/quest';
 import {
   updateReaction,
@@ -77,6 +78,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [showReplyPanel, setShowReplyPanel] = useState(false);
   const [repostLoading, setRepostLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [showTaskGraph, setShowTaskGraph] = useState(false);
   const [completed, setCompleted] = useState(post.tags?.includes('archived') ?? false);
   const [joining, setJoining] = useState(false);
   const [joined, setJoined] = useState(
@@ -333,8 +335,30 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
 
         {(post.type === 'task' || post.type === 'commit' || post.type === 'quest') && (
-          <button className="flex items-center gap-1" onClick={() => setExpanded(prev => !prev)}>
-            {expanded ? <FaCompress /> : <FaExpand />} {expanded ? 'Collapse View' : 'Expand View'}
+          <button
+            className="flex items-center gap-1"
+            onClick={() => {
+              if (post.type === 'task') {
+                setShowTaskGraph((p) => !p);
+              } else {
+                setExpanded((prev) => !prev);
+              }
+            }}
+          >
+            {post.type === 'task'
+              ? showTaskGraph
+                ? <FaCompress />
+                : <FaExpand />
+              : expanded
+              ? <FaCompress />
+              : <FaExpand />}{' '}
+            {post.type === 'task'
+              ? showTaskGraph
+                ? 'Collapse View'
+                : 'Expand View'
+              : expanded
+              ? 'Collapse View'
+              : 'Expand View'}
           </button>
         )}
 
@@ -357,16 +381,15 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </div>
       )}
 
-      {expanded && post.type === 'task' && post.questId && (
-        <div className="mt-3">
-          <QuestNodeInspector
-            questId={post.questId}
-            node={post}
-            user={user}
-            showPost={false}
-          />
-        </div>
+      {showTaskGraph && post.type === 'task' && post.questId && (
+        <TaskGraphSidePanel
+          task={post}
+          questId={post.questId}
+          user={user}
+          onClose={() => setShowTaskGraph(false)}
+        />
       )}
+
 
       {expanded && post.type === 'commit' && (
         <div className="mt-3 text-sm">

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -166,8 +166,9 @@ const PostCard: React.FC<PostCardProps> = ({
 
 
   const canEdit = user?.id === post.authorId || post.collaborators?.some(c => c.userId === user?.id);
-  const timestamp = post.timestamp
-    ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
+  const ts = post.timestamp || post.createdAt;
+  const timestamp = ts
+    ? formatDistanceToNow(new Date(ts), { addSuffix: true })
     : 'Unknown time';
 
   const content = post.renderedContent || post.content;

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useMemo } from 'react';
+import GraphLayout from '../layout/GraphLayout';
+import { useGraph } from '../../hooks/useGraph';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+interface TaskGraphSidePanelProps {
+  task: Post;
+  questId: string;
+  user?: User;
+  onClose: () => void;
+}
+
+const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, user, onClose }) => {
+  const { nodes, edges, loadGraph } = useGraph();
+
+  useEffect(() => {
+    if (questId) {
+      loadGraph(questId);
+    }
+  }, [questId, loadGraph]);
+
+  const subgraphIds = useMemo(() => {
+    const ids = new Set<string>();
+    const gatherChildren = (id: string) => {
+      ids.add(id);
+      edges.filter(e => e.from === id).forEach(e => gatherChildren(e.to));
+    };
+    const gatherParents = (id: string) => {
+      edges.filter(e => e.to === id).forEach(e => {
+        if (!ids.has(e.from)) {
+          ids.add(e.from);
+          gatherParents(e.from);
+        }
+      });
+    };
+    gatherChildren(task.id);
+    gatherParents(task.id);
+    return ids;
+  }, [task.id, edges]);
+
+  const displayNodes = useMemo(() => nodes.filter(n => subgraphIds.has(n.id)), [nodes, subgraphIds]);
+  const displayEdges = useMemo(() => edges.filter(e => subgraphIds.has(e.from) && subgraphIds.has(e.to)), [edges, subgraphIds]);
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-full max-w-md bg-surface shadow-xl z-50 flex flex-col">
+      <div className="p-2 border-b border-secondary text-right">
+        <button className="text-xs underline" onClick={onClose}>Close</button>
+      </div>
+      <div className="flex-1 overflow-auto p-2">
+        <GraphLayout
+          items={displayNodes}
+          edges={displayEdges}
+          user={user}
+          questId={questId}
+          condensed
+          showInspector={false}
+          showStatus={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TaskGraphSidePanel;


### PR DESCRIPTION
## Summary
- show graph panel when expanding tasks
- always show timestamp fallback

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` in backend *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68585e4af628832fa79930b28c3b7c9e