### PR TITLE
Enable inline task expansion

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -19,9 +19,8 @@ import {
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
-import QuestNodeInspector from '../quest/QuestNodeInspector';
 import QuestCard from '../quest/QuestCard';
-import TaskGraphSidePanel from '../quest/TaskGraphSidePanel';
+import TaskCard from '../quest/TaskCard';
 import { fetchQuestById } from '../../api/quest';
 import {
   updateReaction,
@@ -382,12 +381,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       )}
 
       {showTaskGraph && post.type === 'task' && post.questId && (
-        <TaskGraphSidePanel
-          task={post}
-          questId={post.questId}
-          user={user}
-          onClose={() => setShowTaskGraph(false)}
-        />
+        <div className="mt-3">
+          <TaskCard task={post} questId={post.questId} user={user} />
+        </div>
       )}
 
 

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import GraphLayout from '../layout/GraphLayout';
+import { useGraph } from '../../hooks/useGraph';
+import TaskPreviewCard from '../post/TaskPreviewCard';
+import QuestNodeInspector from './QuestNodeInspector';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+interface TaskCardProps {
+  task: Post;
+  questId: string;
+  user?: User;
+}
+
+const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user }) => {
+  const { nodes, edges, loadGraph } = useGraph();
+  const [selected, setSelected] = useState<Post>(task);
+
+  useEffect(() => {
+    if (questId) {
+      loadGraph(questId);
+    }
+  }, [questId, loadGraph]);
+
+  const subgraphIds = useMemo(() => {
+    const ids = new Set<string>();
+    const gatherChildren = (id: string) => {
+      ids.add(id);
+      edges.filter(e => e.from === id).forEach(e => gatherChildren(e.to));
+    };
+    const gatherParents = (id: string) => {
+      edges.filter(e => e.to === id).forEach(e => {
+        if (!ids.has(e.from)) {
+          ids.add(e.from);
+          gatherParents(e.from);
+        }
+      });
+    };
+    gatherChildren(task.id);
+    gatherParents(task.id);
+    return ids;
+  }, [task.id, edges]);
+
+  const displayNodes = useMemo(() => nodes.filter(n => subgraphIds.has(n.id)), [nodes, subgraphIds]);
+  const displayEdges = useMemo(() => edges.filter(e => subgraphIds.has(e.from) && subgraphIds.has(e.to)), [edges, subgraphIds]);
+
+  return (
+    <div className="border border-secondary rounded-lg bg-surface p-4 space-y-2">
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex-1 space-y-2">
+          <TaskPreviewCard post={selected} />
+          <div className="h-80 overflow-auto" data-testid="task-graph-inline">
+            <GraphLayout
+              items={displayNodes}
+              edges={displayEdges}
+              user={user}
+              questId={questId}
+              condensed
+              showInspector={false}
+              showStatus={false}
+              onSelectNode={setSelected}
+            />
+          </div>
+        </div>
+        <div className="w-full md:w-80 overflow-auto">
+          <QuestNodeInspector questId={questId} node={selected} user={user} showPost={false} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TaskCard;


### PR DESCRIPTION
## Summary
- add `TaskCard` component for inline task details
- integrate `TaskCard` in `ReactionControls` when expanding a task
- keep quest expansion behaviour the same

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm run lint --prefix ethos-frontend` *(fails: 15 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858a7951e88832f9267767fdfbd4280