### PR TITLE
Add summary link in task preview

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import { Select, StatusBadge } from '../ui';
+import { Select, StatusBadge, SummaryTag } from '../ui';
 import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
 import type { option } from '../../constants/options';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
+import { buildSummaryTags } from '../../utils/displayUtils';
+import { ROUTES } from '../../constants/routes';
 
 interface TaskPreviewCardProps {
   post: Post;
@@ -29,9 +31,24 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate }) => 
     onUpdate?.({ ...post, taskType: val });
   };
 
+  const summaryTags = buildSummaryTags(post);
+  let taskTag = summaryTags.find(t => t.type === 'task');
+  if (!taskTag && post.nodeId) {
+    taskTag = {
+      type: 'task',
+      label: `Task: ${post.nodeId}`,
+      detailLink: ROUTES.POST(post.id),
+    } as any;
+  }
+
   return (
     <div className="border border-secondary rounded bg-surface p-2 text-xs space-y-1">
       <div className="font-semibold text-sm">{post.content}</div>
+      {taskTag && (
+        <div className="flex flex-wrap gap-1">
+          <SummaryTag {...taskTag} />
+        </div>
+      )}
       {post.gitFilePath && (
         <div className="text-secondary">{post.gitFilePath}</div>
       )}


### PR DESCRIPTION
## Summary
- show summary tag in TaskPreviewCard even when the node is the quest root

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858c3c2c0c4832f9ff1bf5363a54e5c