### PR TITLE
Fix request summary tag links and card width

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -151,7 +151,7 @@ const PostCard: React.FC<PostCardProps> = ({
     ctxBoardId === 'timeline-board' || ctxBoardId === 'my-posts'
       ? 'max-w-3xl'
       : isQuestBoardRequest
-        ? 'max-w-2xl'
+        ? 'w-72'
         : 'max-w-prose';
 
   const expandedView = expanded !== undefined ? expanded : internalExpandedView;

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -123,6 +123,14 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
     );
   }
 
+  if (detailLink) {
+    return (
+      <Link to={detailLink} className={clsx(TAG_BASE, colorClass, className)}>
+        {content}
+      </Link>
+    );
+  }
+
   return <span className={clsx(TAG_BASE, colorClass, className)}>{content}</span>;
 };
 


### PR DESCRIPTION
## Summary
- make SummaryTag clickable when `detailLink` provided
- adjust quest-board request card width

## Testing
- `npm --prefix ethos-frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685af5cc0524832f959471bd0954372d