### PR TITLE
Fix quest title truncation

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -66,7 +66,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
 
   const summaryTags = buildSummaryTags(post);
   let taskTag = summaryTags.find(t => t.type === 'task');
-  const shortTitle = headerText.length > 20 ? headerText.slice(0, 20) + '…' : headerText;
+  const shortTitle = headerText.length > 20 ? headerText.slice(0, 20) + '...' : headerText;
   if (taskTag) {
     taskTag = {
       ...taskTag,

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -195,7 +195,7 @@ export const buildSummaryTags = (
   }
 
   if (!multipleSources && title) {
-    const shortTitle = title.length > 20 ? title.slice(0, 20) + '…' : title;
+    const shortTitle = title.length > 20 ? title.slice(0, 20) + '...' : title;
     tags.push({
       type: "quest",
       label: `Quest: ${shortTitle}`,


### PR DESCRIPTION
## Summary
- show `...` when quest titles are truncated in summary tags

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*
- `npm test` in backend


------
https://chatgpt.com/codex/tasks/task_e_68599cd65504832fa0e741d3b923f6f0