### PR TITLE
Fix QuestCard initialization error

### DIFF
--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -109,6 +109,11 @@ const QuestCard: React.FC<QuestCardProps> = ({
   const shortDesc = desc.length > 120 ? desc.slice(0, 117) + '…' : desc;
   const userRank = getRank(user?.xp ?? 0);
 
+  const isOwner = user?.id === questData.authorId;
+  const isCollaborator = questData.collaborators?.some(c => c.userId === user?.id);
+  const canEdit = isOwner || isCollaborator;
+  const hasJoined = isOwner || isCollaborator;
+
   const tabOptions = [
     {
       value: 'file',
@@ -122,11 +127,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
     { value: 'logs', label: 'Logs' },
     { value: 'options', label: canEdit ? 'Options' : 'Team' },
   ];
-
-  const isOwner = user?.id === questData.authorId;
-  const isCollaborator = questData.collaborators?.some(c => c.userId === user?.id);
-  const canEdit = isOwner || isCollaborator;
-  const hasJoined = isOwner || isCollaborator;
 
   const subgraphIds = useMemo(() => {
     if (!selectedNode) return new Set<string>();


### PR DESCRIPTION
## Summary
- assign ownership flags before building `tabOptions` so `canEdit` is defined

## Testing
- `npm test -- -w=1` in `ethos-frontend`
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_685aec29b280832f90b7bd4e0745f27c