### PR TITLE
Fix folder map saving

### DIFF
--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -11,9 +11,11 @@ import { Select } from '../ui';
 import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
 import type { option } from '../../constants/options';
 import { updatePost } from '../../api/post';
+import { updateQuestTaskGraph } from '../../api/quest';
 import { ROUTES } from '../../constants/routes';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
+import type { TaskEdge } from '../../types/questTypes';
 
 interface TaskCardProps {
   task: Post;
@@ -37,6 +39,15 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
       loadGraph(questId);
     }
   }, [questId, loadGraph]);
+
+  const handleEdgesSave = async (edgesToSave: TaskEdge[]) => {
+    try {
+      await updateQuestTaskGraph(questId, edgesToSave);
+      await loadGraph(questId);
+    } catch (err) {
+      console.error('[TaskCard] Failed to save task graph', err);
+    }
+  };
 
   const subgraphIds = useMemo(() => {
     const ids = new Set<string>();
@@ -113,6 +124,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
             <MapGraphLayout
               items={displayNodes}
               edges={displayEdges}
+              onEdgesChange={handleEdgesSave}
               onNodeClick={(n) => {
                 if (n.id !== task.id) {
                   navigate(ROUTES.POST(n.id));
@@ -186,6 +198,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
                   condensed
                   showInspector={false}
                   showStatus={false}
+                  onEdgesChange={handleEdgesSave}
                   onNodeClick={(n) => {
                     if (n.id !== task.id) {
                       navigate(ROUTES.POST(n.id));

--- a/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
+++ b/ethos-frontend/src/components/quest/TaskGraphSidePanel.tsx
@@ -4,8 +4,10 @@ import { useGraph } from '../../hooks/useGraph';
 import TaskPreviewCard from '../post/TaskPreviewCard';
 import QuestNodeInspector from './QuestNodeInspector';
 import { ROUTES } from '../../constants/routes';
+import { updateQuestTaskGraph } from '../../api/quest';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
+import type { TaskEdge } from '../../types/questTypes';
 
 interface TaskGraphSidePanelProps {
   task: Post;
@@ -23,6 +25,15 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
       loadGraph(questId);
     }
   }, [questId, loadGraph]);
+
+  const handleEdgesSave = async (edgesToSave: TaskEdge[]) => {
+    try {
+      await updateQuestTaskGraph(questId, edgesToSave);
+      await loadGraph(questId);
+    } catch (err) {
+      console.error('[TaskGraphSidePanel] Failed to save task graph', err);
+    }
+  };
 
   const subgraphIds = useMemo(() => {
     const ids = new Set<string>();
@@ -64,6 +75,7 @@ const TaskGraphSidePanel: React.FC<TaskGraphSidePanelProps> = ({ task, questId, 
               condensed
               showInspector={false}
               showStatus={false}
+              onEdgesChange={handleEdgesSave}
               onSelectNode={setSelected}
               onNodeClick={(n) => {
                 if (n.id !== task.id) {


### PR DESCRIPTION
## Summary
- persist folder structure updates when editing tasks
- refresh graph view after saving edges

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68599614e968832fa5c836fb8158917e