### PR TITLE
Update quest map layout separators

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -283,6 +283,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
         {selectedNode && (
           <div className="space-y-2">
             <TaskPreviewCard post={selectedNode} />
+            <hr className="border-secondary" />
             {showTaskForm && (
               <CreatePost
                 initialType="task"
@@ -313,7 +314,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
             </div>
           </div>
         )}
-        <hr className="border-secondary" />
         <div className="flex justify-between items-center text-sm">
           <div className="flex gap-1">
             <span className="font-semibold">View: </span>
@@ -339,7 +339,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
             </button>
           </div>
         </div>
-        <div className="h-80 overflow-auto" data-testid="quest-map-canvas">
+        <hr className="border-secondary" />
+        <hr className="border-secondary" />
+        <div className="h-64 overflow-auto" data-testid="quest-map-canvas">
           {canvas}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add inline separators for task preview sections
- move and duplicate hr elements for map view layout
- shorten quest map container height

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bd2e2848832fa404203064f63081