### PR TITLE
Add team tab and collapsible task form

### DIFF
--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -13,6 +13,7 @@ interface QuickTaskFormProps {
   parentId?: string;
   onSave?: (post: Post) => void;
   onCancel: () => void;
+  allowIssue?: boolean;
 }
 
 const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
@@ -22,11 +23,13 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
   parentId,
   onSave,
   onCancel,
+  allowIssue = false,
 }) => {
   const [title, setTitle] = useState('');
   const [taskType, setTaskType] = useState<'file' | 'folder'>('file');
   const [taskStatus, setTaskStatus] = useState(status || 'To Do');
   const [submitting, setSubmitting] = useState(false);
+  const [postType, setPostType] = useState<'task' | 'issue'>('task');
   const { appendToBoard } = useBoardContext() || {};
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -36,7 +39,7 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
     setSubmitting(true);
     try {
       const newPost = await addPost({
-        type: 'task',
+        type: postType,
         content: title,
         visibility: 'public',
         questId,
@@ -76,6 +79,16 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
         placeholder="Task name"
         required
       />
+      {allowIssue && (
+        <Select
+          value={postType}
+          onChange={(e) => setPostType(e.target.value as 'task' | 'issue')}
+          options={[
+            { value: 'task', label: 'Task' },
+            { value: 'issue', label: 'Issue' },
+          ]}
+        />
+      )}
       <Select
         value={taskType}
         onChange={(e) => setTaskType(e.target.value as 'file' | 'folder')}

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -6,6 +6,7 @@ import LogThreadPanel from './LogThreadPanel';
 import FileEditorPanel from './FileEditorPanel';
 import TaskKanbanBoard from './TaskKanbanBoard';
 import QuickTaskForm from '../post/QuickTaskForm';
+import TeamPanel from './TeamPanel';
 import { useGraph } from '../../hooks/useGraph';
 import { Select } from '../ui';
 import { updatePost } from '../../api/post';
@@ -28,7 +29,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   showLogs = true,
 }) => {
   const [type, setType] = useState<string>(node?.taskType || 'abstract');
-  const [activeTab, setActiveTab] = useState<'logs' | 'file'>('logs');
+  const [activeTab, setActiveTab] = useState<'logs' | 'file' | 'team'>('logs');
   const [showSubtaskForm, setShowSubtaskForm] = useState(false);
   const { loadGraph } = useGraph();
 
@@ -60,6 +61,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
       value: 'file',
       label: type === 'file' ? 'File' : type === 'folder' ? 'Folder' : 'Planner',
     },
+    { value: 'team', label: 'Team' },
   ];
 
   const handleAddSubtask = () => {
@@ -88,6 +90,9 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
           )}
         </div>
       );
+      break;
+    case 'team':
+      panel = <TeamPanel questId={questId} node={node} />;
       break;
     default:
       panel = null;
@@ -119,19 +124,22 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
               {t.label}
             </button>
           ))}
+        {activeTab === 'file' && (
           <button
             onClick={handleAddSubtask}
             className="ml-auto px-2 text-accent underline whitespace-nowrap"
           >
-            + Add Item
+            {showSubtaskForm ? '- Cancel Item' : '+ Add Item'}
           </button>
-        </div>
-        {showSubtaskForm && (
+        )}
+      </div>
+        {showSubtaskForm && activeTab === 'file' && (
           <div className="mt-2">
             <QuickTaskForm
               questId={questId}
               parentId={node.id}
-              boardId={`map-${questId}`}
+              boardId={`task-${node.id}`}
+              allowIssue
               onSave={() => {
                 setShowSubtaskForm(false);
                 loadGraph(questId);


### PR DESCRIPTION
## Summary
- enable QuickTaskForm to create issues
- show a team tab in node inspector
- add collapsible add-item panel for planner/file/folder tab

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858b921433c832fbb2d5620b812fad5