### PR TITLE
Add quest post tag for request cards

### DIFF
--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -62,9 +62,15 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
       }
     >
       <div className="flex items-center gap-2 text-sm text-secondary">
-        <SummaryTag type="request" label={POST_TYPE_LABELS.request} />
+        <SummaryTag
+          type="request"
+          label={post.questId ? 'Quest Post' : POST_TYPE_LABELS.request}
+        />
         {post.questId && (
-          <SummaryTag type="quest" label={post.questNodeTitle || post.questTitle || 'Quest'} />
+          <SummaryTag
+            type="quest"
+            label={post.questNodeTitle || post.questTitle || 'Quest'}
+          />
         )}
       </div>
       {post.title && (


### PR DESCRIPTION
## Summary
- show `Quest Post` tag on quest board cards when the request is linked to a quest

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685ad80013e8832f9b00268d74e61307