### PR TITLE
Fix optimistic update for TaskPreviewCard

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -44,7 +44,11 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
   ) => {
     const val = e.target.value as QuestTaskStatus;
     setStatus(val);
-    onUpdate?.({ ...post, status: val });
+    const optimistic = { ...post, status: val };
+    onUpdate?.(optimistic);
+    document.dispatchEvent(
+      new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+    );
     try {
       const updated = await updatePost(post.id, { status: val });
       onUpdate?.(updated);
@@ -60,7 +64,11 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
   ) => {
     const val = e.target.value as 'file' | 'folder' | 'abstract';
     setTaskType(val);
-    onUpdate?.({ ...post, taskType: val });
+    const optimistic = { ...post, taskType: val };
+    onUpdate?.(optimistic);
+    document.dispatchEvent(
+      new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+    );
     try {
       const updated = await updatePost(post.id, { taskType: val });
       onUpdate?.(updated);


### PR DESCRIPTION
## Summary
- ensure task status and type changes trigger immediate board updates
- dispatch `taskUpdated` events optimistically in TaskPreviewCard

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a295a9f20832fa3d7247bdec49ec7