### PR TITLE
Add repo upload API and default file tab

### DIFF
--- a/ethos-backend/src/routes/gitRoutes.ts
+++ b/ethos-backend/src/routes/gitRoutes.ts
@@ -16,6 +16,7 @@ import {
   createFile,
   updateFile,
   downloadRepo,
+  uploadRepoItem,
 } from '../services/gitService';
 import type { AuthenticatedRequest } from '../types/express';
 
@@ -249,6 +250,23 @@ router.put('/files', authMiddleware, async (
   } catch (err) {
     error('[GIT UPDATE FILE ERROR]', err);
     res.status(500).json({ error: 'Failed to update file' });
+  }
+});
+
+//
+// ✅ POST /api/git/upload
+// Create a file or folder and commit the change
+router.post('/upload', authMiddleware, async (
+  req: AuthenticatedRequest<{}, any, { questId: string; filePath: string; content?: string; isFolder?: boolean; message?: string }>,
+  res: Response
+): Promise<void> => {
+  const { questId, filePath, content = '', isFolder = false, message = 'upload' } = req.body;
+  try {
+    const repo = await uploadRepoItem(questId, filePath, content, isFolder, message);
+    res.json(repo);
+  } catch (err) {
+    error('[GIT UPLOAD ERROR]', err);
+    res.status(500).json({ error: 'Failed to upload item' });
   }
 });
 

--- a/ethos-backend/src/services/gitService.ts
+++ b/ethos-backend/src/services/gitService.ts
@@ -305,3 +305,30 @@ export async function getCommits(questId: string): Promise<any[]> {
     author: { id: c.author_email, username: c.author_name },
   }));
 }
+
+export async function commitRepo(
+  questId: string,
+  message: string,
+  filePaths: string[] = ['.']
+): Promise<GitRepo> {
+  const repoDir = ensureRepoDir(questId);
+  const git = simpleGit(repoDir);
+  await git.add(filePaths);
+  await git.commit(message);
+  return (await getQuestRepoMeta(questId)) as GitRepo;
+}
+
+export async function uploadRepoItem(
+  questId: string,
+  filePath: string,
+  content: string,
+  isFolder: boolean,
+  message: string
+): Promise<GitRepo> {
+  if (isFolder) {
+    await createFolder(questId, filePath);
+  } else {
+    await createFile(questId, filePath, content);
+  }
+  return commitRepo(questId, message, [filePath]);
+}

--- a/ethos-backend/tests/gitRoutes.test.ts
+++ b/ethos-backend/tests/gitRoutes.test.ts
@@ -86,4 +86,23 @@ describe('git routes real operations', () => {
     expect(diff.status).toBe(200);
     expect(diff.body.diffMarkdown).toContain('file.txt');
   });
+
+  it('uploads file and commits', async () => {
+    await request(app)
+      .post('/git/connect')
+      .send({ questId: 'q4', repoUrl: baseRepo, branch: 'main' });
+
+    const res = await request(app)
+      .post('/git/upload')
+      .send({
+        questId: 'q4',
+        filePath: 'new.txt',
+        content: 'hello',
+        message: 'add new.txt',
+      });
+    expect(res.status).toBe(200);
+    const git = simpleGit(path.join(reposRoot, 'q4'));
+    const log = await git.log({ maxCount: 1 });
+    expect(log.latest?.message).toBe('add new.txt');
+  });
 });

--- a/ethos-frontend/src/api/git.ts
+++ b/ethos-frontend/src/api/git.ts
@@ -118,6 +118,23 @@ export const updateRepoFile = async (
   return res.data;
 };
 
+export const uploadRepoItem = async (
+  questId: string,
+  filePath: string,
+  content: string,
+  isFolder = false,
+  message = 'upload'
+): Promise<GitRepoMeta> => {
+  const res = await axiosWithAuth.post(`/git/upload`, {
+    questId,
+    filePath,
+    content,
+    isFolder,
+    message,
+  });
+  return res.data;
+};
+
 export const downloadRepo = async (questId: string): Promise<Blob> => {
   const res = await axiosWithAuth.get(`/git/download/${questId}`, {
     responseType: 'blob',

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -180,7 +180,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       const node = logs.find((p) => p.id === evt.detail.taskId);
       if (node) {
         setSelectedNode(node);
-        setActiveTab('logs');
+        setActiveTab('file');
       }
     };
     window.addEventListener('questTaskOpen', handleTaskOpen);
@@ -225,7 +225,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
                 setExpanded(false);
               } else {
                 setExpanded(true);
-                setActiveTab('logs');
+                setActiveTab('file');
                 setMapMode('folder');
               }
             }}


### PR DESCRIPTION
## Summary
- default to file tab when opening QuestCard or tasks
- add backend routes for uploading repo items as commits
- support uploading via frontend API
- commit includes new unit test for upload endpoint

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68594e4ac508832fbb2d66ffc9f2cf61