### PR TITLE
Increase request card width

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ npm test --prefix ethos-backend
 This runs the Jest tests under `ethos-backend/tests`.
 
 To run the frontend test suite:
-Ensure `jest-environment-jsdom` is installed for the frontend tests.
+Ensure `jest-environment-jsdom` is installed for the frontend tests. Running
+`./setup.sh` will install this dependency for you.
 
 ```bash
 npm test --prefix ethos-frontend

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -130,16 +130,18 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const ctxBoardId = boardId || selectedBoard;
 
-  const widthClass =
-    ctxBoardId === 'timeline-board' || ctxBoardId === 'my-posts'
-      ? 'max-w-3xl'
-      : 'max-w-prose';
-
-  const expandedView = expanded !== undefined ? expanded : internalExpandedView;
-
   const isQuestBoardRequest =
     post.type === 'request' && ctxBoardId === 'quest-board';
   const isTimelineRequest = post.type === 'request' && ctxBoardId === 'timeline-board';
+
+  const widthClass =
+    ctxBoardId === 'timeline-board' || ctxBoardId === 'my-posts'
+      ? 'max-w-3xl'
+      : isQuestBoardRequest
+        ? 'max-w-2xl'
+        : 'max-w-prose';
+
+  const expandedView = expanded !== undefined ? expanded : internalExpandedView;
 
   const handleStatusChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value;
@@ -443,7 +445,7 @@ const PostCard: React.FC<PostCardProps> = ({
           )}
         {titleText && (
           <h3
-            className="font-semibold text-lg mt-1 cursor-pointer"
+            className="font-semibold text-lg mt-1 cursor-pointer truncate"
             onClick={() => navigate(ROUTES.POST(post.id))}
           >
             {titleText}
@@ -540,7 +542,7 @@ const PostCard: React.FC<PostCardProps> = ({
       {renderRepostInfo()}
 
       {titleText && (
-        <h3 className="font-semibold text-lg mt-1">{titleText}</h3>
+        <h3 className="font-semibold text-lg mt-1 truncate">{titleText}</h3>
       )}
 
       <div className="text-sm text-primary">

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -55,7 +55,12 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
   };
 
   return (
-    <div className={"border border-secondary rounded bg-surface p-4 space-y-2 " + (className || '')}>
+    <div
+      className={
+        'border border-secondary rounded bg-surface p-4 space-y-2 w-full max-w-xl ' +
+        (className || '')
+      }
+    >
       <div className="flex items-center gap-2 text-sm text-secondary">
         <SummaryTag type="request" label={POST_TYPE_LABELS.request} />
         {post.questId && (
@@ -63,7 +68,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         )}
       </div>
       {post.title && (
-        <h3 className="font-semibold text-lg">{toTitleCase(post.title)}</h3>
+        <h3 className="font-semibold text-lg truncate">{toTitleCase(post.title)}</h3>
       )}
       {post.content && <p className="text-sm text-primary">{post.content}</p>}
       <div className="flex items-center gap-2 text-xs text-secondary">


### PR DESCRIPTION
## Summary
- widen quest board request cards and truncate long request titles
- widen standalone RequestCard component
- clarify README about installing the jsdom test environment

## Testing
- `npm test --prefix ethos-frontend --silent`
- `npm test --prefix ethos-backend --silent`


------
https://chatgpt.com/codex/tasks/task_e_6859c2911400832f9757ef1905765ab6