### PR TITLE
Improve link viewer

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -345,7 +345,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           )
         )}
 
-        {(post.type === 'task' || post.type === 'commit' || post.type === 'quest') &&
+        {(post.type === 'task' || post.type === 'quest') &&
           !onToggleExpand && (
             <button className="flex items-center gap-1" onClick={() => setInternalExpanded(prev => !prev)}>
               {expanded ? <FaCompress /> : <FaExpand />}{' '}
@@ -372,20 +372,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </div>
       )}
 
-
-
-      {expanded && post.type === 'commit' && (
-        <div className="mt-3 text-sm">
-          {post.commitSummary && (
-            <div className="mb-1 italic text-secondary dark:text-secondary">{post.commitSummary}</div>
-          )}
-          {post.gitDiff && (
-            <pre className="whitespace-pre-wrap overflow-x-auto bg-gray-50 p-2 border text-xs">
-              {post.gitDiff}
-            </pre>
-          )}
-        </div>
-      )}
 
       {expanded && post.type === 'task' && post.questId && (
         <div className="mt-3">

--- a/ethos-frontend/src/components/ui/LinkViewer.test.tsx
+++ b/ethos-frontend/src/components/ui/LinkViewer.test.tsx
@@ -67,14 +67,14 @@ describe('LinkViewer', () => {
 
   it('toggles label text', () => {
     render(<LinkViewer items={items} />);
-    const btn = screen.getByText('Expand Details');
+    const btn = screen.getByText('View Links');
     fireEvent.click(btn);
-    expect(screen.getByText('Collapse Details')).toBeInTheDocument();
+    expect(screen.getByText('Hide Links')).toBeInTheDocument();
   });
 
   it('shows reply chain when enabled', async () => {
     render(<LinkViewer items={[]} post={post} showReplyChain />);
-    fireEvent.click(screen.getByText('Expand Details'));
+    fireEvent.click(screen.getByText('View Links'));
     await waitFor(() => {
       expect(screen.getByText('Q:T02')).toBeInTheDocument();
       expect(screen.getByText('Q:T01')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- restrict expanded view in reaction controls to quests and tasks
- rework LinkViewer with search, filter, and scrollable panel
- update LinkViewer tests for new labels

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685966d1c75c832faded72cd9dd2c44d