### PR TITLE
Open replies on post board pages

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -85,9 +85,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   );
   const [questData, setQuestData] = useState<Quest | null>(null);
   const navigate = useNavigate();
-  const { selectedBoard, appendToBoard } = useBoardContext() || {};
+  const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   const ctxBoardId = boardId || selectedBoard;
+  const ctxBoardType = ctxBoardId ? boards?.[ctxBoardId]?.boardType : undefined;
   const isTimelineBoard = isTimeline ?? ctxBoardId === 'timeline-board';
+  const isPostHistory = ctxBoardId === 'my-posts';
+  const isPostBoard = isPostHistory || ctxBoardType === 'post';
   const isQuestRequest = ctxBoardId === 'quest-board' && post.type === 'request';
   const isRequestCard =
     post.type === 'request' &&
@@ -309,9 +312,11 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               replyOverride.onClick();
             } else if (post.type === 'commit') {
               navigate(ROUTES.POST(post.id));
-            } else if (post.type === 'request') {
-              navigate(ROUTES.POST(post.id) + '?reply=1');
-            } else if (isTimelineBoard) {
+            } else if (
+              post.type === 'request' ||
+              isTimelineBoard ||
+              isPostBoard
+            ) {
               navigate(ROUTES.POST(post.id) + '?reply=1');
             } else {
               setShowReplyPanel(prev => {


### PR DESCRIPTION
## Summary
- ensure ReactionControls knows board types from context
- redirect Reply actions from post history and post boards to the post page with `?reply=1`

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858af320048832fa29638aa7f295374