### PR TITLE
Update quest node update handling

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -122,6 +122,14 @@ const QuestCard: React.FC<QuestCardProps> = ({
     }
   };
 
+  const handleSelectedNodeUpdate = (updated: Post) => {
+    setSelectedNode(updated);
+    setLogs(prev => prev.map(p => (p.id === updated.id ? { ...p, ...updated } : p)));
+    if (rootNode?.id === updated.id) {
+      setRootNode(updated);
+    }
+  };
+
   const handleDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     const startX = e.clientX;
     const startWidth = mapWidth;
@@ -282,7 +290,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       <div className="space-y-2">
         {selectedNode && (
           <div className="space-y-2">
-            <TaskPreviewCard post={selectedNode} />
+            <TaskPreviewCard post={selectedNode} onUpdate={handleSelectedNodeUpdate} />
             {showTaskForm && (
               <CreatePost
                 initialType="task"


### PR DESCRIPTION
## Summary
- allow QuestCard to refresh selected node state from TaskPreviewCard
- update TaskPreviewCard usage to pass through onUpdate handler

## Testing
- `npm test -- -w=1` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_6858bd2ddcbc832f909da56bfb1f87bf