### PR TITLE
Change quest board request timestamps style

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -408,9 +408,11 @@ const PostCard: React.FC<PostCardProps> = ({
             permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
           />
         </div>
-        {isQuestBoardRequest && timestamp && (
-          <div className="text-xs text-secondary mt-1">{timestamp}</div>
-        )}
+          {isQuestBoardRequest && timestamp && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {timestamp}
+            </div>
+          )}
         {titleText && (
           <h3
             className="font-semibold text-lg mt-1 cursor-pointer"
@@ -480,7 +482,9 @@ const PostCard: React.FC<PostCardProps> = ({
         />
       </div>
       {isQuestBoardRequest && timestamp && (
-        <div className="text-xs text-secondary mt-1">{timestamp}</div>
+        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {timestamp}
+        </div>
       )}
 
       {post.linkedNodeId && post.author?.username && !isQuestBoardRequest && (


### PR DESCRIPTION
## Summary
- update quest board request timestamps to use gray text color

## Testing
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68589ddc50ec832fadd2ad77d5d358a2