### PR TITLE
Fix expand view button style

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -399,7 +399,7 @@ const PostCard: React.FC<PostCardProps> = ({
           </div>
           <div className="flex items-center gap-2">
             <button
-              className="flex items-center gap-1 text-secondary"
+              className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400"
               onClick={() => setExpandedView(prev => !prev)}
             >
               {expandedView ? <FaCompress /> : <FaExpand />}{' '}
@@ -481,7 +481,7 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
         <div className="flex items-center gap-2">
           <button
-            className="flex items-center gap-1 text-secondary"
+            className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400"
             onClick={() => setExpandedView(prev => !prev)}
           >
             {expandedView ? <FaCompress /> : <FaExpand />}{' '}


### PR DESCRIPTION
## Summary
- tweak PostCard expand view styling to match reaction buttons

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68596434cdc0832f8cae7583e159a3d9