### PR TITLE
Add hideToggle prop for QuestCard

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -408,7 +408,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       {expanded && post.type === 'quest' && post.questId && (
         <div className="mt-3">
           {questData ? (
-            <QuestCard quest={questData} user={user} defaultExpanded />
+            <QuestCard quest={questData} user={user} defaultExpanded hideToggle />
           ) : (
             <div className="text-sm">Loading...</div>
           )}

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -38,6 +38,8 @@ interface QuestCardProps {
   onCancel?: () => void;
   isEditing?: boolean;
   defaultExpanded?: boolean;
+  /** Hide the built-in expand/collapse toggle button */
+  hideToggle?: boolean;
 }
 
 const QuestCard: React.FC<QuestCardProps> = ({
@@ -48,6 +50,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   onEdit,
   onCancel,
   defaultExpanded = false,
+  hideToggle = false,
 }) => {
   const [mapMode, setMapMode] = useState<'folder' | 'graph'>('graph');
   const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('logs');
@@ -215,20 +218,22 @@ const QuestCard: React.FC<QuestCardProps> = ({
       </div>
 
       <div className="flex gap-2 mt-2 md:mt-0 items-center flex-wrap">
-        <Button
-          variant="ghost"
-          onClick={() => {
-            if (expanded) {
-              setExpanded(false);
-            } else {
-              setExpanded(true);
-              setActiveTab('logs');
-              setMapMode('folder');
-            }
-          }}
-        >
-          {expanded ? "▲ Collapse" : "▼ Expand"}
-        </Button>
+        {!hideToggle && (
+          <Button
+            variant="ghost"
+            onClick={() => {
+              if (expanded) {
+                setExpanded(false);
+              } else {
+                setExpanded(true);
+                setActiveTab('logs');
+                setMapMode('folder');
+              }
+            }}
+          >
+            {expanded ? "▲ Collapse" : "▼ Expand"}
+          </Button>
+        )}
 
         <ActionMenu
           type="quest"


### PR DESCRIPTION
## Summary
- allow QuestCard to hide its expand/collapse button
- hide the toggle when a quest is expanded via ReactionControls

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858cc397b2c832f953fab738651964b