### PR TITLE
Improve board item persistence

### DIFF
--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -26,7 +26,22 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const [selectedBoard, setSelectedBoard] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [, setBoardMetaState] = useState<{ id: string; title: string; layout: string } | null>(null);
-  const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
+  const EXPANDED_KEY = 'ethos.expandedItem';
+  const [expandedItemId, setExpandedItemId] = useState<string | null>(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(EXPANDED_KEY) || null;
+    }
+    return null;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (expandedItemId) {
+      localStorage.setItem(EXPANDED_KEY, expandedItemId);
+    } else {
+      localStorage.removeItem(EXPANDED_KEY);
+    }
+  }, [expandedItemId]);
 
   const setBoardMeta = useCallback(
     (meta: { id: string; title: string; layout: string }) => {


### PR DESCRIPTION
## Summary
- store the last expanded board item in localStorage and restore it when boards load

## Testing
- `npm test` in `ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test` in `ethos-frontend` *(fails: jest-environment-jsdom not found)*
- `npm run lint` in `ethos-frontend` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859f440f370832fac24a394b8170f3b