### PR TITLE
Fix undefined state vars

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -76,6 +76,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const [showLogForm, setShowLogForm] = useState(false);
   const [showFolderForm, setShowFolderForm] = useState(false);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
+  const [statusVal, setStatusVal] = useState<QuestTaskStatus>('To Do');
   const [linkDraft, setLinkDraft] = useState(quest.linkedPosts || []);
   const [joinRequested, setJoinRequested] = useState(false);
   const [showChecklist, setShowChecklist] = useState(false);

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -21,6 +21,8 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
   const { nodes, edges, loadGraph } = useGraph();
   const [selected, setSelected] = useState<Post>(task);
   const [detailWidth, setDetailWidth] = useState<number>(400);
+  const [activeTab, setActiveTab] = useState<'details' | 'folder'>('details');
+  const [showFolderForm, setShowFolderForm] = useState(false);
   const navigate = useNavigate();
 
   const handleNodeUpdate = (updated: Post) => {
@@ -62,6 +64,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
 
   const parentEdge = edges.find(e => e.to === task.id);
   const parentNode = parentEdge ? nodes.find(n => n.id === parentEdge.from) : undefined;
+
+  const taskType = selected.taskType || 'abstract';
+  const status = selected.status;
 
 
   const handleDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- fix QuestCard setStatusVal state usage
- add missing TaskCard state for tabs and folder form
- expose selected task type and status in TaskCard

## Testing
- `npm test` within `ethos-frontend`
- `npm test` within `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6859abde6220832faab7cade55d2ddc3