### PR TITLE
Add node ID tags and team read-only

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -75,13 +75,14 @@ All tags share the `TAG_BASE` style which sets padding, font size and border rad
 
 ### Tag summary format
 
-Summary tags combine the quest title with the post's node ID and a linked author
-handle. The username appears once after each label and links to the profile:
+Summary tags combine the quest title with a node ID badge. The node ID links to
+the request detail page so you can quickly jump to that task. The quest’s root
+task is always labeled `T00` while issues include the task and issue numbers:
 
 ```
-[Quest: Demo Quest] [Task - Q:demo:T01] @alice
-[Quest: Demo Quest] [Issue - Q:demo:T01:I00] @bob
-[Quest: Demo Quest] [Commit - Q:demo:T01:C00] @carol
+[Quest] [T00]
+[Quest Task] [T01]
+[Issue] [T01:I00]
 ```
 Logs and other post types show the author name after a `Log` label. These
 concise tags help identify who created each node at a glance.

--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -122,21 +122,18 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
 
   const summaryTags = buildSummaryTags(post);
   let taskTag = summaryTags.find(t => t.type === 'task');
-  const shortTitle = headerText.length > 20 ? headerText.slice(0, 20) + '...' : headerText;
   if (taskTag) {
     taskTag = {
       ...taskTag,
       label: post.nodeId
-        ? `Q::${post.nodeId.replace(/^Q:[^:]+:/, '')}:${shortTitle}`
+        ? post.nodeId.replace(/^Q:[^:]+:/, '')
         : taskTag.label.replace(/^Task\s*[-:]\s*/, ''),
       username: undefined,
       usernameLink: undefined,
       link: ROUTES.POST(post.id),
     } as any;
   } else {
-    const label = post.nodeId
-      ? `Q::${post.nodeId.replace(/^Q:[^:]+:/, '')}:${shortTitle}`
-      : 'Task';
+    const label = post.nodeId ? post.nodeId.replace(/^Q:[^:]+:/, '') : 'Task';
     taskTag = {
       type: 'task',
       label,

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -120,7 +120,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
           : 'Planner',
     },
     { value: 'logs', label: 'Logs' },
-    { value: 'options', label: 'Options' },
+    { value: 'options', label: canEdit ? 'Options' : 'Team' },
   ];
 
   const isOwner = user?.id === questData.authorId;
@@ -588,7 +588,11 @@ const QuestCard: React.FC<QuestCardProps> = ({
         break;
       case 'options':
         panel = selectedNode || rootNode ? (
-          <TeamPanel questId={quest.id} node={selectedNode || (rootNode as Post)} />
+          <TeamPanel
+            questId={quest.id}
+            node={selectedNode || (rootNode as Post)}
+            canEdit={canEdit}
+          />
         ) : (
           <div className="p-2 text-sm">Select a task</div>
         );

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -126,13 +126,17 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
 
   if (!node) return <div className="p-2 text-sm">Select a task</div>;
 
+  const canEdit =
+    user?.id === node.authorId ||
+    (node.collaborators || []).some(c => c.userId === user?.id);
+
   const tabs = [
     {
       value: 'file',
       label: type === 'file' ? 'File' : type === 'folder' ? 'Folder' : 'Planner',
     },
     ...(showLogs ? [{ value: 'logs', label: 'Logs' }] : []),
-    { value: 'options', label: 'Options' },
+    { value: 'options', label: canEdit ? 'Options' : 'Team' },
   ];
 
   let panel: React.ReactNode = null;
@@ -161,7 +165,7 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
       );
       break;
     case 'options':
-      panel = <TeamPanel questId={questId} node={node} />;
+      panel = <TeamPanel questId={questId} node={node} canEdit={canEdit} />;
       break;
     default:
       panel = null;

--- a/ethos-frontend/src/components/quest/TeamPanel.tsx
+++ b/ethos-frontend/src/components/quest/TeamPanel.tsx
@@ -11,9 +11,10 @@ import type { Quest } from '../../types/questTypes';
 interface TeamPanelProps {
   questId: string;
   node: Post;
+  canEdit?: boolean;
 }
 
-const TeamPanel: React.FC<TeamPanelProps> = ({ questId, node }) => {
+const TeamPanel: React.FC<TeamPanelProps> = ({ questId, node, canEdit = true }) => {
   const [quest, setQuest] = useState<Quest | null>(null);
   const [roles, setRoles] = useState<CollaberatorRoles[]>(node.collaborators || []);
   const [saving, setSaving] = useState(false);
@@ -88,13 +89,29 @@ const TeamPanel: React.FC<TeamPanelProps> = ({ questId, node }) => {
           </Link>
         </div>
       )}
-      <CollaberatorControls value={roles} onChange={setRoles} />
-      <button
-        onClick={handleSave}
-        className="text-xs text-accent underline"
-      >
-        {saving ? 'Saving...' : 'Save Roles'}
-      </button>
+      {canEdit ? (
+        <>
+          <CollaberatorControls value={roles} onChange={setRoles} />
+          <button
+            onClick={handleSave}
+            className="text-xs text-accent underline"
+          >
+            {saving ? 'Saving...' : 'Save Roles'}
+          </button>
+        </>
+      ) : (
+        <div className="text-sm">
+          <p className="font-semibold">Team Members:</p>
+          <ul className="list-disc ml-4 space-y-1">
+            {roles.map((r, i) => (
+              <li key={i}>
+                {r.username ? `@${r.username}` : 'Open Role'}
+                {r.roles && r.roles.length ? ` - ${r.roles.join(', ')}` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -68,6 +68,13 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         ) : (
           <SummaryTag type="request" label={POST_TYPE_LABELS.request} />
         )}
+        {post.nodeId && (
+          <SummaryTag
+            type={post.type === 'issue' || post.subtype === 'issue' ? 'issue' : 'task'}
+            label={post.nodeId.replace(/^Q:[^:]+:/, '')}
+            detailLink={ROUTES.POST(post.id)}
+          />
+        )}
         {post.questId && (
           <SummaryTag
             type="quest"

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -210,7 +210,7 @@ export const buildSummaryTags = (
 
   if (post.type === "task" && post.nodeId) {
     const user = post.author?.username || post.authorId;
-    const label = `Task - ${getQuestLinkLabel(post, title ?? '', false)}`;
+    const label = post.nodeId.replace(/^Q:[^:]+:/, "");
     tags.push({
       type: "task",
       label,
@@ -222,7 +222,7 @@ export const buildSummaryTags = (
     const user = post.author?.username || post.authorId;
     const label =
       post.nodeId && !multipleSources
-        ? `Issue - ${getQuestLinkLabel(post, title ?? '', false)}`
+        ? post.nodeId.replace(/^Q:[^:]+:/, "")
         : "Issue";
     tags.push({
       type: "issue",


### PR DESCRIPTION
## Summary
- add node ID examples to design system docs
- show node id tags on quest and issue request cards
- use read-only Team panel when the viewer can't edit
- label quest tabs as Team when read-only
- display node ids in task preview and summary utils

## Testing
- `./setup.sh`
- `cd ethos-backend && npx tsc -p tsconfig.json`
- `npm test -- -w=1`
- `cd ../ethos-frontend && npx tsc -p tsconfig.json`
- `npm run lint` *(fails: 36 errors)*
- `npm test -- -w=1`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ae41a311c832f8faca6f7c39da111