### PR TITLE
Fix summary tag icon visibility

### DIFF
--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -108,7 +108,7 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
   if (username && usernameLink && detailLink) {
     return (
       <span className={clsx(baseClass, colorClass, className)}>
-        <Icon className="w-3 h-3" />
+        <Icon className="w-3 h-3 flex-shrink-0" />
         <Link to={detailLink} className="underline text-inherit">
           {label}
         </Link>{' '}


### PR DESCRIPTION
## Summary
- keep icon size from collapsing when summary tags include a username

## Testing
- `npm --prefix ethos-backend test`
- `npm --prefix ethos-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685b05c330dc832fb8bdbcb879911f62