### PR TITLE
Fix quest board scroll animation

### DIFF
--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -105,9 +105,14 @@ const ActiveQuestBoard: React.FC<ActiveQuestBoardProps> = ({ onlyMine }) => {
   };
 
   useEffect(() => {
-    scrollToIndex(index);
     indexRef.current = index;
   }, [index]);
+
+  useEffect(() => {
+    if (quests.length > 0) {
+      scrollToIndex(indexRef.current);
+    }
+  }, [quests.length]);
 
   // Update index when user scrolls manually
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid auto-centering on every scroll
- update index while scrolling for horizontal boards
- keep initial centering when quests or items load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685afbb4ac48832fbf22dc7a9bfce544