### PR TITLE
Add quest task label and show tags on quest board

### DIFF
--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -15,9 +15,10 @@ jest.mock('../src/models/stores', () => ({
   usersStore: { read: jest.fn(() => []), write: jest.fn() },
   reactionsStore: { read: jest.fn(() => []), write: jest.fn() },
   questsStore: { read: jest.fn(() => []), write: jest.fn() },
+  notificationsStore: { read: jest.fn(() => []), write: jest.fn() },
 }));
 
-import { postsStore, questsStore, usersStore, reactionsStore } from '../src/models/stores';
+import { postsStore, questsStore, usersStore, reactionsStore, notificationsStore } from '../src/models/stores';
 
 const postsStoreMock = postsStore as jest.Mocked<any>;
 const questsStoreMock = questsStore as jest.Mocked<any>;

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -205,18 +205,6 @@ const PostCard: React.FC<PostCardProps> = ({
   const content = post.renderedContent || post.content;
   const titleText = post.title || makeHeader(post.content);
   let summaryTags = buildSummaryTags(post, questTitle, questId);
-  if (isQuestBoardRequest) {
-    const user = post.author?.username || post.authorId;
-    summaryTags = [
-      {
-        type: 'request',
-        label: 'Request:',
-        detailLink: ROUTES.POST(post.id),
-        username: user,
-        usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
-      },
-    ];
-  }
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -62,7 +62,14 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
       }
     >
       <div className="flex items-center gap-2 text-sm text-secondary">
-        <SummaryTag type="request" label={POST_TYPE_LABELS.request} />
+        {post.questId ? (
+          <SummaryTag
+            type="quest_task"
+            label={post.nodeId && /:T00$/.test(post.nodeId) ? 'Quest' : 'Quest Task'}
+          />
+        ) : (
+          <SummaryTag type="request" label={POST_TYPE_LABELS.request} />
+        )}
         {post.questId && (
           <SummaryTag type="quest" label={post.questNodeTitle || post.questTitle || 'Quest'} />
         )}

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -9,6 +9,7 @@ import {
   FaCommentAlt,
   FaUser,
   FaHandsHelping,
+  FaUserCheck,
   FaCog,
   FaBullhorn,
   FaCodeBranch,
@@ -28,6 +29,7 @@ export type SummaryTagType =
   | 'free_speech'
   | 'type'
   | 'request'
+  | 'quest_task'
   | 'commit'
   | 'meta_system'
   | 'meta_announcement'
@@ -56,6 +58,7 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
   free_speech: FaCommentAlt,
   type: FaUser,
   request: FaHandsHelping,
+  quest_task: FaUserCheck,
   commit: FaCodeBranch,
   meta_system: FaCog,
   meta_announcement: FaBullhorn,
@@ -73,6 +76,7 @@ const colors: Record<SummaryTagType, string> = {
   free_speech: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
   type: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
   request: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
+  quest_task: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-800 dark:text-cyan-200',
   commit: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   meta_system: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',
   meta_announcement: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -94,6 +94,7 @@ export interface SummaryTagData {
     | "free_speech"
     | "type"
     | "commit"
+    | "quest_task"
     | "meta_system"
     | "meta_announcement"
     | "solved";
@@ -142,12 +143,13 @@ export const buildSummaryTags = (
 
   if (post.type === "request") {
     if (post.questId && title) {
+      const isHead = post.nodeId ? /:T00$/.test(post.nodeId) : true;
       tags.push({
-        type: "request",
-        label: `Request: ${title}`,
+        type: "quest_task",
+        label: `${isHead ? 'Quest' : 'Quest Task'}: ${title}`,
         detailLink: ROUTES.POST(post.id),
       });
-      if (post.nodeId) {
+      if (post.nodeId && !isHead) {
         tags.push({
           type: "task",
           label: `Task: ${getQuestLinkLabel(post, title ?? '', false)}`,


### PR DESCRIPTION
## Summary
- rename `quest_post` summary tag type to `quest_task`
- label head tasks as `Quest` and others as `Quest Task`
- display quest-related request tags on the quest board

## Testing
- `npm test --prefix ethos-backend` *(fails: missing dependencies)*
- `npm test --prefix ethos-frontend` *(fails: jest environment missing)*


------
https://chatgpt.com/codex/tasks/task_e_685ad91848c8832f8935c102322625ef