### PR TITLE
Add file diff view and planner checklist

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -52,4 +52,6 @@ The inspector sidebar lets you change the task type. Changing from `file` to `fo
 
 Tab labels reflect the selected type: selecting **file** shows a *File* tab, **folder** shows a *Folder* tab, and **planner** displays a *Planner* tab.
 
+File tasks display the latest Git diff and an inline file editor. Planner nodes render their child tasks as a checklist so progress can be tracked when exporting the repo or downloading a specific file.
+
 

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -18,6 +18,9 @@ import TaskPreviewCard from '../post/TaskPreviewCard';
 import FileEditorPanel from './FileEditorPanel';
 import StatusBoardPanel from './StatusBoardPanel';
 import GitFileBrowserInline from '../git/GitFileBrowserInline';
+import GitDiffViewer from '../git/GitDiffViewer';
+import { useGitDiff } from '../../hooks/useGit';
+import SubtaskChecklist from './SubtaskChecklist';
 import { getRank } from '../../utils/rankUtils';
 
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
@@ -73,6 +76,12 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const [linkDraft, setLinkDraft] = useState(quest.linkedPosts || []);
   const [joinRequested, setJoinRequested] = useState(false);
   const navigate = useNavigate();
+
+  const { data: diffData, isLoading: diffLoading } = useGitDiff({
+    questId: quest.id,
+    filePath: selectedNode?.gitFilePath,
+    commitId: selectedNode?.gitCommitSha,
+  });
 
   const expanded = expandedProp !== undefined ? expandedProp : internalExpanded;
 
@@ -346,6 +355,15 @@ const QuestCard: React.FC<QuestCardProps> = ({
       .map((e) => e.to);
     const children = logs.filter((p) => childIds.includes(p.id));
     const isFolder = selectedNode.id === rootNode?.id || children.length > 0;
+
+    if (selectedNode.taskType === 'abstract') {
+      return (
+        <div className="space-y-2 p-2">
+          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
+          <SubtaskChecklist questId={quest.id} nodeId={selectedNode.id} />
+        </div>
+      );
+    }
     if (isFolder) {
       return (
         <div className="text-sm p-2 space-y-2">
@@ -393,7 +411,12 @@ const QuestCard: React.FC<QuestCardProps> = ({
       <div className="space-y-2 p-2">
         <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
         {selectedNode.taskType === 'file' && (
-          <GitFileBrowserInline questId={quest.id} />
+          <>
+            <GitFileBrowserInline questId={quest.id} />
+            {diffLoading ? null : diffData?.diffMarkdown && (
+              <GitDiffViewer markdown={diffData.diffMarkdown} />
+            )}
+          </>
         )}
         <FileEditorPanel
           questId={quest.id}

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -9,6 +9,8 @@ import QuickTaskForm from '../post/QuickTaskForm';
 import TeamPanel from './TeamPanel';
 import SubtaskChecklist from './SubtaskChecklist';
 import { useGraph } from '../../hooks/useGraph';
+import GitDiffViewer from '../git/GitDiffViewer';
+import { useGitDiff } from '../../hooks/useGit';
 import { Select } from '../ui';
 import { updatePost } from '../../api/post';
 import { TASK_TYPE_OPTIONS, STATUS_OPTIONS } from '../../constants/options';
@@ -44,6 +46,11 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   const [boardOpen, setBoardOpen] = useState(true);
   const [statusVal, setStatusVal] = useState<QuestTaskStatus>(status || node?.status || 'To Do');
   const { loadGraph } = useGraph();
+  const { data: diffData, isLoading: diffLoading } = useGitDiff({
+    questId,
+    filePath: node?.gitFilePath,
+    commitId: node?.gitCommitSha,
+  });
 
   useEffect(() => {
     setType(node?.taskType || 'abstract');
@@ -152,11 +159,16 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
             )}
           </div>
           {type === 'file' ? (
-            <FileEditorPanel
-              questId={questId}
-              filePath={node.gitFilePath || 'file.txt'}
-              content={node.content}
-            />
+            <>
+              {diffLoading ? null : diffData?.diffMarkdown && (
+                <GitDiffViewer markdown={diffData.diffMarkdown} />
+              )}
+              <FileEditorPanel
+                questId={questId}
+                filePath={node.gitFilePath || 'file.txt'}
+                content={node.content}
+              />
+            </>
           ) : (
             <SubtaskChecklist questId={questId} nodeId={node.id} />
           )}


### PR DESCRIPTION
## Summary
- display git diffs in QuestCard and QuestNodeInspector when a file task is selected
- show subtask checklist for planner tasks
- document task panel behavior

## Testing
- `npx tsc -p ethos-frontend/tsconfig.json --noEmit`
- `npm test --silent`
- `npm --workspace ethos-frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68599287bc9c832f856ca47fd4c74b6e