### PR TITLE
Implement resizable panels on task card

### DIFF
--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -23,6 +23,7 @@ interface QuestNodeInspectorProps {
   status?: QuestTaskStatus;
   onStatusChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onUpdate?: (p: Post) => void;
+  hideSelects?: boolean;
 }
 
 const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
@@ -34,6 +35,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   status,
   onStatusChange,
   onUpdate,
+  hideSelects = false,
 }) => {
   const [type, setType] = useState<string>(node?.taskType || 'abstract');
   const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('logs');
@@ -169,7 +171,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     <div className="flex flex-col h-full">
       <div className="p-2 space-y-2 flex-1 overflow-auto">
         {showPost && <PostCard post={node} user={user} questId={questId} />}
-        {node.type === 'task' && (
+        {node.type === 'task' && !hideSelects && (
           <div className="space-y-2">
             <Select
               id="task-type"

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -5,7 +5,8 @@ import { useGraph } from '../../hooks/useGraph';
 import QuestNodeInspector from './QuestNodeInspector';
 import TaskPreviewCard from '../post/TaskPreviewCard';
 import { Select } from '../ui';
-import { STATUS_OPTIONS } from '../../constants/options';
+import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
+import type { option } from '../../constants/options';
 import { updatePost } from '../../api/post';
 import { ROUTES } from '../../constants/routes';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
@@ -22,6 +23,8 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
   const { nodes, edges, loadGraph } = useGraph();
   const [selected, setSelected] = useState<Post>(task);
   const [status, setStatus] = useState<QuestTaskStatus>(task.status || 'To Do');
+  const [taskType, setTaskType] = useState<string>(task.taskType || 'abstract');
+  const [detailWidth, setDetailWidth] = useState<number>(400);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -58,13 +61,67 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
   const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value as QuestTaskStatus;
     setStatus(newStatus);
+    try {
+      const updated = await updatePost(selected.id, { status: newStatus });
+      setSelected(updated);
+      onUpdate?.(updated);
+      document.dispatchEvent(new CustomEvent('taskUpdated', { detail: { task: updated } }));
+    } catch (err) {
+      console.error('[TaskCard] Failed to update status', err);
+    }
+  };
+
+  const handleTypeChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    setTaskType(val);
+    try {
+      const updated = await updatePost(selected.id, { taskType: val });
+      setSelected(updated);
+      onUpdate?.(updated);
+      document.dispatchEvent(new CustomEvent('taskUpdated', { detail: { task: updated } }));
+    } catch (err) {
+      console.error('[TaskCard] Failed to update task type', err);
+    }
+  };
+
+  const handleDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const startX = e.clientX;
+    const startWidth = detailWidth;
+    const onMove = (ev: MouseEvent) => {
+      const newWidth = Math.min(600, Math.max(260, startWidth - (ev.clientX - startX)));
+      setDetailWidth(newWidth);
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
   };
 
   return (
     <div className="border border-secondary rounded-lg bg-surface p-4 space-y-2">
       <div className="flex flex-col md:flex-row gap-4">
-        <div className="flex-1 space-y-2">
+        <div className="flex-1 space-y-2 md:pr-4" style={{ minWidth: 240 }}>
           <TaskPreviewCard post={selected} summaryOnly />
+          <div className="space-y-2">
+            {selected.type === 'task' && (
+              <>
+                <Select
+                  id="task-type"
+                  value={taskType}
+                  onChange={handleTypeChange}
+                  options={TASK_TYPE_OPTIONS as option[]}
+                />
+                <Select
+                  id="task-status"
+                  value={status}
+                  onChange={handleStatusChange}
+                  options={STATUS_OPTIONS as option[]}
+                />
+              </>
+            )}
+          </div>
           <div className="flex items-center justify-between">
             {parentNode && (
               <div
@@ -87,7 +144,8 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
             />
           </div>
         </div>
-        <div className="flex-1 overflow-auto">
+        <div className="hidden md:block w-1.5 bg-gray-200 dark:bg-gray-600 cursor-ew-resize" onMouseDown={handleDividerMouseDown} />
+        <div className="overflow-auto" style={{ width: detailWidth }}>
           <QuestNodeInspector
             questId={questId}
             node={selected}
@@ -95,7 +153,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
             showPost={false}
             onUpdate={onUpdate}
             status={status}
-            onStatusChange={handleStatusChange}
+            hideSelects
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add hideSelects option to `QuestNodeInspector`
- resizeable detail panel for `TaskCard`
- move type/status dropdowns to the left side of expanded task card

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68597aa11e20832f93d4b9ed8de899c4