### PR TITLE
Add Team management tab to QuestCard

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -22,6 +22,7 @@ import { getRank } from '../../utils/rankUtils';
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
 import LogThreadPanel from './LogThreadPanel';
 import QuickTaskForm from '../post/QuickTaskForm';
+import TeamPanel from './TeamPanel';
 
 
 /**
@@ -49,7 +50,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   defaultExpanded = false,
 }) => {
   const [mapMode, setMapMode] = useState<'folder' | 'graph'>('graph');
-  const [activeTab, setActiveTab] = useState<'logs' | 'file'>('logs');
+  const [activeTab, setActiveTab] = useState<'logs' | 'file' | 'team'>('logs');
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [questData, setQuestData] = useState<Quest>(quest);
   const [logs, setLogs] = useState<Post[]>([]);
@@ -87,6 +88,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
           ? 'Folder'
           : 'Planner',
     },
+    { value: 'team', label: 'Team' },
   ];
 
   const isOwner = user?.id === questData.authorId;
@@ -426,6 +428,13 @@ const QuestCard: React.FC<QuestCardProps> = ({
         break;
       case 'file':
         panel = renderFileView();
+        break;
+      case 'team':
+        panel = selectedNode || rootNode ? (
+          <TeamPanel questId={quest.id} node={selectedNode || (rootNode as Post)} />
+        ) : (
+          <div className="p-2 text-sm">Select a task</div>
+        );
         break;
       default:
         panel = null;


### PR DESCRIPTION
## Summary
- add TeamPanel import and tab option in `QuestCard`
- support `team` tab rendering in the quest card panel

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6858bd2c8ad4832f925d54952add24c1