### PR TITLE
Improve planner default tab and status board

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -255,7 +255,9 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               key={col}
               className="min-w-[280px] w-[320px] flex-shrink-0 bg-surface border border-secondary rounded-lg p-4 shadow-sm"
             >
-              <h3 className="text-sm font-bold text-secondary mb-2">{col}</h3>
+              <h3 className="text-sm font-bold text-secondary mb-2">
+                {col} ({grouped[col].length})
+              </h3>
               <DroppableColumn id={col}>
                 {grouped[col].map((item) => (
                   <DraggableCard

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -51,7 +51,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   defaultExpanded = false,
   hideToggle = false,
 }) => {
-  const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('logs');
+  const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('file');
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [questData, setQuestData] = useState<Quest>(quest);
   const [logs, setLogs] = useState<Post[]>([]);
@@ -307,6 +307,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
     if (isFolder) {
       return (
         <div className="text-sm p-2 space-y-2">
+          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
           <div className="flex items-center justify-between">
             <div className="font-semibold">Folder: {selectedNode.content}</div>
             <button
@@ -334,18 +335,17 @@ const QuestCard: React.FC<QuestCardProps> = ({
               <li key={c.id}>{c.content}</li>
             ))}
           </ul>
-          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
         </div>
       );
     }
     return (
       <div className="space-y-2 p-2">
+        <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
         <FileEditorPanel
           questId={quest.id}
           filePath={selectedNode.gitFilePath || 'file.txt'}
           content={selectedNode.content}
         />
-        <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
       </div>
     );
   };

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -21,6 +21,7 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
   const [items, setItems] = useState<Post[]>([]);
   const [filter, setFilter] = useState<'all' | 'issues' | 'tasks'>('all');
   const [showForm, setShowForm] = useState(false);
+  const [open, setOpen] = useState(true);
 
 
   useEffect(() => {
@@ -49,87 +50,109 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNode
   const grouped = STATUS_OPTIONS.reduce<Record<string, Post[]>>((acc, opt) => {
     acc[opt.value] = filtered.filter((i) => i.status === opt.value);
     return acc;
-  }, {});
+  }, {} as Record<string, Post[]>);
+
+  const doneCount = grouped['Done']?.length ?? 0;
+  const totalCount = filtered.length;
 
   return (
-    <div>
-      <div className="flex justify-between items-start mb-2">
-        <div className="flex gap-2 text-xs">
-          <button
-            className={`px-2 py-0.5 rounded border ${
-              filter === 'all' ? 'bg-accent text-white border-accent' : 'border-secondary'
-            }`}
-            onClick={() => setFilter('all')}
-          >
-            All
-          </button>
-          <button
-            className={`px-2 py-0.5 rounded border ${
-              filter === 'issues' ? 'bg-accent text-white border-accent' : 'border-secondary'
-            }`}
-            onClick={() => setFilter('issues')}
-          >
-            Issues
-          </button>
-          <button
-            className={`px-2 py-0.5 rounded border ${
-              filter === 'tasks' ? 'bg-accent text-white border-accent' : 'border-secondary'
-            }`}
-            onClick={() => setFilter('tasks')}
-          >
-            Tasks
-          </button>
+    <div className="border border-secondary rounded">
+      <div
+        className="flex justify-between items-center p-2 bg-soft cursor-pointer"
+        onClick={() => setOpen((p) => !p)}
+      >
+        <span className="font-semibold text-sm">Status Board</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs">
+            {doneCount}/{totalCount} Done
+          </span>
+          <span className="text-xs">{open ? '▲' : '▼'}</span>
         </div>
-        <button
-          className="text-xs text-accent underline"
-          onClick={() => setShowForm((p) => !p)}
-        >
-          {showForm ? '- Cancel' : '+ Add Item'}
-        </button>
       </div>
-      {showForm && (
-        <div className="mb-2">
-          <QuickTaskForm
-            questId={questId}
-            boardId={`log-${questId}`}
-            parentId={linkedNodeId}
-            allowIssue
-            onSave={(p) => {
-              setItems((prev) => [...prev, p]);
-              setShowForm(false);
-            }}
-            onCancel={() => setShowForm(false)}
-          />
+      {open && (
+        <div className="p-2 space-y-2">
+          <div className="flex justify-between items-start">
+            <div className="flex gap-2 text-xs">
+              <button
+                className={`px-2 py-0.5 rounded border ${
+                  filter === 'all' ? 'bg-accent text-white border-accent' : 'border-secondary'
+                }`}
+                onClick={() => setFilter('all')}
+              >
+                All
+              </button>
+              <button
+                className={`px-2 py-0.5 rounded border ${
+                  filter === 'issues' ? 'bg-accent text-white border-accent' : 'border-secondary'
+                }`}
+                onClick={() => setFilter('issues')}
+              >
+                Issues
+              </button>
+              <button
+                className={`px-2 py-0.5 rounded border ${
+                  filter === 'tasks' ? 'bg-accent text-white border-accent' : 'border-secondary'
+                }`}
+                onClick={() => setFilter('tasks')}
+              >
+                Tasks
+              </button>
+            </div>
+            <button
+              className="text-xs text-accent underline"
+              onClick={() => setShowForm((p) => !p)}
+            >
+              {showForm ? '- Cancel' : '+ Add Item'}
+            </button>
+          </div>
+          {showForm && (
+            <div className="mb-2">
+              <QuickTaskForm
+                questId={questId}
+                boardId={`log-${questId}`}
+                parentId={linkedNodeId}
+                allowIssue
+                onSave={(p) => {
+                  setItems((prev) => [...prev, p]);
+                  setShowForm(false);
+                }}
+                onCancel={() => setShowForm(false)}
+              />
+            </div>
+          )}
+          <div className="flex overflow-auto space-x-2">
+            {STATUS_OPTIONS.map(({ value }) => (
+              <div
+                key={value}
+                className="min-w-[80px] w-28 flex-shrink-0 bg-surface border border-secondary rounded-lg p-2 space-y-2"
+              >
+                <h4 className="text-sm font-semibold flex items-center gap-1">
+                  <span>{statusIcons[value] || '➡️'}</span>
+                  {value}
+                  <span className="ml-auto text-xs text-secondary">
+                    {grouped[value].length}
+                  </span>
+                </h4>
+                {grouped[value].length === 0 ? (
+                  <div className="text-xs text-secondary">No items</div>
+                ) : (
+                  grouped[value].map((issue) => (
+                    <div
+                      key={issue.id}
+                      className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
+                    >
+                      <div className="font-semibold truncate">
+                        {issue.content.length > 15 ? `${issue.content.slice(0, 12)}…` : issue.content}
+                      </div>
+                      {issue.status && <StatusBadge status={issue.status} />}
+                    </div>
+                  ))
+                )}
+              </div>
+            ))}
+          </div>
         </div>
       )}
-      <div className="flex overflow-auto space-x-2">
-        {STATUS_OPTIONS.map(({ value }) => (
-          <div
-            key={value}
-            className="min-w-[80px] w-28 flex-shrink-0 bg-surface border border-secondary rounded-lg p-2 space-y-2"
-          >
-            <h4 className="text-sm font-semibold flex items-center gap-1">
-              <span>{statusIcons[value] || '➡️'}</span>
-              {value}
-            </h4>
-            {grouped[value].length === 0 ? (
-              <div className="text-xs text-secondary">No items</div>
-            ) : (
-              grouped[value].map((issue) => (
-                <div
-                  key={issue.id}
-                  className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
-                >
-                  <div className="font-semibold truncate">
-                    {issue.content.length > 15 ? `${issue.content.slice(0, 12)}…` : issue.content}
-                  </div>
-                  {issue.status && <StatusBadge status={issue.status} />}
-                </div>
-              ))
-            )}
-          </div>
-        ))}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- default QuestCard to open on the file/folder tab
- move StatusBoardPanel to the top of the file view
- show task counts in the Status board header and each column
- add counts to Kanban board columns

## Testing
- `./setup.sh` *(fails: blocked by network)*
- `npm test --prefix ethos-backend` *(fails: missing dependencies)*
- `npm test --prefix ethos-frontend` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858cef0ea20832f8225983e0e4221bc