### PR TITLE
Reduce task panel heights

### DIFF
--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -49,7 +49,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user }) => {
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex-1 space-y-2">
           <TaskPreviewCard post={selected} />
-          <div className="h-80 overflow-auto" data-testid="task-graph-inline">
+          <div className="h-64 overflow-auto" data-testid="task-graph-inline">
             <GraphLayout
               items={displayNodes}
               edges={displayEdges}

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -54,7 +54,7 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 overflow-auto p-2 border-r border-secondary space-y-2">
           <TaskPreviewCard post={selected} />
-          <div className="h-80 md:h-auto overflow-auto" data-testid="task-graph">
+          <div className="h-64 md:h-auto overflow-auto" data-testid="task-graph">
             <GraphLayout
               items={displayNodes}
               edges={displayEdges}


### PR DESCRIPTION
## Summary
- shorten the height of inline TaskCard panel
- shorten the height of TaskGraphSidePanel

## Testing
- `npm test` in `ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm test` in `ethos-backend` *(fails to find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685965e02bb8832f924fb81267142554