### PR TITLE
Fix username display on Recent Activity board

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -72,10 +72,23 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
     // Display quests on timeline and post history boards like regular posts for consistency
     if (boardId === 'timeline-board' || boardId === 'my-posts') {
       const headPost = (quest as any).headPost as Post | undefined;
-      const postLike = headPost ?? ({
+      const enrichedHeadPost = headPost
+        ? {
+            ...headPost,
+            author:
+              headPost.author ||
+              (quest.author
+                ? { id: quest.author.id, username: quest.author.username }
+                : undefined),
+          }
+        : undefined;
+      const postLike = enrichedHeadPost ?? ({
         id: quest.headPostId,
         type: 'quest',
         authorId: quest.authorId,
+        author: quest.author
+          ? { id: quest.author.id, username: quest.author.username }
+          : undefined,
         content: quest.title,
         visibility: 'public',
         timestamp: quest.createdAt || '',


### PR DESCRIPTION
## Summary
- ensure quest posts rendered on the timeline board include author info so username tags show instead of raw IDs

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6858ab514ec8832f8ea5ded3d0e3c60a