### PR TITLE
Truncate long quest titles in summary tags

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -73,8 +73,8 @@ Posts and quests are annotated with small tags that reuse the same color palette
 | party_request | `bg-pink-100 text-pink-800` / `dark:bg-pink-800 dark:text-pink-200` |
 
 All tags share the `TAG_BASE` style which sets padding, font size and border radius.
-Most tags also use `TAG_TRUNCATED` to limit width and truncate long labels with an ellipsis,
-while quest tags use `TAG_BASE` so the full quest title is visible.
+Most tags also use `TAG_TRUNCATED` to limit width and truncate long labels with an ellipsis.
+Quest tags now also use `TAG_TRUNCATED` so extremely long quest titles are shortened with an ellipsis instead of wrapping to the next line.
 
 ### Tag summary format
 

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -208,7 +208,6 @@ export const buildSummaryTags = (
         questId || post.questId
           ? ROUTES.QUEST(questId || post.questId!)
           : undefined,
-      truncate: false,
     });
   }
 


### PR DESCRIPTION
## Summary
- truncate quest summary tags if the text is very long
- document that quest tags now use `TAG_TRUNCATED`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_685b01a4a19c832fadcd81f8060ed36e