### PR TITLE
Fix quest canvas height

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -317,7 +317,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           "overflow-auto w-full h-full p-4 max-w-7xl mx-auto " +
           (rootNodes.length === 1 ? "flex justify-center" : "")
         }
-        style={{ minHeight: "60vh", maxHeight: "80vh", position: "relative" }}
+        style={{ minHeight: "40vh", maxHeight: "60vh", position: "relative" }}
       >
         <svg
           className="absolute top-0 left-0 w-full h-full pointer-events-none"

--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -131,7 +131,7 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
     <div
       ref={containerRef}
       className="overflow-auto w-full h-full p-2 max-w-7xl mx-auto"
-      style={{ minHeight: '60vh', maxHeight: '80vh', border: '1px solid #ccc', position: 'relative' }}
+      style={{ minHeight: '40vh', maxHeight: '60vh', border: '1px solid #ccc', position: 'relative' }}
     >
       <button
         type="button"


### PR DESCRIPTION
## Summary
- shorten the graph display's canvas height so expanded quest cards fit within their panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858c37a7fc4832f97eddd737d31052c