### PR TITLE
Adjust timeline board post width

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -132,7 +132,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const widthClass =
     ctxBoardId === 'timeline-board' || ctxBoardId === 'my-posts'
-      ? 'max-w-xl'
+      ? 'max-w-3xl'
       : 'max-w-prose';
 
   const expandedView = expanded !== undefined ? expanded : internalExpandedView;


### PR DESCRIPTION
## Summary
- widen posts on the timeline board so they take up more space

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_6859c0da8c4c832f86ca20c47a64471c