### PR TITLE
Fix board filter and remove grid view

### DIFF
--- a/ethos-frontend/src/components/board/BoardSearchFilter.tsx
+++ b/ethos-frontend/src/components/board/BoardSearchFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Input, Select, Button } from '../ui';
-import type { option } from '../../constants/options';
+import { POST_TYPES, type option } from '../../constants/options';
 
 export interface FilterState {
   search: string;
@@ -27,9 +27,7 @@ const STATUS_OPTIONS: option[] = [
 
 const POST_TYPE_OPTIONS: option[] = [
   { value: '', label: 'All Types' },
-  { value: 'request', label: 'Request' },
-  { value: 'quest_log', label: 'Quest Log' },
-  { value: 'deliverable', label: 'Deliverable' },
+  ...POST_TYPES,
 ];
 
 const ROLE_OPTIONS: option[] = [
@@ -45,19 +43,14 @@ const SORT_OPTIONS: option[] = [
   { value: 'trending', label: 'Trending' },
 ];
 
-const VIEW_OPTIONS: option[] = [
-  { value: 'grid', label: 'Grid' },
-  { value: 'list', label: 'List' },
-];
-
-const DEFAULT_FILTERS: FilterState = {
+export const DEFAULT_FILTERS: FilterState = {
   search: '',
   tags: [],
   status: '',
   postType: '',
   role: '',
   sortBy: 'recent',
-  view: 'grid',
+  view: 'list',
 };
 
 const STORAGE_KEY = 'boardFilters';
@@ -158,11 +151,6 @@ const BoardSearchFilter: React.FC<BoardSearchFilterProps> = ({
             value={filters.sortBy}
             onChange={(e) => setFilters({ ...filters, sortBy: e.target.value })}
             options={SORT_OPTIONS}
-          />
-          <Select
-            value={filters.view}
-            onChange={(e) => setFilters({ ...filters, view: e.target.value as 'grid' | 'list' })}
-            options={VIEW_OPTIONS}
           />
         </div>
       )}

--- a/ethos-frontend/src/pages/Profile.tsx
+++ b/ethos-frontend/src/pages/Profile.tsx
@@ -8,7 +8,10 @@ import { ROUTES } from '../constants/routes';
 
 import Banner from '../components/ui/Banner';
 import Board from '../components/board/Board';
-import BoardSearchFilter from '../components/board/BoardSearchFilter';
+import BoardSearchFilter, {
+  DEFAULT_FILTERS,
+  type FilterState,
+} from '../components/board/BoardSearchFilter';
 import { Spinner } from '../components/ui';
 import ActiveQuestBoard from '../components/quest/ActiveQuestBoard';
 
@@ -29,7 +32,7 @@ const ProfilePage: React.FC = () => {
     isLoading: loadingPosts,
   } = useBoard('my-posts', { pageSize: 1000 });
 
-  const [view, setView] = useState<'grid' | 'list'>('list');
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
 
 
   useSocketListener('board:update', (updatedBoard: BoardData) => {
@@ -77,15 +80,16 @@ const ProfilePage: React.FC = () => {
           <Spinner />
         ) : (
           <div className="flex flex-col md:flex-row gap-6">
-            <BoardSearchFilter className="md:w-64" onChange={(f) => setView(f.view)} />
+            <BoardSearchFilter className="md:w-64" onChange={setFilters} />
             <div className="flex-1">
               <Board
                 boardId="my-posts"
                 board={userPostBoard}
-                layout={view}
+                layout="list"
                 user={castUser}
                 compact
                 hideControls
+                filter={filters}
                 headerOnly
               />
               {userPostBoard?.enrichedItems?.length === 0 && (

--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -8,7 +8,10 @@ import { useSocket } from '../../hooks/useSocket';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePermissions } from '../../hooks/usePermissions';
 import Board from '../../components/board/Board';
-import BoardSearchFilter from '../../components/board/BoardSearchFilter';
+import BoardSearchFilter, {
+  DEFAULT_FILTERS,
+  type FilterState,
+} from '../../components/board/BoardSearchFilter';
 import { Spinner } from '../../components/ui';
 import { toTitleCase } from '../../utils/displayUtils';
 
@@ -31,7 +34,7 @@ const BoardPage: React.FC = () => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
-  const [view, setView] = useState<'grid' | 'list'>('grid');
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
 
   const loadQuest = useCallback(async (questId: string) => {
     try {
@@ -129,7 +132,7 @@ const BoardPage: React.FC = () => {
           <BoardSearchFilter
             tags={availableTags}
             className="md:w-64"
-            onChange={(f) => setView(f.view)}
+            onChange={setFilters}
           />
         )}
         <div className="flex-1">
@@ -157,11 +160,12 @@ const BoardPage: React.FC = () => {
               <Board
                 boardId={id}
                 board={boardData}
-                layout={view}
+                layout="list"
                 quest={quest || undefined}
                 editable={editable}
                 showCreate={editable}
                 hideControls
+                filter={filters}
                 onScrollEnd={loadMore}
                 loading={loadingMore}
               />


### PR DESCRIPTION
## Summary
- use shared post type constants in board search filter
- default to list view and remove layout dropdown
- wire filter selections into board view on board page and profile page

## Testing
- `npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom missing)*
- `npm --prefix ethos-backend test` *(fails: supertest module missing)*
- `npm --prefix ethos-frontend run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_685961f3a478832fad12cbe425c05f9e