### PR TITLE
Align timestamps on posts

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -243,7 +243,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
   return (
     <>
-      <div className="flex gap-4 items-center text-sm text-gray-500 dark:text-gray-400">
+      <div className="flex gap-4 items-center text-sm text-gray-500 dark:text-gray-400 w-full">
         <button
           className={clsx('flex items-center gap-1', reactions.like && 'text-blue-600')}
           onClick={() => handleToggleReaction('like')}

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -42,17 +42,21 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
       )}
       onClick={() => navigate(ROUTES.POST(post.id))}
     >
-      <div className="flex justify-between items-center">
-        <div className="text-sm font-semibold">
-          {header}
-          <span className="text-xs text-secondary ml-2">{timestamp}</span>
+      <div className="flex justify-between items-start">
+        <div>
+          <div className="text-sm font-semibold">{header}</div>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {summaryTags.map((tag, idx) => (
+              <SummaryTag key={idx} {...tag} />
+            ))}
+            {post.type === 'review' && post.rating && renderStars(post.rating)}
+          </div>
         </div>
-        <div className="flex flex-wrap gap-1 ml-2">
-          {summaryTags.map((tag, idx) => (
-            <SummaryTag key={idx} {...tag} />
-          ))}
-          {post.type === 'review' && post.rating && renderStars(post.rating)}
-        </div>
+        {timestamp && (
+          <span className="text-xs text-secondary whitespace-nowrap ml-2">
+            {timestamp}
+          </span>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep ReactionControls bar full-width so timestamps can align right
- show timestamps on the right side of PostListItem entries

## Testing
- `./setup.sh`
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68588f687978832faea581c6b180ce6d