### PR TITLE
Add map view and folder tab for tasks

### DIFF
--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -15,12 +15,15 @@ interface MapGraphLayoutProps {
   loadingMore?: boolean;
   /** Notify parent when the edge list updates */
   onEdgesChange?: (edges: TaskEdge[]) => void;
+  /** Custom handler when a node is clicked */
+  onNodeClick?: (node: Post) => void;
 }
 
 const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
   items,
   edges = [],
   onEdgesChange,
+  onNodeClick,
 }) => {
   const fgRef = useRef<ForceGraphMethods>();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -72,9 +75,13 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
 
   const handleNodeClick = (node: unknown) => {
     const n = node as Post;
-    window.dispatchEvent(
-      new CustomEvent('questTaskOpen', { detail: { taskId: n.id } }),
-    );
+    if (onNodeClick) {
+      onNodeClick(n);
+    } else {
+      window.dispatchEvent(
+        new CustomEvent('questTaskOpen', { detail: { taskId: n.id } }),
+      );
+    }
   };
 
   const handleNodeDragEnd = (node: unknown) => {


### PR DESCRIPTION
## Summary
- add `onNodeClick` prop to `MapGraphLayout`
- switch `TaskCard` left panel to map view
- add folder tab with status board inside `TaskCard`
- reuse folder tree in `QuestCard` when selected node is a folder

## Testing
- `npm test` (backend) *(fails: Cannot find module 'supertest')*
- `npm test` (frontend) *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68598e54c0c8832f97573c91e8115d0a