### PR TITLE
Default expand task card on file tab

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -83,7 +83,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
   const [showReplyPanel, setShowReplyPanel] = useState(false);
   const [repostLoading, setRepostLoading] = useState(false);
-  const [internalExpanded, setInternalExpanded] = useState(false);
+  const [internalExpanded, setInternalExpanded] = useState(post.type === 'task');
   const [completed, setCompleted] = useState(post.tags?.includes('archived') ?? false);
   const [joining, setJoining] = useState(false);
   const [joined, setJoined] = useState(

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -118,7 +118,9 @@ const PostCard: React.FC<PostCardProps> = ({
   const [headPostId, setHeadPostId] = useState<string | null>(null);
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [linkExpanded, setLinkExpanded] = useState(false);
-  const [internalExpandedView, setInternalExpandedView] = useState(false);
+  const [internalExpandedView, setInternalExpandedView] = useState(
+    post.type === 'task'
+  );
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -41,7 +41,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   hideSelects = false,
 }) => {
   const [type, setType] = useState<string>(node?.taskType || 'abstract');
-  const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('logs');
+  const [activeTab, setActiveTab] = useState<'file' | 'logs' | 'options'>('file');
   const [showSubtaskForm, setShowSubtaskForm] = useState(false);
   const [boardOpen, setBoardOpen] = useState(true);
   const [statusVal, setStatusVal] = useState<QuestTaskStatus>(status || node?.status || 'To Do');
@@ -58,7 +58,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
   }, [node?.taskType, node?.status, status]);
 
   useEffect(() => {
-    setActiveTab('logs');
+    setActiveTab('file');
   }, [node?.id]);
 
   const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
## Summary
- expand task posts by default
- open QuestNodeInspector on file/folder tab

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aa6bd7c80832f97a26741067803cc