### PR TITLE
Implement improved task map and inline file browser

### DIFF
--- a/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { useGitFileTree } from '../../hooks/useGit';
+import { createRepoFile, updateRepoFile, fetchGitDiff, createRepoFolder } from '../../api/git';
+import { addPost } from '../../api/post';
+import type { GitFile } from '../../types/gitTypes';
+import { TextArea, Input, Button } from '../ui';
+
+interface GitFileBrowserInlineProps {
+  questId: string;
+  onClose?: () => void;
+}
+
+const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, onClose }) => {
+  const { data: tree, isLoading } = useGitFileTree(questId);
+  const [currentPath, setCurrentPath] = useState<string>('');
+  const [editingFile, setEditingFile] = useState<GitFile | null>(null);
+  const [content, setContent] = useState('');
+  const [message, setMessage] = useState('Commit change');
+  const [issueId, setIssueId] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [creatingFolder, setCreatingFolder] = useState(false);
+  const [newFolder, setNewFolder] = useState('');
+
+  const files = (tree || []).filter((f) => f.path.startsWith(currentPath));
+  const items = files
+    .filter((f) => {
+      const rest = f.path.slice(currentPath.length).split('/').filter(Boolean);
+      return rest.length === 1;
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  const handleOpen = (f: GitFile) => {
+    if (f.type === 'folder') {
+      setCurrentPath(f.path.endsWith('/') ? f.path : f.path + '/');
+    } else {
+      setEditingFile(f);
+      setContent('');
+      setMessage('Commit change');
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editingFile) return;
+    setSaving(true);
+    try {
+      const existing = tree?.some((f) => f.path === editingFile.path);
+      if (existing) {
+        await updateRepoFile(questId, editingFile.path, content);
+      } else {
+        await createRepoFile(questId, editingFile.path, content);
+      }
+      const diff = await fetchGitDiff(questId, editingFile.path);
+      const commitMsg = message || `Update ${editingFile.path}`;
+      await addPost({
+        type: 'commit',
+        questId,
+        content: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
+        commitSummary: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
+        gitDiff: diff.diffMarkdown,
+        linkedNodeId: editingFile.path,
+        ...(issueId ? { issueId } : {}),
+        visibility: 'public',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+      });
+      setEditingFile(null);
+    } catch (err) {
+      console.error('[GitFileBrowserInline] save error', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCreateFolder = async () => {
+    if (!newFolder) return;
+    try {
+      await createRepoFolder(questId, currentPath + newFolder);
+      setNewFolder('');
+      setCreatingFolder(false);
+    } catch (err) {
+      console.error('[GitFileBrowserInline] create folder error', err);
+    }
+  };
+
+  return (
+    <div className="border border-secondary rounded p-2 space-y-2">
+      {editingFile ? (
+        <div className="space-y-2">
+          <div className="font-semibold">{editingFile.path}</div>
+          <Input value={issueId} onChange={(e) => setIssueId(e.target.value)} placeholder="Issue ID" />
+          <Input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Commit message" />
+          <TextArea rows={10} value={content} onChange={(e) => setContent(e.target.value)} />
+          <div className="flex gap-2">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Commit Change'}
+            </Button>
+            <Button variant="ghost" onClick={() => setEditingFile(null)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <div className="mb-2 flex justify-between items-center">
+            <div className="font-semibold">{currentPath || 'root'}</div>
+            <div className="space-x-2">
+              {currentPath && (
+                <button className="text-accent underline text-xs" onClick={() => setCurrentPath(currentPath.replace(/[^/]+\/?$/, ''))}>
+                  Back
+                </button>
+              )}
+              {onClose && (
+                <button className="text-accent underline text-xs" onClick={onClose}>
+                  Close
+                </button>
+              )}
+            </div>
+          </div>
+          {creatingFolder && (
+            <div className="flex gap-2 mb-2">
+              <Input value={newFolder} onChange={(e) => setNewFolder(e.target.value)} placeholder="Folder name" />
+              <Button size="sm" onClick={handleCreateFolder}>Create</Button>
+              <Button size="sm" variant="ghost" onClick={() => setCreatingFolder(false)}>Cancel</Button>
+            </div>
+          )}
+          {isLoading ? (
+            <div>Loading...</div>
+          ) : (
+            <>
+              <ul className="space-y-1">
+                {items.map((f) => (
+                  <li key={f.path}>
+                    <button className="text-accent underline text-sm" onClick={() => handleOpen(f)}>
+                      {f.type === 'folder' ? '📁' : '📄'} {f.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-2 text-right">
+                <button className="text-xs underline" onClick={() => setCreatingFolder(true)}>
+                  + New Folder
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GitFileBrowserInline;

--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -29,6 +29,8 @@ interface GraphLayoutProps {
   showInspector?: boolean;
   /** Notify parent when a node is selected */
   onSelectNode?: (n: Post) => void;
+  /** Custom handler when a node is clicked */
+  onNodeClick?: (n: Post) => void;
   /** Notify parent when edges change */
   onEdgesChange?: (edges: TaskEdge[]) => void;
   onScrollEnd?: () => void;
@@ -65,6 +67,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   showStatus = true,
   showInspector = true,
   onSelectNode,
+  onNodeClick,
   onEdgesChange,
   onScrollEnd,
   loadingMore = false,
@@ -360,6 +363,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
             onFocus={handleNodeFocus}
             selectedNode={selectedNode}
             onSelect={handleNodeClick}
+            onNodeClick={onNodeClick}
             onRemoveEdge={handleRemoveEdge}
             diffData={diffData}
             diffLoading={diffLoading}

--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -29,6 +29,8 @@ interface GraphNodeProps {
   onFocus?: (id: string) => void;
   selectedNode: Post | null;
   onSelect: (n: Post) => void;
+  /** Custom handler when a node is clicked */
+  onNodeClick?: (n: Post) => void;
   diffData?: { diffMarkdown?: string } | null;
   diffLoading: boolean;
   registerNode?: (id: string, el: HTMLDivElement | null) => void;
@@ -48,6 +50,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   onFocus,
   selectedNode,
   onSelect,
+  onNodeClick,
   diffData,
   diffLoading,
   registerNode,
@@ -240,15 +243,23 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           className="mb-6 flex items-start space-x-2 cursor-pointer"
           onClick={() => {
             onSelect(node);
-            window.dispatchEvent(
-              new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
-            );
+            if (onNodeClick) {
+              onNodeClick(node);
+            } else {
+              window.dispatchEvent(
+                new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
+              );
+            }
           }}
           onDoubleClick={() => {
             onSelect(node);
-            window.dispatchEvent(
-              new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
-            );
+            if (onNodeClick) {
+              onNodeClick(node);
+            } else {
+              window.dispatchEvent(
+                new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
+              );
+            }
           }}
         >
           <span
@@ -257,9 +268,13 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             {...listeners}
             onDoubleClick={() => {
               onSelect(node);
-              window.dispatchEvent(
-                new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
-              );
+              if (onNodeClick) {
+                onNodeClick(node);
+              } else {
+                window.dispatchEvent(
+                  new CustomEvent('questTaskOpen', { detail: { taskId: node.id } })
+                );
+              }
             }}
           >
             {icon}
@@ -355,6 +370,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
                 onFocus={onFocus}
                 selectedNode={selectedNode}
                 onSelect={onSelect}
+                onNodeClick={onNodeClick}
                 diffData={diffData}
                 diffLoading={diffLoading}
               />

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -22,7 +22,7 @@ import LinkViewer from '../ui/LinkViewer';
 import LinkControls from '../controls/LinkControls';
 import EditPost from './EditPost';
 import ActionMenu from '../ui/ActionMenu';
-import GitFileBrowser from '../git/GitFileBrowser';
+import GitFileBrowserInline from '../git/GitFileBrowserInline';
 import NestedReply from './NestedReply';
 import { buildSummaryTags } from '../../utils/displayUtils';
 import { TAG_BASE } from '../../constants/styles';
@@ -757,10 +757,12 @@ const PostCard: React.FC<PostCardProps> = ({
             View {post.taskType === 'file' ? 'File' : post.taskType === 'folder' ? 'Folder' : 'Planner'}
           </button>
           {showBrowser && (
-            <GitFileBrowser
-              questId={post.questId}
-              onClose={() => setShowBrowser(false)}
-            />
+            <div className="mt-2">
+              <GitFileBrowserInline
+                questId={post.questId}
+                onClose={() => setShowBrowser(false)}
+              />
+            </div>
           )}
         </>
       )}

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -16,6 +16,7 @@ import ActionMenu from '../ui/ActionMenu';
 import TaskPreviewCard from '../post/TaskPreviewCard';
 import FileEditorPanel from './FileEditorPanel';
 import StatusBoardPanel from './StatusBoardPanel';
+import GitFileBrowserInline from '../git/GitFileBrowserInline';
 import { getRank } from '../../utils/rankUtils';
 
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
@@ -355,6 +356,9 @@ const QuestCard: React.FC<QuestCardProps> = ({
     return (
       <div className="space-y-2 p-2">
         <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
+        {selectedNode.taskType === 'file' && (
+          <GitFileBrowserInline questId={quest.id} />
+        )}
         <FileEditorPanel
           questId={quest.id}
           filePath={selectedNode.gitFilePath || 'file.txt'}

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -37,18 +37,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
     const ids = new Set<string>();
     const gatherChildren = (id: string) => {
       ids.add(id);
-      edges.filter(e => e.from === id).forEach(e => gatherChildren(e.to));
-    };
-    const gatherParents = (id: string) => {
-      edges.filter(e => e.to === id).forEach(e => {
-        if (!ids.has(e.from)) {
-          ids.add(e.from);
-          gatherParents(e.from);
-        }
-      });
+      edges.filter((e) => e.from === id).forEach((e) => gatherChildren(e.to));
     };
     gatherChildren(task.id);
-    gatherParents(task.id);
     return ids;
   }, [task.id, edges]);
 
@@ -123,6 +114,11 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
               showInspector={false}
               showStatus={false}
               onSelectNode={setSelected}
+              onNodeClick={(n) => {
+                if (n.id !== task.id) {
+                  navigate(ROUTES.POST(n.id));
+                }
+              }}
             />
           </div>
         </div>

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -3,6 +3,7 @@ import GraphLayout from '../layout/GraphLayout';
 import { useGraph } from '../../hooks/useGraph';
 import TaskPreviewCard from '../post/TaskPreviewCard';
 import QuestNodeInspector from './QuestNodeInspector';
+import { ROUTES } from '../../constants/routes';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
@@ -64,6 +65,11 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
               showInspector={false}
               showStatus={false}
               onSelectNode={setSelected}
+              onNodeClick={(n) => {
+                if (n.id !== task.id) {
+                  window.location.assign(ROUTES.POST(n.id));
+                }
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add onNodeClick prop to GraphLayout and GraphNode
- limit TaskCard subgraph to children only and open nodes in new pages
- hook TaskGraphSidePanel and TaskCard to open task pages on map click
- display Git file browser inline in QuestCard and PostCard
- add new `GitFileBrowserInline` component

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm test` in `ethos-backend` *(fails: supertest missing)*

------
https://chatgpt.com/codex/tasks/task_e_685989ff8790832fa3c62c2988df5d05