### PR TITLE
Update quest card graph view and folder board

### DIFF
--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -93,6 +93,7 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
             questId={questId}
             boardId={`log-${questId}`}
             parentId={linkedNodeId}
+            allowIssue
             onSave={(p) => {
               setItems((prev) => [...prev, p]);
               setShowForm(false);


### PR DESCRIPTION
## Summary
- update quest card to show only graph map
- add canvas link under the map
- show QuickTaskForm for folders and include status board
- allow issue type creation on status boards

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-react-hooks')*
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6858cb844b74832fa5f84ed9e4cb4052