### PR TITLE
Fix task panel updates

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -131,7 +131,10 @@ const PostCard: React.FC<PostCardProps> = ({
   const dispatchTaskUpdated = (p: Post) => {
     if (p.type === 'task') {
       document.dispatchEvent(
-        new CustomEvent('taskUpdated', { detail: { task: p } })
+        new CustomEvent('taskUpdated', {
+          detail: { task: p },
+          bubbles: true,
+        })
       );
     }
   };

--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -47,13 +47,19 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
     const optimistic = { ...post, status: val };
     onUpdate?.(optimistic);
     document.dispatchEvent(
-      new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+      new CustomEvent('taskUpdated', {
+        detail: { task: optimistic },
+        bubbles: true,
+      })
     );
     try {
       const updated = await updatePost(post.id, { status: val });
       onUpdate?.(updated);
       document.dispatchEvent(
-        new CustomEvent('taskUpdated', { detail: { task: updated } })
+        new CustomEvent('taskUpdated', {
+          detail: { task: updated },
+          bubbles: true,
+        })
       );
     } catch (err) {
       console.error('[TaskPreviewCard] Failed to update status', err);
@@ -67,13 +73,19 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
     const optimistic = { ...post, taskType: val };
     onUpdate?.(optimistic);
     document.dispatchEvent(
-      new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+      new CustomEvent('taskUpdated', {
+        detail: { task: optimistic },
+        bubbles: true,
+      })
     );
     try {
       const updated = await updatePost(post.id, { taskType: val });
       onUpdate?.(updated);
       document.dispatchEvent(
-        new CustomEvent('taskUpdated', { detail: { task: updated } })
+        new CustomEvent('taskUpdated', {
+          detail: { task: updated },
+          bubbles: true,
+        })
       );
     } catch (err) {
       console.error('[TaskPreviewCard] Failed to update task type', err);

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -70,13 +70,19 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
       const optimistic = { ...node, taskType: val } as Post;
       onUpdate?.(optimistic);
       document.dispatchEvent(
-        new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+        new CustomEvent('taskUpdated', {
+          detail: { task: optimistic },
+          bubbles: true,
+        })
       );
       try {
         const updated = await updatePost(node.id, { taskType: val });
         onUpdate?.(updated);
         document.dispatchEvent(
-          new CustomEvent('taskUpdated', { detail: { task: updated } })
+          new CustomEvent('taskUpdated', {
+            detail: { task: updated },
+            bubbles: true,
+          })
         );
       } catch (err) {
         console.error('[QuestNodeInspector] Failed to update task type', err);
@@ -93,13 +99,19 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
       const optimistic = { ...node, status: newStatus } as Post;
       onUpdate?.(optimistic);
       document.dispatchEvent(
-        new CustomEvent('taskUpdated', { detail: { task: optimistic } })
+        new CustomEvent('taskUpdated', {
+          detail: { task: optimistic },
+          bubbles: true,
+        })
       );
       try {
         const updated = await updatePost(node.id, { status: newStatus });
         onUpdate?.(updated);
         document.dispatchEvent(
-          new CustomEvent('taskUpdated', { detail: { task: updated } })
+          new CustomEvent('taskUpdated', {
+            detail: { task: updated },
+            bubbles: true,
+          })
         );
       } catch (err) {
         console.error('[QuestNodeInspector] Failed to update status', err);


### PR DESCRIPTION
## Summary
- ensure custom `taskUpdated` events bubble

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685aa3bd2bac832f8b29836dd192f59d