### PR TITLE
Add party request tag

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -70,6 +70,7 @@ Posts and quests are annotated with small tags that reuse the same color palette
 | status | `bg-yellow-100 text-yellow-800` / `dark:bg-yellow-800 dark:text-yellow-200` |
 | category | `bg-indigo-100 text-indigo-800` / `dark:bg-indigo-800 dark:text-indigo-200` |
 | free_speech | `bg-gray-100 text-gray-700` / `dark:bg-gray-700 dark:text-gray-200` |
+| party_request | `bg-pink-100 text-pink-800` / `dark:bg-pink-800 dark:text-pink-200` |
 
 All tags share the `TAG_BASE` style which sets padding, font size and border radius.
 

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -55,7 +55,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
   return (
     <div
       className={
-        'border border-secondary rounded bg-surface p-4 space-y-2 w-full max-w-xl ' +
+        'border border-secondary rounded bg-surface p-4 space-y-2 w-72 flex-shrink-0 ' +
         (className || '')
       }
     >

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -13,7 +13,8 @@ import {
   FaCog,
   FaBullhorn,
   FaCodeBranch,
-  FaCheckCircle
+  FaCheckCircle,
+  FaUsers
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import { TAG_BASE } from '../../constants/styles';
@@ -29,6 +30,7 @@ export type SummaryTagType =
   | 'free_speech'
   | 'type'
   | 'request'
+  | 'party_request'
   | 'quest_task'
   | 'commit'
   | 'meta_system'
@@ -58,6 +60,7 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
   free_speech: FaCommentAlt,
   type: FaUser,
   request: FaHandsHelping,
+  party_request: FaUsers,
   quest_task: FaUserCheck,
   commit: FaCodeBranch,
   meta_system: FaCog,
@@ -76,6 +79,7 @@ const colors: Record<SummaryTagType, string> = {
   free_speech: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
   type: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
   request: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
+  party_request: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   quest_task: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-800 dark:text-cyan-200',
   commit: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   meta_system: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -59,7 +59,7 @@ const HomePage: React.FC = () => {
           boardId="quest-board"
           title="🗺️ Quest Board"
           layout="grid"
-          gridLayout="paged"
+          gridLayout="horizontal"
           compact
           user={user as User}
           hideControls

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -154,6 +154,27 @@ export const buildSummaryTags = (
           ? getQuestLinkLabel(post, "", false)
           : undefined;
         label = id ? `Issue Request - ${id}` : "Issue Request";
+      } else if (post.subtype === "party") {
+        const id = post.nodeId
+          ? getQuestLinkLabel(post, "", false)
+          : undefined;
+        label = id ? `Party Request - ${id}` : "Party Request";
+        const user = post.author?.username || post.authorId;
+        tags.push({
+          type: "party_request",
+          label,
+          detailLink: ROUTES.POST(post.id),
+          username: user,
+          usernameLink: ROUTES.PUBLIC_PROFILE(post.authorId),
+        });
+        if (post.status && post.status !== "To Do") {
+          tags.push({
+            type: "status",
+            label: post.status,
+            detailLink: ROUTES.POST(post.id),
+          });
+        }
+        return tags;
       } else {
         label = "Request - Quest";
       }
@@ -311,6 +332,10 @@ export const getPostSummary = (
           `(Issue - ${getQuestLinkLabel(post, title ?? '', false)})`
         );
       else parts.push("(Issue)");
+    } else if (post.subtype === "party") {
+      if (post.nodeId)
+        parts.push(`(Party - ${getQuestLinkLabel(post, title ?? '', false)})`);
+      else parts.push("(Party)");
     }
     return parts.join(" ").trim();
   }


### PR DESCRIPTION
## Summary
- support new `party_request` SummaryTag type with icon and color
- generate party request labels in `buildSummaryTags` and summaries
- adjust Quest Board layout to use horizontal scrolling
- fix RequestCard width
- document new tag style

## Testing
- `./setup.sh`
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_685af8653b3c832f977d9e7ea029a14d