### PR TITLE
Sort my-posts board by newest first

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -50,6 +50,11 @@ router.get(
               p.type !== 'meta_system' &&
               p.systemGenerated !== true
           )
+          .sort((a, b) =>
+            (b.timestamp || b.createdAt || '').localeCompare(
+              a.timestamp || a.createdAt || ''
+            )
+          )
           .map(p => p.id);
         return { ...board, items: filtered };
       }
@@ -258,6 +263,11 @@ router.get(
             p.type !== 'meta_system' &&
             p.systemGenerated !== true
         )
+        .sort((a, b) =>
+          (b.timestamp || b.createdAt || '').localeCompare(
+            a.timestamp || a.createdAt || ''
+          )
+        )
         .map(p => p.id);
     } else if (userId && board.id === 'my-quests') {
       boardItems = quests.filter(q => q.authorId === userId).map(q => q.id);
@@ -363,6 +373,11 @@ router.get(
             p.authorId === userId &&
             p.type !== 'meta_system' &&
             p.systemGenerated !== true
+        )
+        .sort((a, b) =>
+          (b.timestamp || b.createdAt || '').localeCompare(
+            a.timestamp || a.createdAt || ''
+          )
         )
         .map(p => p.id);
     } else if (userId && board.id === 'my-quests') {


### PR DESCRIPTION
## Summary
- update backend board routes to sort posts in `my-posts` board by timestamp/creation date descending

## Testing
- `npm test --prefix ethos-backend --silent`
- `npm test --prefix ethos-frontend --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68589a83f910832f894b54d5d208e7a9