### PR TITLE
Fix quest tag icons

### DIFF
--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -110,7 +110,7 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
 
   const content = (
     <>
-      <Icon className="w-3 h-3" />
+      <Icon className="w-3 h-3 flex-shrink-0" />
       {label}
     </>
   );


### PR DESCRIPTION
## Summary
- keep quest tag icons from shrinking out of view

## Testing
- `npm test --silent --prefix ethos-backend`
- `npm test --silent --prefix ethos-frontend tests/ -- -t "summary tag"`

------
https://chatgpt.com/codex/tasks/task_e_685ae67b9fa4832f995d66fbeab261a1