### PR TITLE
Fix task card expansion overlay

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -20,7 +20,7 @@ import {
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
 import QuestCard from '../quest/QuestCard';
-import TaskCard from '../quest/TaskCard';
+import TaskGraphSidePanel from '../quest/TaskGraphSidePanel';
 import { fetchQuestById } from '../../api/quest';
 import {
   updateReaction,
@@ -386,9 +386,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       )}
 
       {showTaskGraph && post.type === 'task' && post.questId && (
-        <div className="mt-3">
-          <TaskCard task={post} questId={post.questId} user={user} />
-        </div>
+        <TaskGraphSidePanel
+          task={post}
+          questId={post.questId}
+          user={user}
+          onClose={() => setShowTaskGraph(false)}
+        />
       )}
 
 


### PR DESCRIPTION
## Summary
- fix expanded task view to open TaskGraphSidePanel overlay

## Testing
- `npm test --silent --prefix ethos-frontend`
- `npm test --silent --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6858cfc3d10c832f94de2a4fb39dcf4e