### PR TITLE
Fix boardId prop in GridLayout

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -44,7 +44,8 @@ const DraggableCard: React.FC<{
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
   initialExpanded?: boolean;
-}> = ({ item, user, compact, onEdit, onDelete, initialExpanded }) => {
+  boardId?: string;
+}> = ({ item, user, compact, onEdit, onDelete, initialExpanded, boardId }) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: item.id,
     data: { item },
@@ -267,6 +268,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
                     compact={true}
                     onEdit={onEdit}
                     onDelete={onDelete}
+                    boardId={boardId}
                   />
                 ))}
               </DroppableColumn>


### PR DESCRIPTION
## Summary
- ensure `boardId` is passed to `DraggableCard` in `GridLayout`
- declare optional `boardId` prop in `DraggableCard`

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm run lint` *(fails: missing eslint plugins)*
- `npm run build` in `ethos-frontend` *(fails: missing type packages)*

------
https://chatgpt.com/codex/tasks/task_e_68597e8ed85c832fa1f6fb15242aaf57