### PR TITLE
Fix linking for nested subtasks

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -186,12 +186,12 @@ router.post(
       const quest = quests.find((q) => q.id === questId);
       if (quest) {
         quest.taskGraph = quest.taskGraph || [];
-        const from = quest.headPostId || '';
+        const parentId = replyTo || linkedNodeId || quest.headPostId || '';
         const exists = quest.taskGraph.some(
-          (e) => e.from === from && e.to === newPost.id
+          (e) => e.from === parentId && e.to === newPost.id
         );
         if (!exists) {
-          quest.taskGraph.push({ from, to: newPost.id });
+          quest.taskGraph.push({ from: parentId, to: newPost.id });
         }
         questsStore.write(quests);
       }


### PR DESCRIPTION
## Summary
- link new tasks to their parent in POST /posts route
- test linking when replyTo is provided

## Testing
- `bash setup.sh`
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_68598e919208832f8eec46a4c4574811