### PR TITLE
Fix stack overflow in TaskCard recursion

### DIFF
--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -84,8 +84,11 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
   const subgraphIds = useMemo(() => {
     const ids = new Set<string>();
     const gatherChildren = (id: string) => {
+      if (ids.has(id)) return; // Prevent infinite recursion on cyclical graphs
       ids.add(id);
-      edges.filter((e) => e.from === id).forEach((e) => gatherChildren(e.to));
+      edges
+        .filter((e) => e.from === id)
+        .forEach((e) => gatherChildren(e.to));
     };
     gatherChildren(task.id);
     return ids;


### PR DESCRIPTION
## Summary
- avoid infinite recursion when building TaskCard subgraph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aaa1720b0832f97a1abd6b451716b