### PR TITLE
Prevent duplicate quest names ignoring spaces/case

### DIFF
--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -108,6 +108,16 @@ router.post('/', authMiddleware, (req: AuthRequest, res: Response): void => {
     return;
   }
 
+  const existingQuests = questsStore.read();
+  const normalize = (t: string): string => t.replace(/\s+/g, '').toLowerCase();
+  const duplicate = existingQuests.some(
+    (q) => normalize(q.title) === normalize(title)
+  );
+  if (duplicate) {
+    res.status(400).json({ error: 'Quest title already exists' });
+    return;
+  }
+
   const newQuest: Quest = {
     id: uuidv4(),
     authorId,

--- a/ethos-backend/tests/questCreation.test.ts
+++ b/ethos-backend/tests/questCreation.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express from 'express';
+
+import questRoutes from '../src/routes/questRoutes';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => { _req.user = { id: 'u1' }; next(); }
+}));
+
+jest.mock('../src/models/stores', () => ({
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
+  postsStore: { read: jest.fn(() => []), write: jest.fn() },
+  boardsStore: { read: jest.fn(() => []), write: jest.fn() },
+}));
+
+import { questsStore, postsStore, boardsStore } from '../src/models/stores';
+
+const questsStoreMock = questsStore as jest.Mocked<any>;
+const postsStoreMock = postsStore as jest.Mocked<any>;
+const boardsStoreMock = boardsStore as jest.Mocked<any>;
+
+const app = express();
+app.use(express.json());
+app.use('/quests', questRoutes);
+
+describe('quest creation', () => {
+  beforeEach(() => {
+    postsStoreMock.read.mockReturnValue([]);
+    boardsStoreMock.read.mockReturnValue([]);
+    postsStoreMock.write.mockClear();
+    questsStoreMock.write.mockClear();
+  });
+
+  it('rejects duplicate quest titles ignoring spaces and capitals', async () => {
+    questsStoreMock.read.mockReturnValue([
+      {
+        id: 'q1',
+        authorId: 'u1',
+        title: 'MyQuest',
+        status: 'active',
+        headPostId: '',
+        linkedPosts: [],
+        collaborators: [],
+        taskGraph: [],
+      },
+    ]);
+
+    const res = await request(app).post('/quests').send({ title: 'my quest' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- disallow creating quests with duplicate titles (ignoring spacing and capitalization)
- add regression test

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_6858ad9e82a0832fad7e42b670d912a4