### PR TITLE
Add summary tag and clickable header

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -1,13 +1,21 @@
 import React, { useState } from 'react';
-import { Select, StatusBadge } from '../ui';
+import { Link } from 'react-router-dom';
+import { Select, StatusBadge, SummaryTag } from '../ui';
 import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
 import type { option } from '../../constants/options';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
+import { buildSummaryTags } from '../../utils/displayUtils';
+import { ROUTES } from '../../constants/routes';
 
 interface TaskPreviewCardProps {
   post: Post;
   onUpdate?: (updated: Post) => void;
 }
+
+const makeHeader = (content: string): string => {
+  const text = content.trim();
+  return text.length <= 50 ? text : text.slice(0, 50) + '…';
+};
 
 const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate }) => {
   const [status, setStatus] = useState<QuestTaskStatus>(post.status || 'To Do');
@@ -29,9 +37,31 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate }) => 
     onUpdate?.({ ...post, taskType: val });
   };
 
+  const summaryTags = buildSummaryTags(post);
+  let taskTag = summaryTags.find(t => t.type === 'task');
+  if (!taskTag) {
+    const label = post.nodeId ? `Task: ${post.nodeId}` : 'Task';
+    taskTag = {
+      type: 'task',
+      label,
+      detailLink: ROUTES.POST(post.id),
+    } as any;
+  }
+
+  const headerText = post.questNodeTitle || makeHeader(post.content);
+
   return (
     <div className="border border-secondary rounded bg-surface p-2 text-xs space-y-1">
-      <div className="font-semibold text-sm">{post.content}</div>
+      {taskTag && (
+        <div className="flex flex-wrap gap-1">
+          <SummaryTag {...taskTag} />
+        </div>
+      )}
+      <div className="font-semibold text-sm truncate">
+        <Link to={ROUTES.POST(post.id)} className="hover:underline">
+          {headerText}
+        </Link>
+      </div>
       {post.gitFilePath && (
         <div className="text-secondary">{post.gitFilePath}</div>
       )}


### PR DESCRIPTION
## Summary
- show fallback task tag when none exists
- move summary tag above header and link header to post
- trim long header text

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858c3c2c0c4832f9ff1bf5363a54e5c