### PR TITLE
Add collapsible kanban panel

### DIFF
--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -76,7 +76,7 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
       <Input
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="Task name"
+        placeholder="Item name"
         required
       />
       {allowIssue && (

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -30,7 +30,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
 }) => {
   const [type, setType] = useState<string>(node?.taskType || 'abstract');
   const [activeTab, setActiveTab] = useState<'logs' | 'file' | 'team'>('logs');
-  const [showSubtaskForm, setShowSubtaskForm] = useState(false);
+  const [showKanban, setShowKanban] = useState(false);
   const { loadGraph } = useGraph();
 
   useEffect(() => {
@@ -64,8 +64,8 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     { value: 'team', label: 'Team' },
   ];
 
-  const handleAddSubtask = () => {
-    setShowSubtaskForm((p) => !p);
+  const handleToggleKanban = () => {
+    setShowKanban((p) => !p);
   };
 
   let panel: React.ReactNode = null;
@@ -76,11 +76,26 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     case 'file':
       panel = (
         <div className="space-y-2">
-          <TaskKanbanBoard
-            questId={questId}
-            linkedNodeId={node.id}
-            user={user}
-          />
+          {showKanban && (
+            <div className="space-y-2">
+              <TaskKanbanBoard
+                questId={questId}
+                linkedNodeId={node.id}
+                user={user}
+              />
+              <QuickTaskForm
+                questId={questId}
+                parentId={node.id}
+                boardId={`task-${node.id}`}
+                allowIssue
+                onSave={() => {
+                  setShowKanban(false);
+                  loadGraph(questId);
+                }}
+                onCancel={() => setShowKanban(false)}
+              />
+            </div>
+          )}
           {type === 'file' && (
             <FileEditorPanel
               questId={questId}
@@ -126,28 +141,13 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
           ))}
         {activeTab === 'file' && (
           <button
-            onClick={handleAddSubtask}
+            onClick={handleToggleKanban}
             className="ml-auto px-2 text-accent underline whitespace-nowrap"
           >
-            {showSubtaskForm ? '- Cancel Item' : '+ Add Item'}
+            {showKanban ? '- Cancel Item' : '+ Add Item'}
           </button>
         )}
       </div>
-        {showSubtaskForm && activeTab === 'file' && (
-          <div className="mt-2">
-            <QuickTaskForm
-              questId={questId}
-              parentId={node.id}
-              boardId={`task-${node.id}`}
-              allowIssue
-              onSave={() => {
-                setShowSubtaskForm(false);
-                loadGraph(questId);
-              }}
-              onCancel={() => setShowSubtaskForm(false)}
-            />
-          </div>
-        )}
         <div className="mt-2">{panel}</div>
       </div>
     </div>

--- a/ethos-frontend/tests/QuickTaskFormPersist.test.tsx
+++ b/ethos-frontend/tests/QuickTaskFormPersist.test.tsx
@@ -41,7 +41,7 @@ describe('QuickTaskForm persistence', () => {
     );
 
     fireEvent.click(screen.getByText('+ Add Task'));
-    fireEvent.change(screen.getByPlaceholderText('Task name'), { target: { value: 'Sub' } });
+    fireEvent.change(screen.getByPlaceholderText('Item name'), { target: { value: 'Sub' } });
     fireEvent.click(screen.getByText('Add'));
 
     await waitFor(() => expect(addPost).toHaveBeenCalled());


### PR DESCRIPTION
## Summary
- introduce `showKanban` state in `QuestNodeInspector`
- wrap kanban board and quick add form in a collapsible container
- toggle kanban visibility with an "Add Item" button in the tab bar

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6858bd2d5348832f8b544fe071975330