### PR TITLE
Fix immediate update in task inspector

### DIFF
--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -66,6 +66,9 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     setType(val);
     setActiveTab('file');
     if (node) {
+      // Optimistically update local state so parent components react immediately
+      const optimistic = { ...node, taskType: val } as Post;
+      onUpdate?.(optimistic);
       try {
         const updated = await updatePost(node.id, { taskType: val });
         onUpdate?.(updated);
@@ -83,6 +86,9 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
     setStatusVal(newStatus);
     onStatusChange?.(e);
     if (node) {
+      // Optimistically update local state for immediate UI feedback
+      const optimistic = { ...node, status: newStatus } as Post;
+      onUpdate?.(optimistic);
       try {
         const updated = await updatePost(node.id, { status: newStatus });
         onUpdate?.(updated);


### PR DESCRIPTION
## Summary
- optimistically update state when changing task type or status in `QuestNodeInspector`

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bcc427e4832f9d3f6ca3433c4f05