### PR TITLE
Adjust quest card layout and add collapsible board

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -283,34 +283,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
         {selectedNode && (
           <div className="space-y-2">
             <TaskPreviewCard post={selectedNode} />
-            {showTaskForm && (
-              <CreatePost
-                initialType="task"
-                questId={quest.id}
-                boardId={`map-${quest.id}`}
-                replyTo={selectedNode}
-                onSave={(p) => {
-                  setLogs((prev) => [...prev, p]);
-                  setShowTaskForm(false);
-                }}
-                onCancel={() => setShowTaskForm(false)}
-              />
-            )}
-            <div className="text-right">
-              {canEdit ? (
-                <Button
-                  size="sm"
-                  variant="contrast"
-                  onClick={() => setShowTaskForm(true)}
-                >
-                  Add Subtask
-                </Button>
-              ) : (
-                <Button size="sm" variant="contrast" onClick={handleJoinRequest}>
-                  Request to Join
-                </Button>
-              )}
-            </div>
           </div>
         )}
         <hr className="border-secondary" />
@@ -339,7 +311,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
             </button>
           </div>
         </div>
-        <div className="h-80 overflow-auto" data-testid="quest-map-canvas">
+        <hr className="border-secondary" />
+        <div className="h-60 overflow-auto" data-testid="quest-map-canvas">
           {canvas}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove Add Subtask button in quest map view
- add horizontal dividers and adjust map canvas height
- switch right panel tab when task type changes
- add collapsible Kanban board with Add Item button in node inspector

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858bc68bfb4832f86e9300d8c5e7212