### PR TITLE
Remove summary tag from expanded task preview

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -12,6 +12,7 @@ interface TaskPreviewCardProps {
   post: Post;
   onUpdate?: (updated: Post) => void;
   summaryOnly?: boolean;
+  hideSummaryTag?: boolean;
 }
 
 const makeHeader = (content: string): string => {
@@ -19,7 +20,12 @@ const makeHeader = (content: string): string => {
   return text.length <= 50 ? text : text.slice(0, 50) + '…';
 };
 
-const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summaryOnly = false }) => {
+const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
+  post,
+  onUpdate,
+  summaryOnly = false,
+  hideSummaryTag = false,
+}) => {
   const [status, setStatus] = useState<QuestTaskStatus>(post.status || 'To Do');
   const [taskType, setTaskType] = useState(post.taskType || 'abstract');
   const [organizeFile, setOrganizeFile] = useState(false);
@@ -89,7 +95,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({ post, onUpdate, summa
     } as any;
   }
 
-  const tagNode = taskTag ? (
+  const tagNode = !hideSummaryTag && taskTag ? (
     <div className="flex flex-wrap gap-1">
       <SummaryTag {...taskTag} />
     </div>

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -83,7 +83,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
     <div className="border border-secondary rounded-lg bg-surface p-4 space-y-2">
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex-1 space-y-2 md:pr-4" style={{ minWidth: 240 }}>
-          <TaskPreviewCard post={selected} summaryOnly />
+          <TaskPreviewCard post={selected} summaryOnly hideSummaryTag />
           <div className="flex items-center justify-between">
             {parentNode && (
               <div


### PR DESCRIPTION
## Summary
- hide SummaryTag in `TaskPreviewCard` when requested
- disable summary tag within `TaskCard`

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_68599c68ae74832f9f87dae164dd2c72