### PR TITLE
Add collapsed status board

### DIFF
--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PostCard from '../post/PostCard';
 import QuestCard from '../quest/QuestCard';
+import { ErrorBoundary } from '../ui';
 
 import type { Post } from '../../types/postTypes';
 import type { Quest } from '../../types/questTypes';
@@ -126,15 +127,17 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
     }
 
     return (
-      <QuestCard
-        quest={quest}
-        user={user}
-        compact={compact}
-        expanded={expanded}
-        onToggleExpand={onToggleExpand}
-        onEdit={onEdit ? () => onEdit(quest.id) : undefined}
-        onDelete={onDelete ? (q) => onDelete(q.id) : undefined}
-      />
+      <ErrorBoundary>
+        <QuestCard
+          quest={quest}
+          user={user}
+          compact={compact}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+          onEdit={onEdit ? () => onEdit(quest.id) : undefined}
+          onDelete={onDelete ? (q) => onDelete(q.id) : undefined}
+        />
+      </ErrorBoundary>
     );
   }
   // 🛑 Fallback for unknown types

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -20,6 +20,7 @@ import {
 import clsx from 'clsx';
 import CreatePost from '../post/CreatePost';
 import QuestCard from '../quest/QuestCard';
+import { ErrorBoundary } from '../ui';
 import TaskCard from '../quest/TaskCard';
 import { fetchQuestById } from '../../api/quest';
 import {
@@ -383,7 +384,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       {expanded && post.type === 'quest' && post.questId && (
         <div className="mt-3">
           {questData ? (
-            <QuestCard quest={questData} user={user} defaultExpanded hideToggle />
+            <ErrorBoundary>
+              <QuestCard quest={questData} user={user} defaultExpanded hideToggle />
+            </ErrorBoundary>
           ) : (
             <div className="text-sm">Loading...</div>
           )}

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -4,7 +4,7 @@ import { fetchActiveQuests } from '../../api/quest';
 import { fetchRecentPosts, fetchPostById } from '../../api/post';
 import QuestCard from './QuestCard';
 import CreateQuest from './CreateQuest';
-import { Spinner, Button } from '../ui';
+import { Spinner, Button, ErrorBoundary } from '../ui';
 import { BOARD_PREVIEW_LIMIT } from '../../constants/pagination';
 import type { Quest } from '../../types/questTypes';
 import type { Post } from '../../types/postTypes';
@@ -190,7 +190,9 @@ const ActiveQuestBoard: React.FC<ActiveQuestBoardProps> = ({ onlyMine }) => {
                   : 'scale-90 opacity-50')
               }
             >
-              <QuestCard quest={q} user={user} />
+              <ErrorBoundary>
+                <QuestCard quest={q} user={user} />
+              </ErrorBoundary>
             </div>
           ))}
         </div>

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -75,6 +75,8 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const [showLinkEditor, setShowLinkEditor] = useState(false);
   const [linkDraft, setLinkDraft] = useState(quest.linkedPosts || []);
   const [joinRequested, setJoinRequested] = useState(false);
+  const [showChecklist, setShowChecklist] = useState(false);
+  const [showFolderView, setShowFolderView] = useState(false);
   const navigate = useNavigate();
 
   const { data: diffData, isLoading: diffLoading } = useGitDiff({
@@ -179,6 +181,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
     }
   };
 
+
   const handleDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     const startX = e.clientX;
     const startWidth = mapWidth;
@@ -242,6 +245,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
     window.addEventListener('taskUpdated', handler);
     return () => window.removeEventListener('taskUpdated', handler);
   }, [selectedNode, rootNode]);
+
 
 
 
@@ -366,60 +370,85 @@ const QuestCard: React.FC<QuestCardProps> = ({
     const children = logs.filter((p) => childIds.includes(p.id));
     const isFolder = selectedNode.id === rootNode?.id || children.length > 0;
 
-    if (selectedNode.taskType === 'abstract') {
-      return (
-        <div className="space-y-2 p-2">
-          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
-          <SubtaskChecklist questId={quest.id} nodeId={selectedNode.id} />
+    const statusBoard = (
+      <StatusBoardPanel
+        questId={quest.id}
+        linkedNodeId={selectedNode.id}
+        initialOpen={false}
+      />
+    );
+
+    const checklistSection = (
+      <div className="border border-secondary rounded">
+        <div
+          className="flex justify-between items-center p-2 bg-soft cursor-pointer"
+          onClick={() => setShowChecklist((p) => !p)}
+        >
+          <span className="font-semibold text-sm">Checklist</span>
+          <span className="text-xs">{showChecklist ? '▲' : '▼'}</span>
         </div>
-      );
-    }
-    if (isFolder) {
-      return (
-        <div className="text-sm p-2 space-y-2">
-          <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
-          {showFolderForm && (
-            <QuickTaskForm
-              questId={quest.id}
-              parentId={selectedNode.id}
-              boardId={`task-${selectedNode.id}`}
-              allowIssue
-              onSave={(p) => {
-                setLogs((prev) => [...prev, p]);
-                setShowFolderForm(false);
-              }}
-              onCancel={() => setShowFolderForm(false)}
-            />
-          )}
-          <div className="text-right">
-            <button
-              onClick={() => setShowFolderForm((p) => !p)}
-              className="text-xs text-accent underline"
-            >
-              {showFolderForm ? '- Cancel' : '+ Add Item'}
-            </button>
+        {showChecklist && (
+          <div className="p-2">
+            <SubtaskChecklist questId={quest.id} nodeId={selectedNode.id} />
           </div>
-          <div className="h-64 overflow-auto">
-            <GraphLayout
-              items={folderNodes}
-              edges={folderEdges}
-              questId={quest.id}
-              condensed
-              showInspector={false}
-              showStatus={false}
-              onNodeClick={(n) => {
-                if (n.id !== selectedNode.id) {
-                  navigate(ROUTES.POST(n.id));
-                }
-              }}
-            />
-          </div>
+        )}
+      </div>
+    );
+
+    const folderSection = isFolder && (
+      <div className="border border-secondary rounded">
+        <div
+          className="flex justify-between items-center p-2 bg-soft cursor-pointer"
+          onClick={() => setShowFolderView((p) => !p)}
+        >
+          <span className="font-semibold text-sm">Folder Structure</span>
+          <span className="text-xs">{showFolderView ? '▲' : '▼'}</span>
         </div>
-      );
-    }
-    return (
-      <div className="space-y-2 p-2">
-        <StatusBoardPanel questId={quest.id} linkedNodeId={selectedNode.id} />
+        {showFolderView && (
+          <div className="p-2 space-y-2">
+            {showFolderForm && (
+              <QuickTaskForm
+                questId={quest.id}
+                parentId={selectedNode.id}
+                boardId={`task-${selectedNode.id}`}
+                allowIssue
+                onSave={(p) => {
+                  setLogs((prev) => [...prev, p]);
+                  setShowFolderForm(false);
+                }}
+                onCancel={() => setShowFolderForm(false)}
+              />
+            )}
+            <div className="text-right">
+              <button
+                onClick={() => setShowFolderForm((p) => !p)}
+                className="text-xs text-accent underline"
+              >
+                {showFolderForm ? '- Cancel' : '+ Add Item'}
+              </button>
+            </div>
+            <div className="h-64 overflow-auto">
+              <GraphLayout
+                items={folderNodes}
+                edges={folderEdges}
+                questId={quest.id}
+                condensed
+                showInspector={false}
+                showStatus={false}
+                onNodeClick={(n) => {
+                  if (n.id !== selectedNode.id) {
+                    navigate(ROUTES.POST(n.id));
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+
+    const fileSection = (
+      <div className="space-y-2">
         {selectedNode.taskType === 'file' && (
           <>
             <GitFileBrowserInline questId={quest.id} />
@@ -433,6 +462,15 @@ const QuestCard: React.FC<QuestCardProps> = ({
           filePath={selectedNode.gitFilePath || 'file.txt'}
           content={selectedNode.content}
         />
+      </div>
+    );
+
+    return (
+      <div className="space-y-2 p-2">
+        {statusBoard}
+        {checklistSection}
+        {folderSection}
+        {selectedNode.taskType !== 'abstract' && fileSection}
       </div>
     );
   };

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -8,6 +8,8 @@ import QuickTaskForm from '../post/QuickTaskForm';
 interface StatusBoardPanelProps {
   questId: string;
   linkedNodeId: string;
+  /** Whether the panel starts open. Default false */
+  initialOpen?: boolean;
 }
 
 const statusIcons: Record<string, string> = {
@@ -17,11 +19,15 @@ const statusIcons: Record<string, string> = {
   Done: '✅',
 };
 
-const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({ questId, linkedNodeId }) => {
+const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
+  questId,
+  linkedNodeId,
+  initialOpen = false,
+}) => {
   const [items, setItems] = useState<Post[]>([]);
   const [filter, setFilter] = useState<'all' | 'issues' | 'tasks'>('all');
   const [showForm, setShowForm] = useState(false);
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(initialOpen);
 
 
   useEffect(() => {

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -182,7 +182,11 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
             />
           ) : (
             <div className="space-y-2 p-2">
-              <StatusBoardPanel questId={questId} linkedNodeId={selected.id} />
+              <StatusBoardPanel
+                questId={questId}
+                linkedNodeId={selected.id}
+                initialOpen={false}
+              />
               {showFolderForm && (
                 <QuickTaskForm
                   questId={questId}

--- a/ethos-frontend/src/pages/admin/BannedQuests.tsx
+++ b/ethos-frontend/src/pages/admin/BannedQuests.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { fetchAllQuests } from '../../api/quest';
 import type { Quest } from '../../types/questTypes';
 import QuestCard from '../../components/quest/QuestCard';
-import { Spinner } from '../../components/ui';
+import { Spinner, ErrorBoundary } from '../../components/ui';
 
 const BannedQuestsPage: React.FC = () => {
   const { user } = useAuth();
@@ -32,7 +32,9 @@ const BannedQuestsPage: React.FC = () => {
     <main className="container mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold">Banned Quests</h1>
       {quests.map(q => (
-        <QuestCard key={q.id} quest={q} defaultExpanded />
+        <ErrorBoundary key={q.id}>
+          <QuestCard quest={q} defaultExpanded />
+        </ErrorBoundary>
       ))}
       {quests.length === 0 && <p>No banned quests.</p>}
     </main>


### PR DESCRIPTION
## Summary
- collapse StatusBoardPanel by default
- pass `initialOpen` to TaskCard and QuestCard so the status board starts closed
- wrap QuestCard usages with ErrorBoundary for safer rendering

## Testing
- `npm --prefix ethos-frontend test` *(fails: jest-environment-jsdom missing)*
- `npm --prefix ethos-backend test` *(fails: supertest and bcryptjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599bcd3e60832fbfe8c526f1719415