### PR TITLE
Display quest board request timestamp

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
+import { jest } from '@jest/globals';
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
@@ -22,6 +23,14 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-02T00:00:00Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 const post: Post = {
   id: 'p1',
   authorId: 'u1',
@@ -29,7 +38,7 @@ const post: Post = {
   content: 'Help me',
   status: 'In Progress',
   visibility: 'public',
-  timestamp: '',
+  timestamp: '2023-01-01T00:00:00Z',
   tags: [],
   collaborators: [],
   linkedItems: [],
@@ -45,4 +54,5 @@ it('hides status controls and shows only request tag', () => {
   expect(screen.getByText('Request: @u1')).toBeInTheDocument();
   expect(screen.queryByText('In Progress')).toBeNull();
   expect(screen.queryByRole('combobox')).toBeNull();
+  expect(screen.getByText('1 day ago')).toBeInTheDocument();
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -400,6 +400,9 @@ const PostCard: React.FC<PostCardProps> = ({
             permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
           />
         </div>
+        {isQuestBoardRequest && timestamp && (
+          <div className="text-xs text-secondary mt-1">{timestamp}</div>
+        )}
         {titleText && (
           <h3
             className="font-semibold text-lg mt-1 cursor-pointer"
@@ -413,7 +416,7 @@ const PostCard: React.FC<PostCardProps> = ({
             post={post}
             user={user}
             onUpdate={onUpdate}
-            timestamp={timestamp}
+            timestamp={!isQuestBoardRequest ? timestamp : undefined}
             replyOverride={replyOverride}
             boardId={ctxBoardId || undefined}
           />
@@ -468,6 +471,9 @@ const PostCard: React.FC<PostCardProps> = ({
           permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
         />
       </div>
+      {isQuestBoardRequest && timestamp && (
+        <div className="text-xs text-secondary mt-1">{timestamp}</div>
+      )}
 
       {post.linkedNodeId && post.author?.username && !isQuestBoardRequest && (
         <div className="text-xs text-secondary italic">
@@ -562,7 +568,7 @@ const PostCard: React.FC<PostCardProps> = ({
         onUpdate={onUpdate}
         replyOverride={replyOverride}
         boardId={ctxBoardId || undefined}
-        timestamp={timestamp}
+        timestamp={!isQuestBoardRequest ? timestamp : undefined}
         onReplyToggle={
           post.linkedItems && post.linkedItems.length > 0 ? setShowReplyForm : undefined
         }


### PR DESCRIPTION
## Summary
- render timestamps for request posts on the quest board beneath the summary tag
- hide timestamp inside ReactionControls for quest board requests
- test quest board request timestamp placement

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_685899f4a240832f951054d446a18f55