### PR TITLE
Filter profile quests by author

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -13,7 +13,12 @@ interface QuestWithLog extends Quest {
   lastLog?: Post;
 }
 
-const ActiveQuestBoard: React.FC = () => {
+interface ActiveQuestBoardProps {
+  /** When true, only display quests authored by the current user */
+  onlyMine?: boolean;
+}
+
+const ActiveQuestBoard: React.FC<ActiveQuestBoardProps> = ({ onlyMine }) => {
   const { user } = useAuth();
   const [quests, setQuests] = useState<QuestWithLog[]>([]);
   const [loading, setLoading] = useState(false);
@@ -65,7 +70,10 @@ const ActiveQuestBoard: React.FC = () => {
           })
         );
 
-        const enriched = Object.values(questMap);
+        let enriched = Object.values(questMap);
+        if (onlyMine) {
+          enriched = enriched.filter(q => q.authorId === user?.id);
+        }
         setQuests(enriched);
       } catch (err) {
         console.warn('[ActiveQuestBoard] Failed to load quests', err);

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -60,7 +60,7 @@ const ProfilePage: React.FC = () => {
 
       {/* 📘 Your Quests */}
       <section className="mb-12">
-        <ActiveQuestBoard />
+        <ActiveQuestBoard onlyMine />
 
         <div className="text-right">
           <Link to={ROUTES.BOARD('active')} className="text-sm text-blue-600 underline">


### PR DESCRIPTION
## Summary
- restrict `ActiveQuestBoard` to optionally show only the current user's quests
- use this mode on the profile page

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6858e61f22dc832f830201a6989b4b6a