### PR TITLE
Handle quest tags in node labels

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -31,7 +31,7 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
   const timestamp = post.timestamp
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
-  const header = getDisplayTitle(post);
+  const header = getDisplayTitle(post, post.questTitle);
   const summaryTags = buildSummaryTags(post);
 
   return (


### PR DESCRIPTION
## Summary
- make quest link label aware of quest name and omit it by default
- display node labels with quest info when quest summary tag present

## Testing
- `./setup.sh`
- `npx tsc -p tsconfig.json` in backend
- `npx tsc -p tsconfig.json` in frontend
- `npm test --prefix ../ethos-backend -- -w=1`
- `npm test -- -w=1`
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm run build` *(fails: TS errors in Board.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_685893498508832f959eccb00c3dd83b