### PR TITLE
Fix tag overflow

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -71,7 +71,8 @@ Posts and quests are annotated with small tags that reuse the same color palette
 | category | `bg-indigo-100 text-indigo-800` / `dark:bg-indigo-800 dark:text-indigo-200` |
 | free_speech | `bg-gray-100 text-gray-700` / `dark:bg-gray-700 dark:text-gray-200` |
 
-All tags share the `TAG_BASE` style which sets padding, font size and border radius.
+All tags share the `TAG_BASE` style which sets padding, font size and border radius
+and prevents long text from overflowing by truncating with an ellipsis.
 
 ### Tag summary format
 

--- a/ethos-frontend/src/constants/styles.ts
+++ b/ethos-frontend/src/constants/styles.ts
@@ -1,1 +1,2 @@
-export const TAG_BASE = 'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+export const TAG_BASE =
+  'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 whitespace-nowrap overflow-hidden text-ellipsis';


### PR DESCRIPTION
## Summary
- truncate long SummaryTag labels so they don't overflow
- document overflow handling in the design system

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_685af8c92cf4832f8727aa0e5b5a2d2a