### PR TITLE
Fix tag overflow

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -72,6 +72,8 @@ Posts and quests are annotated with small tags that reuse the same color palette
 | free_speech | `bg-gray-100 text-gray-700` / `dark:bg-gray-700 dark:text-gray-200` |
 
 All tags share the `TAG_BASE` style which sets padding, font size and border radius.
+Most tags also use `TAG_TRUNCATED` to limit width and truncate long labels with an ellipsis,
+while quest tags use `TAG_BASE` so the full quest title is visible.
 
 ### Tag summary format
 

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -16,7 +16,7 @@ import {
   FaCheckCircle
 } from 'react-icons/fa';
 import clsx from 'clsx';
-import { TAG_BASE } from '../../constants/styles';
+import { TAG_BASE, TAG_TRUNCATED } from '../../constants/styles';
 
 export type SummaryTagType =
   | 'quest'
@@ -45,6 +45,8 @@ export interface SummaryTagData {
   usernameLink?: string;
   /** Separate link for the label itself (e.g. post detail page) */
   detailLink?: string;
+  /** Whether the text should be truncated with ellipsis */
+  truncate?: boolean;
 }
 
 const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> = {
@@ -92,13 +94,16 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
   username,
   usernameLink,
   detailLink,
+  truncate = true,
 }) => {
   const Icon = icons[type] || FaStickyNote;
   const colorClass = colors[type] || colors.type;
 
+  const baseClass = truncate ? TAG_TRUNCATED : TAG_BASE;
+
   if (username && usernameLink && detailLink) {
     return (
-      <span className={clsx(TAG_BASE, colorClass, className)}>
+      <span className={clsx(baseClass, colorClass, className)}>
         <Icon className="w-3 h-3" />
         <Link to={detailLink} className="underline text-inherit">
           {label}
@@ -117,7 +122,7 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
 
   if (link) {
     return (
-      <Link to={link} className={clsx(TAG_BASE, colorClass, className)}>
+      <Link to={link} className={clsx(baseClass, colorClass, className)}>
         {content}
       </Link>
     );
@@ -125,13 +130,13 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
 
   if (detailLink) {
     return (
-      <Link to={detailLink} className={clsx(TAG_BASE, colorClass, className)}>
+      <Link to={detailLink} className={clsx(baseClass, colorClass, className)}>
         {content}
       </Link>
     );
   }
 
-  return <span className={clsx(TAG_BASE, colorClass, className)}>{content}</span>;
+  return <span className={clsx(baseClass, colorClass, className)}>{content}</span>;
 };
 
 export default SummaryTag;

--- a/ethos-frontend/src/constants/styles.ts
+++ b/ethos-frontend/src/constants/styles.ts
@@ -1,1 +1,5 @@
-export const TAG_BASE = 'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+export const TAG_BASE =
+  'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+
+export const TAG_TRUNCATED =
+  `${TAG_BASE} max-w-[150px] whitespace-nowrap overflow-hidden text-ellipsis`;

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -103,6 +103,7 @@ export interface SummaryTagData {
   username?: string;
   usernameLink?: string;
   detailLink?: string;
+  truncate?: boolean;
 }
 
 /**
@@ -179,14 +180,14 @@ export const buildSummaryTags = (
   }
 
   if (!multipleSources && title) {
-    const shortTitle = title.length > 20 ? title.slice(0, 20) + '...' : title;
     tags.push({
       type: "quest",
-      label: `Quest: ${shortTitle}`,
+      label: `Quest: ${title}`,
       link:
         questId || post.questId
           ? ROUTES.QUEST(questId || post.questId!)
           : undefined,
+      truncate: false,
     });
   }
 


### PR DESCRIPTION
## Summary
- truncate text by default but allow quest tags to show full titles
- document `TAG_TRUNCATED` style in the design system

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_685af8c92cf4832f8727aa0e5b5a2d2a