### PR TITLE
Add review summary endpoint and summary pages

### DIFF
--- a/ethos-backend/src/routes/reviewRoutes.ts
+++ b/ethos-backend/src/routes/reviewRoutes.ts
@@ -44,6 +44,41 @@ router.get('/:id', (req: Request<{ id: string }>, res: Response): void => {
   res.json(review);
 });
 
+// GET /api/reviews/summary/:entityType/:id
+router.get('/summary/:entityType/:id', (req: Request<{ entityType: string; id: string }>, res: Response): void => {
+  const { entityType, id } = req.params;
+  const reviews = reviewsStore.read().filter(r => {
+    if (r.targetType !== entityType) return false;
+    switch (entityType) {
+      case 'quest':
+        return r.questId === id;
+      case 'ai_app':
+        return r.repoUrl === id;
+      case 'dataset':
+        return r.modelId === id;
+      case 'creator':
+        return r.modelId === id;
+      default:
+        return false;
+    }
+  });
+
+  if (reviews.length === 0) {
+    res.json({ averageRating: 0, count: 0, tagCounts: {} });
+    return;
+  }
+
+  const total = reviews.reduce((sum, r) => sum + r.rating, 0);
+  const tagCounts: Record<string, number> = {};
+  reviews.forEach(r => {
+    (r.tags || []).forEach(t => {
+      tagCounts[t] = (tagCounts[t] || 0) + 1;
+    });
+  });
+  const averageRating = parseFloat((total / reviews.length).toFixed(2));
+  res.json({ averageRating, count: reviews.length, tagCounts });
+});
+
 // POST /api/reviews
 router.post('/', authMiddleware, (req: AuthenticatedRequest, res: Response): void => {
   const { targetType, rating, tags = [], feedback = '', repoUrl, modelId, questId, postId } = req.body;

--- a/ethos-backend/tests/reviews.test.ts
+++ b/ethos-backend/tests/reviews.test.ts
@@ -51,4 +51,19 @@ describe('review routes', () => {
       .send({ targetType: 'quest', rating: 4, feedback: 'badword inside' });
     expect(res.status).toBe(400);
   });
+
+  it('GET /reviews/summary/:entityType/:id returns averages', async () => {
+    const data = [
+      { id: 'r1', reviewerId: 'u1', targetType: 'quest', rating: 4, tags: ['easy'], questId: 'q1', createdAt: '1' },
+      { id: 'r2', reviewerId: 'u2', targetType: 'quest', rating: 2, tags: ['hard'], questId: 'q1', createdAt: '2' },
+      { id: 'r3', reviewerId: 'u3', targetType: 'quest', rating: 5, tags: ['easy'], questId: 'q2', createdAt: '3' },
+    ];
+    reviewsStoreMock.read.mockReturnValue(data);
+
+    const res = await request(app).get('/reviews/summary/quest/q1');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+    expect(res.body.averageRating).toBe(3);
+    expect(res.body.tagCounts.easy).toBe(1);
+  });
 });

--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -30,6 +30,7 @@ const Post = lazy(() => import('./pages/post/[id]'));
 const Board = lazy(() => import('./pages/board/[id]'));
 const BoardType = lazy(() => import('./pages/board/[boardType]'));
 const TeamBoard = lazy(() => import('./pages/board/team-[questId]'));
+const ReviewSummary = lazy(() => import('./pages/review/[entityType]/[id]'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
@@ -71,6 +72,7 @@ const App: React.FC = () => {
                   <Route path={ROUTES.TERMS} element={<Terms />} />
                   <Route path={ROUTES.PUBLIC_PROFILE()} element={<PublicProfile />} />
                   <Route path={ROUTES.RESET_PASSWORD()} element={<ResetPassword />} />
+                  <Route path={ROUTES.REVIEW_SUMMARY()} element={<ReviewSummary />} />
 
                   {/* 🔒 Routes requiring authentication (wrapped in PrivateRoute) */}
                   <Route element={<PrivateRoute />}>

--- a/ethos-frontend/src/api/review.ts
+++ b/ethos-frontend/src/api/review.ts
@@ -17,3 +17,17 @@ export const fetchReviews = async (params: {
   const res = await axiosWithAuth.get(BASE_URL, { params });
   return res.data;
 };
+
+export interface ReviewSummary {
+  averageRating: number;
+  count: number;
+  tagCounts: Record<string, number>;
+}
+
+export const fetchReviewSummary = async (
+  entityType: string,
+  id: string,
+): Promise<ReviewSummary> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/summary/${entityType}/${id}`);
+  return res.data;
+};

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -75,6 +75,16 @@ export const ROUTES = {
      */
     BOARD_TYPE: (boardType = ':boardType') => `/board/${boardType}`,
 
+    /**
+     * Review summary page
+     * @param entityType Entity type being reviewed
+     * @param id Entity ID
+     */
+    REVIEW_SUMMARY: (
+      entityType = ':entityType',
+      id = ':id',
+    ) => `/reviews/${entityType}/${id}`,
+
     FLAGGED_QUESTS: '/admin/flagged-quests',
     BANNED_QUESTS: '/admin/banned-quests',
 

--- a/ethos-frontend/src/pages/review/[entityType]/[id].tsx
+++ b/ethos-frontend/src/pages/review/[entityType]/[id].tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchReviewSummary, type ReviewSummary } from '../../api/review';
+import FeaturedQuestBoard from '../../components/quest/FeaturedQuestBoard';
+import { Spinner } from '../../components/ui';
+
+const ReviewSummaryPage: React.FC = () => {
+  const { entityType, id } = useParams<{ entityType: string; id: string }>();
+  const [summary, setSummary] = useState<ReviewSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!entityType || !id) return;
+    const load = async () => {
+      try {
+        const data = await fetchReviewSummary(entityType, id);
+        setSummary(data);
+      } catch (err) {
+        console.error('[ReviewSummaryPage] Failed to load summary:', err);
+        setError('Failed to load review summary.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [entityType, id]);
+
+  if (loading) return <Spinner />;
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+
+  return (
+    <main className="max-w-3xl mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Review Summary</h1>
+      {summary && summary.count > 0 ? (
+        <div className="space-y-2">
+          <div>
+            Average Rating: {summary.averageRating} ({summary.count} reviews)
+          </div>
+          <ul className="list-disc list-inside text-sm">
+            {Object.entries(summary.tagCounts).map(([tag, count]) => (
+              <li key={tag}>{tag}: {count}</li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p>No reviews yet.</p>
+      )}
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Featured Quests</h2>
+        <FeaturedQuestBoard />
+      </section>
+    </main>
+  );
+};
+
+export default ReviewSummaryPage;


### PR DESCRIPTION
## Summary
- add `/reviews/summary/:entityType/:id` endpoint for average rating and tag counts
- expose `fetchReviewSummary` in the frontend API
- create a dynamic page to display review summaries with featured quests
- wire up new route constant and React route
- add tests for the new backend endpoint

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685b0a2e1f78832fadb97b9449c27f74