### PR TITLE
Fix mini task summary tag

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -39,8 +39,15 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate }) => 
 
   const summaryTags = buildSummaryTags(post);
   let taskTag = summaryTags.find(t => t.type === 'task');
-  if (!taskTag) {
-    const label = post.nodeId ? `Task: ${post.nodeId}` : 'Task';
+  if (taskTag) {
+    taskTag = {
+      ...taskTag,
+      label: post.nodeId || taskTag.label.replace(/^Task\s*[-:]\s*/, ''),
+      username: undefined,
+      usernameLink: undefined,
+    } as any;
+  } else {
+    const label = post.nodeId || 'Task';
     taskTag = {
       type: 'task',
       label,


### PR DESCRIPTION
## Summary
- tweak summary tag on `TaskPreviewCard` so mini posts show only the node ID

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858d30362b0832fbffb63a3c5d6f22b