### PR TITLE
Simplify task card

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -389,7 +389,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
       {expanded && post.type === 'task' && post.questId && (
         <div className="mt-3">
-          <TaskCard task={post} questId={post.questId} user={user} />
+          <TaskCard task={post} questId={post.questId} user={user} onUpdate={onUpdate} />
         </div>
       )}
 

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -282,7 +282,11 @@ const QuestCard: React.FC<QuestCardProps> = ({
       <div className="space-y-2">
         {selectedNode && (
           <div className="space-y-2">
-            <TaskPreviewCard post={selectedNode} onUpdate={handleSelectedNodeUpdate} />
+            <TaskPreviewCard
+              post={selectedNode}
+              onUpdate={handleSelectedNodeUpdate}
+              summaryOnly={selectedNode.id === rootNode?.id}
+            />
           </div>
         )}
         <div className="h-48 overflow-auto border-b border-secondary" data-testid="quest-map-canvas">

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -1,20 +1,27 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import GraphLayout from '../layout/GraphLayout';
 import { useGraph } from '../../hooks/useGraph';
-import TaskPreviewCard from '../post/TaskPreviewCard';
 import QuestNodeInspector from './QuestNodeInspector';
-import type { Post } from '../../types/postTypes';
+import { Select } from '../ui';
+import { STATUS_OPTIONS } from '../../constants/options';
+import { updatePost } from '../../api/post';
+import { ROUTES } from '../../constants/routes';
+import type { Post, QuestTaskStatus } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
 interface TaskCardProps {
   task: Post;
   questId: string;
   user?: User;
+  onUpdate?: (p: Post) => void;
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user }) => {
+const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) => {
   const { nodes, edges, loadGraph } = useGraph();
   const [selected, setSelected] = useState<Post>(task);
+  const [status, setStatus] = useState<QuestTaskStatus>(task.status || 'To Do');
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (questId) {
@@ -44,11 +51,41 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user }) => {
   const displayNodes = useMemo(() => nodes.filter(n => subgraphIds.has(n.id)), [nodes, subgraphIds]);
   const displayEdges = useMemo(() => edges.filter(e => subgraphIds.has(e.from) && subgraphIds.has(e.to)), [edges, subgraphIds]);
 
+  const parentEdge = edges.find(e => e.to === task.id);
+  const parentNode = parentEdge ? nodes.find(n => n.id === parentEdge.from) : undefined;
+
+  const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newStatus = e.target.value as QuestTaskStatus;
+    setStatus(newStatus);
+    const optimistic = { ...task, status: newStatus };
+    onUpdate?.(optimistic);
+    try {
+      const updated = await updatePost(task.id, { status: newStatus });
+      onUpdate?.(updated);
+    } catch (err) {
+      console.error('[TaskCard] failed to update status', err);
+    }
+  };
+
   return (
     <div className="border border-secondary rounded-lg bg-surface p-4 space-y-2">
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex-1 space-y-2">
-          <TaskPreviewCard post={selected} />
+          <div className="flex items-center justify-between">
+            {parentNode && (
+              <div
+                className="w-px h-4 border-l-2 border-dotted border-secondary cursor-pointer"
+                title={`Parent: ${parentNode.content.slice(0, 50)}`}
+                onClick={() => navigate(ROUTES.POST(parentNode.id))}
+              />
+            )}
+            <Select
+              value={status}
+              onChange={handleStatusChange}
+              options={STATUS_OPTIONS as any}
+              className="text-xs w-32"
+            />
+          </div>
           <div className="h-64 overflow-auto" data-testid="task-graph-inline">
             <GraphLayout
               items={displayNodes}


### PR DESCRIPTION
## Summary
- update TaskCard to remove mini preview and add status dropdown
- show parent tether above task graph
- show root tasks as summary tag only
- truncate quest node labels in TaskPreviewCard

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68596ac73d6c832f8d8ab3f25e119cc2