### PR TITLE
Update quest card mini task display

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -52,6 +52,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
         : taskTag.label.replace(/^Task\s*[-:]\s*/, ''),
       username: undefined,
       usernameLink: undefined,
+      link: ROUTES.POST(post.id),
     } as any;
   } else {
     const label = post.nodeId
@@ -61,6 +62,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
       type: 'task',
       label,
       detailLink: ROUTES.POST(post.id),
+      link: ROUTES.POST(post.id),
     } as any;
   }
 
@@ -72,8 +74,58 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
 
   if (summaryOnly) {
     return (
-      <div className="border border-secondary rounded bg-surface p-2 text-xs">
+      <div className="border border-secondary rounded bg-surface p-2 text-xs space-y-1">
         {tagNode}
+        <div className="flex items-center gap-2">
+          <StatusBadge status={status} />
+          <Select
+            value={status}
+            onChange={handleStatusChange}
+            options={STATUS_OPTIONS as option[]}
+            className="text-xs"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={taskType}
+            onChange={handleTypeChange}
+            options={TASK_TYPE_OPTIONS as option[]}
+            className="text-xs"
+          />
+        </div>
+        {taskType === 'file' && (
+          <label className="inline-flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              className="form-checkbox"
+              checked={organizeFile}
+              onChange={(e) => setOrganizeFile(e.target.checked)}
+            />
+            Organize File
+          </label>
+        )}
+        {taskType === 'folder' && (
+          <label className="inline-flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              className="form-checkbox"
+              checked={plannerFile}
+              onChange={(e) => setPlannerFile(e.target.checked)}
+            />
+            Make Planner File
+          </label>
+        )}
+        {taskType === 'abstract' && (
+          <label className="inline-flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              className="form-checkbox"
+              checked={plannerFile}
+              onChange={(e) => setPlannerFile(e.target.checked)}
+            />
+            Make Planner File
+          </label>
+        )}
       </div>
     );
   }

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -285,6 +285,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
             <TaskPreviewCard
               post={selectedNode}
               onUpdate={handleSelectedNodeUpdate}
+              summaryOnly
             />
           </div>
         )}

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import GraphLayout from '../layout/GraphLayout';
 import { useGraph } from '../../hooks/useGraph';
 import QuestNodeInspector from './QuestNodeInspector';
+import TaskPreviewCard from '../post/TaskPreviewCard';
 import { Select } from '../ui';
 import { STATUS_OPTIONS } from '../../constants/options';
 import { updatePost } from '../../api/post';
@@ -71,6 +72,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
     <div className="border border-secondary rounded-lg bg-surface p-4 space-y-2">
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex-1 space-y-2">
+          <TaskPreviewCard post={selected} summaryOnly />
           <div className="flex items-center justify-between">
             {parentNode && (
               <div

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -53,7 +53,7 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
       </div>
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 overflow-auto p-2 border-r border-secondary space-y-2">
-          <TaskPreviewCard post={selected} />
+          <TaskPreviewCard post={selected} summaryOnly />
           <div className="h-22 md:h-auto overflow-auto" data-testid="task-graph">
             <GraphLayout
               items={displayNodes}


### PR DESCRIPTION
## Summary
- keep summary tag only for header in mini task card, but retain progress & task type controls
- embed summary-only TaskPreviewCard in TaskCard above map graph

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_6859735ebd04832faf58da33b0d43241