### PR TITLE
Fix ActiveQuestBoard quest ownership display

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -182,7 +182,7 @@ const ActiveQuestBoard: React.FC = () => {
                   : 'scale-90 opacity-50')
               }
             >
-              <QuestCard quest={q} />
+              <QuestCard quest={q} user={user} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- ensure ActiveQuestBoard passes the current user to QuestCard so that ownership status is detected

## Testing
- `npm test` (fails: jest-environment-jsdom not found)
- `cd ethos-backend && npm test` (fails: supertest module not found)


------
https://chatgpt.com/codex/tasks/task_e_6858a6a66964832fad3e24a397863b13