### PR TITLE
Update quest & task panels

### DIFF
--- a/ethos-frontend/src/components/quest/FileEditorPanel.tsx
+++ b/ethos-frontend/src/components/quest/FileEditorPanel.tsx
@@ -10,14 +10,15 @@ interface FileEditorPanelProps {
 const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, content }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(content);
+  const [draft, setDraft] = useState(content + '\n');
   const [commitMsg, setCommitMsg] = useState('Update file');
   const lines = content.split('\n');
 
   const handleSave = () => {
-    // Placeholder save handler
-    console.log('Save file', filePath, commitMsg);
-    setEditing(false);
+    if (window.confirm('Commit these changes?')) {
+      console.log('Save file', filePath, commitMsg, draft);
+      setEditing(false);
+    }
   };
 
   if (editing) {
@@ -67,8 +68,7 @@ const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, co
               className="ml-1 text-accent underline text-xs"
               onClick={() => {
                 setEditing(true);
-                const allLines = draft.split('\n');
-                setDraft(allLines.map((l, i) => (i === idx ? line : l)).join('\n'));
+                setDraft(lines.join('\n') + '\n');
               }}
             >
               Edit
@@ -86,7 +86,13 @@ const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, co
           </div>
         ))}
       </pre>
-      <button onClick={() => setEditing(true)} className="mt-2 text-accent underline text-sm">
+      <button
+        onClick={() => {
+          setEditing(true);
+          setDraft(content + '\n');
+        }}
+        className="mt-2 text-accent underline text-sm"
+      >
         Edit File
       </button>
     </div>

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import GraphLayout from '../layout/GraphLayout';
 import { useGraph } from '../../hooks/useGraph';
+import TaskPreviewCard from '../post/TaskPreviewCard';
+import QuestNodeInspector from './QuestNodeInspector';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
@@ -13,6 +15,7 @@ interface TaskGraphSidePanelProps {
 
 const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, user, onClose }) => {
   const { nodes, edges, loadGraph } = useGraph();
+  const [selected, setSelected] = useState<Post>(task);
 
   useEffect(() => {
     if (questId) {
@@ -43,20 +46,30 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
   const displayEdges = useMemo(() => edges.filter(e => subgraphIds.has(e.from) && subgraphIds.has(e.to)), [edges, subgraphIds]);
 
   return (
-    <div className="fixed inset-y-0 right-0 w-full max-w-md bg-surface shadow-xl z-50 flex flex-col">
-      <div className="p-2 border-b border-secondary text-right">
+    <div className="fixed inset-0 md:inset-y-0 md:right-0 w-full md:max-w-3xl bg-surface shadow-xl z-50 flex flex-col">
+      <div className="p-2 border-b border-secondary flex justify-between items-center">
+        <span className="font-semibold text-sm truncate">{task.content}</span>
         <button className="text-xs underline" onClick={onClose}>Close</button>
       </div>
-      <div className="flex-1 overflow-auto p-2">
-        <GraphLayout
-          items={displayNodes}
-          edges={displayEdges}
-          user={user}
-          questId={questId}
-          condensed
-          showInspector={false}
-          showStatus={false}
-        />
+      <div className="flex-1 flex overflow-hidden">
+        <div className="flex-1 overflow-auto p-2 border-r border-secondary space-y-2">
+          <TaskPreviewCard post={selected} />
+          <div className="h-80 md:h-auto overflow-auto" data-testid="task-graph">
+            <GraphLayout
+              items={displayNodes}
+              edges={displayEdges}
+              user={user}
+              questId={questId}
+              condensed
+              showInspector={false}
+              showStatus={false}
+              onSelectNode={setSelected}
+            />
+          </div>
+        </div>
+        <div className="w-full md:w-80 overflow-auto">
+          <QuestNodeInspector questId={questId} node={selected} user={user} showPost={false} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify quest card tabs to just Logs and File/Folder/Planner
- confirm save in file editor and keep an empty line ready
- show graph and task preview with inspector when expanding a task

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858965af984832fbed8d1e218ee001a