### PR TITLE
Fix quest board paging layout

### DIFF
--- a/ethos-frontend/src/components/layout/GridLayout.tsx
+++ b/ethos-frontend/src/components/layout/GridLayout.tsx
@@ -172,8 +172,8 @@ const GridLayout: React.FC<GridLayoutProps> = ({
   // that the hook order remains stable when the layout changes at runtime.
   const pagedContainerRef = useRef<HTMLDivElement>(null);
   const pages = useMemo(() => {
-    const perPage = 6; // show 6 posts at a time
-    const step = 1; // move one column at a time
+    const perPage = 6; // show 6 posts at a time (2 rows x 3 columns)
+    const step = 2; // move one request column (2 posts) at a time
     if (items.length <= perPage) return [items];
     const count = Math.ceil((items.length - perPage) / step) + 1;
     return Array.from({ length: count }, (_, i) =>
@@ -393,7 +393,7 @@ const GridLayout: React.FC<GridLayoutProps> = ({
             {pages.map((group, idx) => (
               <div
                 key={idx}
-                className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 px-2 flex-shrink-0 w-full snap-center"
+                className="grid grid-cols-3 gap-6 px-2 flex-shrink-0 w-full snap-center"
               >
                 {group.map(item => (
                 <ContributionCard


### PR DESCRIPTION
## Summary
- adjust quest board `GridLayout` to show a 3x2 grid on each page
- slide by one column of requests at a time

## Testing
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*
- `npm run lint --prefix ethos-frontend` *(fails: eslint-plugin-react-hooks missing)*
- `npm test --prefix ethos-backend` *(fails: supertest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859c06cd224832f8411e53da12b5f6d