### PR TITLE
Fix map graph errors and add error boundaries

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -18,6 +18,7 @@ import type { User } from '../../types/userTypes';
 import { Spinner } from '../ui';
 import QuickTaskForm from '../post/QuickTaskForm';
 
+import { ErrorBoundary } from '../ui';
 type GridLayoutProps = {
   items: Post[];
   user?: User;
@@ -50,7 +51,8 @@ const DraggableCard: React.FC<{
   initialExpanded?: boolean;
   expandedId?: string | null;
   onExpand?: (id: string | null) => void;
-}> = ({ item, user, compact, onEdit, onDelete, initialExpanded, expandedId, onExpand }) => {
+  boardId?: string;
+}> = ({ item, user, compact, onEdit, onDelete, initialExpanded, expandedId, onExpand, boardId }) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: item.id,
     data: { item },
@@ -273,15 +275,16 @@ const GridLayout: React.FC<GridLayoutProps> = ({
               </h3>
               <DroppableColumn id={col}>
                 {grouped[col].map((item) => (
-                  <DraggableCard
-                    key={item.id}
-                    item={item}
-                    user={user}
-                    compact={true}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                    boardId={boardId}
-                  />
+                  <ErrorBoundary key={item.id}>
+                    <DraggableCard
+                      item={item}
+                      user={user}
+                      compact={true}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      boardId={boardId}
+                    />
+                  </ErrorBoundary>
                 ))}
               </DroppableColumn>
             </div>

--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -37,13 +37,16 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
     fgRef.current?.zoomToFit(200, 20);
   }, [items, edgeList]);
 
-  const data = useMemo(
-    () => ({
+  const data = useMemo(() => {
+    const nodeSet = new Set(items.map((p) => p.id));
+    const links = edgeList
+      .filter((e) => nodeSet.has(e.from) && nodeSet.has(e.to))
+      .map((e) => ({ source: e.from, target: e.to }));
+    return {
       nodes: items.map((p) => ({ ...p, id: p.id, val: 4 })),
-      links: edgeList.map((e) => ({ source: e.from, target: e.to })),
-    }),
-    [items, edgeList],
-  );
+      links,
+    };
+  }, [items, edgeList]);
 
   const emitEdges = (updated: TaskEdge[]) => {
     if (onEdgesChange) {
@@ -86,7 +89,11 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
 
   const handleNodeDragEnd = (node: unknown) => {
     const dragged = node as Post & { x?: number; y?: number };
-    const nodes = fgRef.current?.graphData().nodes || [];
+    const data =
+      typeof fgRef.current?.graphData === 'function'
+        ? fgRef.current?.graphData()
+        : fgRef.current?.graphData;
+    const nodes = data?.nodes || [];
     let targetId: string | null = null;
     let minDist = Infinity;
     nodes.forEach((n) => {

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -264,7 +264,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
               }
               if (!expanded) {
                 setActiveTab('file');
-                setMapMode('folder');
               }
             }}
           >

--- a/ethos-frontend/src/components/ui/ErrorBoundary.tsx
+++ b/ethos-frontend/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<{ children?: React.ReactNode }, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div className="p-4 text-red-500">Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/ethos-frontend/src/components/ui/index.tsx
+++ b/ethos-frontend/src/components/ui/index.tsx
@@ -17,3 +17,4 @@ export { default as MarkdownRenderer } from './MarkdownRenderer';
 export { default as MarkdownEditor } from './MarkdownEditor';
 export { default as AvatarStack } from './AvatarStack';
 export { default as SummaryTag } from './SummaryTag';
+export { default as ErrorBoundary } from "./ErrorBoundary";


### PR DESCRIPTION
## Summary
- sanitize GraphLayout data to filter invalid links
- handle ForceGraph graphData API safely
- ensure boardId prop is passed to DraggableCard
- wrap Kanban cards in an error boundary component
- remove unused setMapMode call
- add new ErrorBoundary component

## Testing
- `npm test --silent --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6859919c819c832f8807e5cb83241064