### PR TITLE
Extend review visibility/status support

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -440,13 +440,26 @@ export interface GitAccount {
 // Reviews
 // --------------------------------------------
 
-export type ReviewTargetType = 'ai_app' | 'quest' | 'creator' | 'dataset';
+export type ReviewTargetType =
+  | 'ai_app'
+  | 'quest'
+  | 'creator'
+  | 'dataset'
+  | 'user'
+  | 'party'
+  | 'guild'
+  | 'company'
+  | 'product'
+  | 'request'
+  | 'task';
 
 export interface Review {
   id: string;
   reviewerId: string;
   targetType: ReviewTargetType;
   rating: number; // 1-5
+  visibility: 'private' | 'public';
+  status: 'draft' | 'submitted' | 'accepted';
   tags?: string[];
   feedback?: string;
 

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -228,6 +228,8 @@ export interface DBReview {
   reviewerId: string;
   targetType: ReviewTargetType;
   rating: number;
+  visibility: 'private' | 'public';
+  status: 'draft' | 'submitted' | 'accepted';
   tags?: string[];
   feedback?: string;
   repoUrl?: string;

--- a/ethos-backend/tests/reviews.test.ts
+++ b/ethos-backend/tests/reviews.test.ts
@@ -26,10 +26,17 @@ describe('review routes', () => {
   it('POST /reviews creates review', async () => {
     const res = await request(app)
       .post('/reviews')
-      .send({ targetType: 'quest', rating: 5, feedback: 'great' });
+      .send({
+        targetType: 'quest',
+        rating: 5,
+        feedback: 'great',
+        visibility: 'public',
+        status: 'submitted',
+      });
     expect(res.status).toBe(201);
     expect(reviewsStoreMock.write).toHaveBeenCalled();
     expect(res.body.rating).toBe(5);
+    expect(res.body.visibility).toBe('public');
   });
 
   it('GET /reviews filters by type and sorts', async () => {
@@ -50,5 +57,27 @@ describe('review routes', () => {
       .post('/reviews')
       .send({ targetType: 'quest', rating: 4, feedback: 'badword inside' });
     expect(res.status).toBe(400);
+  });
+
+  it('PATCH /reviews/:id updates fields', async () => {
+    const existing = {
+      id: 'r1',
+      reviewerId: 'u1',
+      targetType: 'quest',
+      rating: 3,
+      visibility: 'public',
+      status: 'submitted',
+      createdAt: '1',
+    };
+    reviewsStoreMock.read.mockReturnValue([existing]);
+
+    const res = await request(app)
+      .patch('/reviews/r1')
+      .send({ rating: 4, visibility: 'private', status: 'accepted' });
+
+    expect(res.status).toBe(200);
+    expect(reviewsStoreMock.write).toHaveBeenCalled();
+    expect(res.body.visibility).toBe('private');
+    expect(res.body.status).toBe('accepted');
   });
 });

--- a/ethos-frontend/src/api/review.ts
+++ b/ethos-frontend/src/api/review.ts
@@ -8,6 +8,14 @@ export const addReview = async (data: Partial<Review>): Promise<Review> => {
   return res.data;
 };
 
+export const updateReview = async (
+  id: string,
+  data: Partial<Review>
+): Promise<Review> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}`, data);
+  return res.data;
+};
+
 export const fetchReviews = async (params: {
   type: string;
   questId?: string;

--- a/ethos-frontend/src/components/ReviewForm.tsx
+++ b/ethos-frontend/src/components/ReviewForm.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
-import { addReview } from '../api/review';
-import { Button, Input, TextArea, Label, FormSection } from './ui';
+import { addReview, updateReview } from '../api/review';
+import { Button, Input, TextArea, Label, FormSection, Select } from './ui';
+import { VISIBILITY_OPTIONS, REVIEW_STATUS_OPTIONS } from '../constants/options';
 import type { ReviewTargetType, Review } from '../types/reviewTypes';
 
 interface ReviewFormProps {
+  reviewId?: string;
   targetType: ReviewTargetType;
   questId?: string;
   postId?: string;
@@ -14,9 +16,12 @@ interface ReviewFormProps {
   initialRating?: number;
   initialTags?: string[];
   initialFeedback?: string;
+  initialVisibility?: 'private' | 'public';
+  initialStatus?: 'draft' | 'submitted' | 'accepted';
 }
 
 const ReviewForm: React.FC<ReviewFormProps> = ({
+  reviewId,
   targetType,
   questId,
   postId,
@@ -26,10 +31,14 @@ const ReviewForm: React.FC<ReviewFormProps> = ({
   initialRating = 0,
   initialTags = [],
   initialFeedback = '',
+  initialVisibility = 'public',
+  initialStatus = 'submitted',
 }) => {
   const [rating, setRating] = useState(initialRating);
   const [tags, setTags] = useState(initialTags.join(', '));
   const [feedback, setFeedback] = useState(initialFeedback);
+  const [visibility, setVisibility] = useState<'public' | 'private'>(initialVisibility);
+  const [status, setStatus] = useState<'draft' | 'submitted' | 'accepted'>(initialStatus);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
 
@@ -44,7 +53,7 @@ const ReviewForm: React.FC<ReviewFormProps> = ({
     setError('');
 
     try {
-      const review = await addReview({
+      const payload = {
         targetType,
         rating,
         tags: tags
@@ -56,10 +65,17 @@ const ReviewForm: React.FC<ReviewFormProps> = ({
         postId,
         repoUrl,
         modelId,
-      });
+        visibility,
+        status,
+      };
+      const review = reviewId
+        ? await updateReview(reviewId, payload)
+        : await addReview(payload);
       setRating(0);
       setTags('');
       setFeedback('');
+      setVisibility('public');
+      setStatus('submitted');
       onSubmitted?.(review);
     } catch (err: unknown) {
       console.error('[ReviewForm] Failed to submit review:', err);
@@ -95,6 +111,20 @@ const ReviewForm: React.FC<ReviewFormProps> = ({
             );
           })}
         </div>
+      </FormSection>
+      <FormSection title="Visibility">
+        <Select
+          value={visibility}
+          onChange={e => setVisibility(e.target.value as 'public' | 'private')}
+          options={VISIBILITY_OPTIONS.slice()}
+        />
+      </FormSection>
+      <FormSection title="Status">
+        <Select
+          value={status}
+          onChange={e => setStatus(e.target.value as 'draft' | 'submitted' | 'accepted')}
+          options={REVIEW_STATUS_OPTIONS.slice()}
+        />
       </FormSection>
       <FormSection title="Tags">
         <Label htmlFor="review-tags">Comma-separated Tags</Label>

--- a/ethos-frontend/src/components/ReviewList.tsx
+++ b/ethos-frontend/src/components/ReviewList.tsx
@@ -103,6 +103,7 @@ const ReviewList: React.FC<ReviewListProps> = ({ type, questId, postId, classNam
               {editing?.id === review.id && (
                 <div className="mt-3">
                   <ReviewForm
+                    reviewId={review.id}
                     targetType={review.targetType}
                     questId={review.questId}
                     postId={review.postId}
@@ -111,6 +112,8 @@ const ReviewList: React.FC<ReviewListProps> = ({ type, questId, postId, classNam
                     initialRating={review.rating}
                     initialTags={review.tags}
                     initialFeedback={review.feedback}
+                    initialVisibility={review.visibility}
+                    initialStatus={review.status}
                     onSubmitted={() => {
                       setEditing(null);
                       load();

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -36,6 +36,12 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'review', label: 'Review' },
 ];
 
+export const REVIEW_STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'submitted', label: 'Submitted' },
+  { value: 'accepted', label: 'Accepted' },
+] as const;
+
 export const LINK_TYPES = ['solution', 'duplicate', 'citation'];
 
 export const STATUS_OPTIONS = [

--- a/ethos-frontend/src/types/reviewTypes.ts
+++ b/ethos-frontend/src/types/reviewTypes.ts
@@ -1,10 +1,23 @@
-export type ReviewTargetType = 'ai_app' | 'quest' | 'creator' | 'dataset';
+export type ReviewTargetType =
+  | 'ai_app'
+  | 'quest'
+  | 'creator'
+  | 'dataset'
+  | 'user'
+  | 'party'
+  | 'guild'
+  | 'company'
+  | 'product'
+  | 'request'
+  | 'task';
 
 export interface Review {
   id: string;
   reviewerId: string;
   targetType: ReviewTargetType;
   rating: number;
+  visibility: 'private' | 'public';
+  status: 'draft' | 'submitted' | 'accepted';
   tags?: string[];
   feedback?: string;
   repoUrl?: string;


### PR DESCRIPTION
## Summary
- expand allowed review targets and add visibility & status fields
- track review visibility/status in database types
- accept and update visibility/status via backend routes
- allow setting review visibility/status from the frontend UI
- update tests for new review attributes

## Testing
- `npm test --silent --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_685b0a2c81b0832f8406b383727d34f3