### PR TITLE
Implement help request cancelation and quest cleanups

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -243,6 +243,16 @@ export const requestHelp = async (
 };
 
 /**
+ * ❌ Cancel a help request for a post
+ */
+export const removeHelpRequest = async (
+  postId: string
+): Promise<{ success: boolean }> => {
+  const res = await axiosWithAuth.delete(`/posts/${postId}/request-help`);
+  return res.data;
+};
+
+/**
  * ✅ Accept a help request
  */
 export const acceptRequest = async (

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -29,8 +29,8 @@ import {
   fetchReactions,
   fetchRepostCount,
   fetchUserRepost,
-  updatePost,
   requestHelp,
+  removeHelpRequest,
   acceptRequest,
   unacceptRequest,
   archivePost,
@@ -200,8 +200,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       }
     } else {
       try {
-        await updatePost(post.id, { helpRequest: false, needsHelp: false });
+        await removeHelpRequest(post.id);
         setHelpRequested(false);
+        onUpdate?.({ ...post, helpRequest: false, needsHelp: false } as Post);
       } catch (err) {
         console.error('[ReactionControls] Failed to cancel help request:', err);
       }

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
-import { requestHelp, updatePost } from '../../api/post';
+import { requestHelp, removeHelpRequest } from '../../api/post';
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
@@ -23,7 +23,7 @@ jest.mock('../../api/post', () => ({
       subRequests: [],
     })
   ),
-  updatePost: jest.fn(() => Promise.resolve({})),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
   updateReaction: jest.fn(() => Promise.resolve()),
   addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
   removeRepost: jest.fn(() => Promise.resolve()),
@@ -82,7 +82,9 @@ describe('PostCard request help', () => {
     await act(async () => {
       fireEvent.click(screen.getByText(/Cancel Help/i));
     });
-    await waitFor(() => expect(updatePost).toHaveBeenCalledWith('t1', { helpRequest: false, needsHelp: false }));
+    await waitFor(() =>
+      expect(removeHelpRequest).toHaveBeenCalledWith('t1')
+    );
   });
 
   it('does not show checkbox for free speech posts', () => {


### PR DESCRIPTION
## Summary
- add API to remove help requests and integrate with ReactionControls
- update backend to delete/archive quest posts and handle task edges
- adjust tests for new help-request toggle behaviour

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68597f061168832f9b8c9d42af06e264