### PR TITLE
Fix parent edges for nested tasks

### DIFF
--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -237,9 +237,12 @@ router.patch(
       quest.linkedPosts.push({ itemId, itemType: 'post' });
       if (post && post.type === 'task') {
         quest.taskGraph = quest.taskGraph || [];
-        const edgeExists = quest.taskGraph.some(e => e.to === itemId);
+        const from = post.replyTo || post.linkedNodeId || quest.headPostId;
+        const edgeExists = quest.taskGraph.some(
+          e => e.to === itemId && e.from === from
+        );
         if (!edgeExists) {
-          quest.taskGraph.push({ from: quest.headPostId, to: itemId });
+          quest.taskGraph.push({ from, to: itemId });
         }
       }
     }


### PR DESCRIPTION
## Summary
- ensure quest PATCH uses task parent for new taskGraph edges

## Testing
- `npm test --silent --prefix ethos-backend`
- `npm test --silent --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68599199b4a4832fb6a2876f24f79d5d