### PR TITLE
Update quest board request actions

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -370,7 +370,15 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           </span>
         )}
 
-        {post.type !== 'task' && (
+        {(post.type === 'task' || post.type === 'quest') &&
+          !onToggleExpand && (
+            <button className="flex items-center gap-1" onClick={() => setInternalExpanded(prev => !prev)}>
+              {expanded ? <FaCompress /> : <FaExpand />}{' '}
+              {expanded ? 'Collapse View' : 'Expand View'}
+            </button>
+          )}
+
+        {post.type !== 'task' && !isRequestCard && (
           <button
             className={clsx(
               'flex items-center gap-1',
@@ -406,14 +414,6 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               : 'Reply'}
           </button>
         )}
-
-        {(post.type === 'task' || post.type === 'quest') &&
-          !onToggleExpand && (
-            <button className="flex items-center gap-1" onClick={() => setInternalExpanded(prev => !prev)}>
-              {expanded ? <FaCompress /> : <FaExpand />}{' '}
-              {expanded ? 'Collapse View' : 'Expand View'}
-            </button>
-          )}
 
         {timestamp && (
           <span className="ml-auto text-xs text-secondary">{timestamp}</span>

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { Post } from '../../types/postTypes';
 import { Button, AvatarStack, SummaryTag } from '../ui';
 import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
@@ -8,7 +8,6 @@ import { useAuth } from '../../contexts/AuthContext';
 import { acceptRequest, unacceptRequest } from '../../api/post';
 
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
-import CreatePost from '../post/CreatePost';
 
 interface RequestCardProps {
   post: Post;
@@ -17,7 +16,6 @@ interface RequestCardProps {
 }
 
 const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) => {
-  const [showReply, setShowReply] = useState(false);
   const { user } = useAuth();
   const collaboratorUsers = (post as any).enrichedCollaborators || [];
   const collaboratorCount = collaboratorUsers.filter((c: any) => c.userId).length || 0;
@@ -86,9 +84,6 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         </div>
       )}
       <div className="flex gap-2">
-        <Button variant="ghost" size="sm" onClick={() => setShowReply(r => !r)}>
-          {showReply ? 'Cancel' : 'Reply'}
-        </Button>
         <Button variant="primary" size="sm" onClick={handleJoin} disabled={joining}>
           {joining ? (
             '...'
@@ -99,16 +94,6 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
           )}
         </Button>
       </div>
-      {showReply && (
-        <CreatePost
-          replyTo={post}
-          onSave={(p) => {
-            onUpdate?.(p);
-            setShowReply(false);
-          }}
-          onCancel={() => setShowReply(false)}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide the Reply button on quest board request cards
- move Reply after other actions in ReactionControls
- remove Reply feature from generic RequestCard

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend` *(fails: POST /posts links task to parent when replyTo is set)*

------
https://chatgpt.com/codex/tasks/task_e_685ada5c66c4832fbd6bf177a1cf5ed9