### PR TITLE
Fix status board persistence

### DIFF
--- a/ethos-frontend/src/components/post/QuickTaskForm.tsx
+++ b/ethos-frontend/src/components/post/QuickTaskForm.tsx
@@ -46,6 +46,7 @@ const QuickTaskForm: React.FC<QuickTaskFormProps> = ({
         status: taskStatus,
         taskType,
         ...(boardId ? { boardId } : {}),
+        ...(parentId ? { replyTo: parentId, linkedNodeId: parentId } : {}),
       });
       if (boardId) appendToBoard?.(boardId, newPost);
       if (parentId) {


### PR DESCRIPTION
## Summary
- ensure subtasks are persisted by recording parent id when creating them

## Testing
- `npm test -- -w=1` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68597806b6e8832f85e4f7622da954fe