### PR TITLE
Add hyperlink to quest board request summary tag

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -176,7 +176,15 @@ const PostCard: React.FC<PostCardProps> = ({
   let summaryTags = buildSummaryTags(post, questTitle, questId);
   if (isQuestBoardRequest) {
     const user = post.author?.username || post.authorId;
-    summaryTags = [{ type: 'request', label: `Request: @${user}` }];
+    summaryTags = [
+      {
+        type: 'request',
+        label: 'Request:',
+        detailLink: ROUTES.POST(post.id),
+        username: user,
+        usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
+      },
+    ];
   }
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;


### PR DESCRIPTION
## Summary
- add detail link for `Request:` tag on quest board requests so it links to the request post

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589a4447e4832f9842f39fc056c262