### PR TITLE
Add nested checklist for planner tasks

### DIFF
--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -7,6 +7,7 @@ import FileEditorPanel from './FileEditorPanel';
 import TaskKanbanBoard from './TaskKanbanBoard';
 import QuickTaskForm from '../post/QuickTaskForm';
 import TeamPanel from './TeamPanel';
+import SubtaskChecklist from './SubtaskChecklist';
 import { useGraph } from '../../hooks/useGraph';
 import { Select } from '../ui';
 import { updatePost } from '../../api/post';
@@ -148,12 +149,14 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
               </div>
             )}
           </div>
-          {type === 'file' && (
+          {type === 'file' ? (
             <FileEditorPanel
               questId={questId}
               filePath={node.gitFilePath || 'file.txt'}
               content={node.content}
             />
+          ) : (
+            <SubtaskChecklist questId={questId} nodeId={node.id} />
           )}
         </div>
       );

--- a/ethos-frontend/src/components/quest/SubtaskChecklist.tsx
+++ b/ethos-frontend/src/components/quest/SubtaskChecklist.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react';
+import { useGraph } from '../../hooks/useGraph';
+import { updatePost } from '../../api/post';
+import type { Post } from '../../types/postTypes';
+
+interface SubtaskChecklistProps {
+  questId: string;
+  nodeId: string;
+  indent?: number;
+}
+
+const SubtaskChecklist: React.FC<SubtaskChecklistProps> = ({ questId, nodeId, indent = 0 }) => {
+  const { nodes, edges, loadGraph } = useGraph();
+
+  useEffect(() => {
+    if (questId) loadGraph(questId);
+  }, [questId, loadGraph]);
+
+  const children = edges
+    .filter(e => e.from === nodeId)
+    .map(e => nodes.find(n => n.id === e.to))
+    .filter((n): n is Post => !!n);
+
+  const toggleStatus = async (task: Post) => {
+    const newStatus = task.status === 'Done' ? 'To Do' : 'Done';
+    try {
+      await updatePost(task.id, { status: newStatus });
+      await loadGraph(questId);
+    } catch (err) {
+      console.error('[SubtaskChecklist] failed to update status', err);
+    }
+  };
+
+  if (children.length === 0) return null;
+
+  return (
+    <ul className="space-y-1" style={{ marginLeft: indent * 12 }}>
+      {children.map(child => (
+        <li key={child.id}>
+          <label className="inline-flex items-center gap-1 text-sm">
+            <input
+              type="checkbox"
+              className="form-checkbox"
+              checked={child.status === 'Done'}
+              onChange={() => toggleStatus(child)}
+            />
+            <span className={child.status === 'Done' ? 'line-through' : ''}>
+              {child.content}
+            </span>
+          </label>
+          <SubtaskChecklist questId={questId} nodeId={child.id} indent={indent + 1} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default SubtaskChecklist;


### PR DESCRIPTION
## Summary
- add new `SubtaskChecklist` component to display subtasks in a checklist tree
- show the checklist when inspecting folder/planner tasks

## Testing
- `npm test --prefix ethos-frontend` *(fails: Cannot find module 'highlight.js')*

------
https://chatgpt.com/codex/tasks/task_e_68597caf23ec832fae4662227aa2a066