### PR TITLE
Update quest card mini task display

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -52,6 +52,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
         : taskTag.label.replace(/^Task\s*[-:]\s*/, ''),
       username: undefined,
       usernameLink: undefined,
+      link: ROUTES.POST(post.id),
     } as any;
   } else {
     const label = post.nodeId
@@ -61,6 +62,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
       type: 'task',
       label,
       detailLink: ROUTES.POST(post.id),
+      link: ROUTES.POST(post.id),
     } as any;
   }
 

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -285,6 +285,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             <TaskPreviewCard
               post={selectedNode}
               onUpdate={handleSelectedNodeUpdate}
+              summaryOnly
             />
           </div>
         )}

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -53,7 +53,7 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
       </div>
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 overflow-auto p-2 border-r border-secondary space-y-2">
-          <TaskPreviewCard post={selected} />
+          <TaskPreviewCard post={selected} summaryOnly />
           <div className="h-22 md:h-auto overflow-auto" data-testid="task-graph">
             <GraphLayout
               items={displayNodes}


### PR DESCRIPTION
## Summary
- keep only SummaryTag in mini task preview card and make tag clickable
- show summary-only TaskPreviewCard in expanded quest view and task side panel

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6859735ebd04832faf58da33b0d43241