### PR TITLE
Implement join workflow update

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -40,7 +40,7 @@ import {
   followPost,
   unfollowPost,
 } from '../../api/post';
-import type { Post, ReactionType, ReactionCountMap, Reaction } from '../../types/postTypes';
+import type { Post, ReactionType, ReactionCountMap, Reaction, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import type { Quest } from '../../types/questTypes';
 
@@ -110,6 +110,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const isQuestRequest = ctxBoardId === 'quest-board' && post.type === 'request';
   const isRequestCard =
     post.type === 'request' && ctxBoardId === 'quest-board';
+  const roleTag = post.tags?.find(t => t.toLowerCase().startsWith('role:'));
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
   const expanded = expandedProp !== undefined ? expandedProp : internalExpanded;
 
@@ -236,6 +237,17 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
 
   const handleJoin = async () => {
     if (!user) return;
+    const joinAndNavigate =
+      ctxBoardId === 'my-posts' && post.type === 'request' && post.questId && roleTag;
+    if (joinAndNavigate) {
+      const isPrivate =
+        post.visibility === 'private' || questData?.visibility === 'private';
+      const type: PostType = isPrivate ? 'request' : 'log';
+      navigate(
+        ROUTES.POST(post.id) + `?reply=1&initialType=${type}&intro=1`
+      );
+      return;
+    }
     try {
       setJoining(true);
       if (joined) {
@@ -332,7 +344,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               onClick={handleJoin}
               disabled={joining || !user}
             >
-              {joining ? '...' : (<><FaUserPlus /> {post.questId ? 'Join' : 'Apply'}</>)}
+              {joining ? '...' : (
+                <>
+                  <FaUserPlus />{' '}
+                  {post.questId && roleTag ? 'Join' : 'Accept'}
+                </>
+              )}
             </button>
           ) : (
             <span className="flex items-center gap-1">

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -24,6 +24,8 @@ type CreatePostProps = {
    * Useful when creating quest tasks or logs from a quest board.
    */
   questId?: string;
+  /** Prefill the content field */
+  initialContent?: string;
   /**
    * Optional board ID to associate the new post with.
    * When provided this overrides the currently selected board context.
@@ -47,6 +49,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   boardId,
   initialGitFilePath,
   initialLinkedNodeId,
+  initialContent,
 }) => {
   const restrictedReply =
     replyTo && ['task', 'log', 'commit', 'issue'].includes(replyTo.type);
@@ -56,7 +59,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   );
   const [status, setStatus] = useState<string>('To Do');
   const [title, setTitle] = useState<string>('');
-  const [content, setContent] = useState<string>('');
+  const [content, setContent] = useState<string>(initialContent || '');
   const [details, setDetails] = useState<string>('');
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -91,11 +91,11 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         </Button>
         <Button variant="primary" size="sm" onClick={handleJoin} disabled={joining}>
           {joining ? (
-            '...' 
+            '...'
           ) : joined ? (
             <><FaUserCheck className="inline mr-1" /> Joined</>
           ) : (
-            <><FaUserPlus className="inline mr-1" /> {post.questId ? 'Join' : 'Apply'}</>
+            <><FaUserPlus className="inline mr-1" /> {post.questId && role ? 'Join' : 'Accept'}</>
           )}
         </Button>
       </div>

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -12,7 +12,7 @@ import { ROUTES } from '../../constants/routes';
 import { fetchPostById, fetchReplyBoard } from '../../api/post';
 import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
 
-import type { Post } from '../../types/postTypes';
+import type { Post, PostType } from '../../types/postTypes';
 import type { BoardData } from '../../types/boardTypes';
 
 const PostPage: React.FC = () => {
@@ -21,6 +21,8 @@ const PostPage: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const initialTypeParam = searchParams.get('initialType') as PostType | null;
+  const introParam = searchParams.get('intro') === '1';
 
   const [post, setPost] = useState<Post | null>(null);
   const [replyBoard, setReplyBoard] = useState<BoardData | null>(null);
@@ -130,6 +132,12 @@ const PostPage: React.FC = () => {
           <div className="mt-4">
             <CreatePost
               replyTo={post}
+              initialType={initialTypeParam || undefined}
+              initialContent={
+                introParam && user
+                  ? `Hi @${post.author?.username}, I'm @${user.username} and would like to join.`
+                  : undefined
+              }
               onSave={() => {
                 setShowReplyForm(false);
                 navigate(ROUTES.POST(post.id), { replace: true });


### PR DESCRIPTION
## Summary
- add party role check and join navigation for reaction controls
- tweak request card text
- support prefilled content in create post
- allow passing initial type/content via post page

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: eslint-plugin-react-hooks missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5ebc644832f8d847ad50d9c9c33