### PR TITLE
fix timeline board root task ordering

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -236,7 +236,7 @@ router.get(
           let highlight = false;
           if (userId) {
             if (p.questId && userQuestIds.includes(p.questId)) {
-              weight = 2;
+              weight = p.type === 'task' ? 3 : 2;
               if (p.type === 'task') highlight = true;
             } else if (
               p.linkedItems?.some(
@@ -347,7 +347,7 @@ router.get(
           let highlight = false;
           if (userId) {
             if (p.questId && userQuestIds.includes(p.questId)) {
-              weight = 2;
+              weight = p.type === 'task' ? 3 : 2;
               if (p.type === 'task') highlight = true;
             } else if (
               p.linkedItems?.some(


### PR DESCRIPTION
## Summary
- prioritize task nodes when building timeline board

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858a41abc20832f9a0050725fcd5bd4