### PR TITLE
Simplify board summary labels

### DIFF
--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -156,7 +156,7 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
                       >
                         <SummaryTag
                           type={issue.type as 'task' | 'issue'}
-                          label={`${issue.type === 'issue' ? 'Issue' : 'Task'} - ${getQuestLinkLabel(issue, '', false)}`}
+                          label={getQuestLinkLabel(issue, '', false)}
                           link={ROUTES.POST(issue.id)}
                         />
                       </span>


### PR DESCRIPTION
## Summary
- update StatusBoardPanel to show just the node id for task and issue labels

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6859b814962c832f9245c76609fd0dd1