### PR TITLE
fix duplicate status display

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -13,7 +13,7 @@ import { linkPostToQuest, fetchQuestById } from '../../api/quest';
 import { useGraph } from '../../hooks/useGraph';
 import ReactionControls from '../controls/ReactionControls';
 import CreatePost from './CreatePost';
-import { StatusBadge, Spinner, Select, SummaryTag } from '../ui';
+import { Spinner, Select, SummaryTag } from '../ui';
 import { STATUS_OPTIONS } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
 import MarkdownRenderer from '../ui/MarkdownRenderer';
@@ -410,9 +410,6 @@ const PostCard: React.FC<PostCardProps> = ({
               </React.Fragment>
             ))}
             {post.type === 'review' && post.rating && renderStars(post.rating)}
-            {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
-              <StatusBadge status={post.status} />
-            )}
           </div>
           <div className="flex items-center gap-2">
             {['task', 'quest'].includes(post.type) && (
@@ -490,9 +487,6 @@ const PostCard: React.FC<PostCardProps> = ({
             </React.Fragment>
           ))}
           {post.type === 'review' && post.rating && renderStars(post.rating)}
-          {!isQuestBoardRequest && post.status && post.status !== 'To Do' && (
-            <StatusBadge status={post.status} />
-          )}
           {!isQuestBoardRequest &&
             canEdit &&
             ['task', 'request', 'issue'].includes(post.type) &&


### PR DESCRIPTION
## Summary
- remove redundant status badge from PostCard to avoid duplicate progress info

## Testing
- `npm test` (backend)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_6859c0b4baf4832f8c4249bc2e7dfcf8