### PR TITLE
Fix task card expansion view

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -20,7 +20,7 @@ import {
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
 import QuestCard from '../quest/QuestCard';
-import TaskGraphSidePanel from '../quest/TaskGraphSidePanel';
+import TaskCard from '../quest/TaskCard';
 import { fetchQuestById } from '../../api/quest';
 import {
   updateReaction,
@@ -77,7 +77,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [showReplyPanel, setShowReplyPanel] = useState(false);
   const [repostLoading, setRepostLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  const [showTaskGraph, setShowTaskGraph] = useState(false);
   const [completed, setCompleted] = useState(post.tags?.includes('archived') ?? false);
   const [joining, setJoining] = useState(false);
   const [joined, setJoined] = useState(
@@ -341,28 +340,10 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         {(post.type === 'task' || post.type === 'commit' || post.type === 'quest') && (
           <button
             className="flex items-center gap-1"
-            onClick={() => {
-              if (post.type === 'task') {
-                setShowTaskGraph((p) => !p);
-              } else {
-                setExpanded((prev) => !prev);
-              }
-            }}
+            onClick={() => setExpanded((prev) => !prev)}
           >
-            {post.type === 'task'
-              ? showTaskGraph
-                ? <FaCompress />
-                : <FaExpand />
-              : expanded
-              ? <FaCompress />
-              : <FaExpand />}{' '}
-            {post.type === 'task'
-              ? showTaskGraph
-                ? 'Collapse View'
-                : 'Expand View'
-              : expanded
-              ? 'Collapse View'
-              : 'Expand View'}
+            {expanded ? <FaCompress /> : <FaExpand />}{' '}
+            {expanded ? 'Collapse View' : 'Expand View'}
           </button>
         )}
 
@@ -385,14 +366,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </div>
       )}
 
-      {showTaskGraph && post.type === 'task' && post.questId && (
-        <TaskGraphSidePanel
-          task={post}
-          questId={post.questId}
-          user={user}
-          onClose={() => setShowTaskGraph(false)}
-        />
-      )}
 
 
       {expanded && post.type === 'commit' && (
@@ -405,6 +378,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               {post.gitDiff}
             </pre>
           )}
+        </div>
+      )}
+
+      {expanded && post.type === 'task' && post.questId && (
+        <div className="mt-3">
+          <TaskCard task={post} questId={post.questId} user={user} />
         </div>
       )}
 

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -421,16 +421,14 @@ const PostCard: React.FC<PostCardProps> = ({
             {titleText}
           </h3>
         )}
-        <div className="flex items-center justify-between gap-2">
-          <ReactionControls
-            post={post}
-            user={user}
-            onUpdate={onUpdate}
-            timestamp={!isQuestBoardRequest ? timestamp : undefined}
-            replyOverride={replyOverride}
-            boardId={ctxBoardId || undefined}
-          />
-        </div>
+        <ReactionControls
+          post={post}
+          user={user}
+          onUpdate={onUpdate}
+          timestamp={!isQuestBoardRequest ? timestamp : undefined}
+          replyOverride={replyOverride}
+          boardId={ctxBoardId || undefined}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- allow expanding task posts inline like quests
- ensure task card expansion appears below reaction buttons on boards

## Testing
- `npm test --prefix ethos-backend` *(fails: missing supertest & bcryptjs)*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858d2c837a0832f8df49e18dec46ce0