### PR TITLE
Add basic project CRUD and frontend page

### DIFF
--- a/ethos-backend/src/models/stores.ts
+++ b/ethos-backend/src/models/stores.ts
@@ -7,6 +7,7 @@ export const boardsStore = createDataStore<DBSchema['boards']>('boards.json', []
 export const gitStore = createDataStore<DBSchema['git']>('git.json', []);
 export const postsStore = createDataStore<DBSchema['posts']>('posts.json', []);
 export const questsStore = createDataStore<DBSchema['quests']>('quests.json', []);
+export const projectsStore = createDataStore<DBSchema['projects']>('projects.json', []);
 export const usersStore = createDataStore<DBSchema['users']>('users.json', []);
 export const reactionsStore = createDataStore<string[]>('reactions.json', []);
 export const reviewsStore = createDataStore<DBSchema['reviews']>('reviews.json', []);

--- a/ethos-backend/src/routes/projectRoutes.ts
+++ b/ethos-backend/src/routes/projectRoutes.ts
@@ -1,0 +1,112 @@
+import express, { Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { projectsStore } from '../models/stores';
+import type { DBProject } from '../types/db';
+import type { AuthenticatedRequest } from '../types/express';
+
+const router = express.Router();
+
+// GET all projects
+router.get('/', (_req: Request, res: Response) => {
+  const projects = projectsStore.read();
+  res.json(projects);
+});
+
+// GET a single project
+router.get('/:id', (req: Request<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const projects = projectsStore.read();
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  res.json(project);
+});
+
+// CREATE a new project
+router.post('/', authMiddleware, (req: AuthenticatedRequest, res: Response) => {
+  const { title, description = '', visibility = 'public', tags = [] } = req.body;
+  const authorId = req.user?.id;
+  if (!authorId || !title) {
+    res.status(400).json({ error: 'Missing required fields' });
+    return;
+  }
+  const newProject: DBProject = {
+    id: uuidv4(),
+    authorId,
+    title,
+    description,
+    visibility,
+    status: 'active',
+    tags,
+    createdAt: new Date().toISOString(),
+    quests: [],
+    deliverables: [],
+    mapEdges: [],
+    collaborators: [],
+  };
+  const projects = projectsStore.read();
+  projects.push(newProject);
+  projectsStore.write(projects);
+  res.status(201).json(newProject);
+});
+
+// PATCH update a project
+router.patch('/:id', authMiddleware, (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const updates = req.body as Partial<DBProject>;
+  const projects = projectsStore.read();
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  Object.assign(project, updates);
+  projectsStore.write(projects);
+  res.json(project);
+});
+
+// DELETE a project
+router.delete('/:id', authMiddleware, (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const projects = projectsStore.read();
+  const index = projects.findIndex((p) => p.id === id);
+  if (index === -1) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  projects.splice(index, 1);
+  projectsStore.write(projects);
+  res.json({ success: true });
+});
+
+// GET project map edges
+router.get('/:id/map', (req: Request<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const projects = projectsStore.read();
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  res.json({ edges: project.mapEdges || [] });
+});
+
+// PATCH update map edges
+router.patch('/:id/map', authMiddleware, (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+  const { id } = req.params;
+  const { edges } = req.body as { edges: DBProject['mapEdges'] };
+  const projects = projectsStore.read();
+  const project = projects.find((p) => p.id === id);
+  if (!project) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+  project.mapEdges = edges || [];
+  projectsStore.write(projects);
+  res.json({ success: true, edges: project.mapEdges });
+});
+
+export default router;

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -10,6 +10,7 @@ import authRoutes from './routes/authRoutes';
 import gitRoutes from './routes/gitRoutes';
 import postRoutes from './routes/postRoutes';
 import questRoutes from './routes/questRoutes';
+import projectRoutes from './routes/projectRoutes';
 import boardRoutes from './routes/boardRoutes';
 import reviewRoutes from './routes/reviewRoutes';
 import userRoutes from './routes/userRoutes';
@@ -68,6 +69,7 @@ app.use('/api/auth', authRoutes);     // 🔐 Authentication (login, register, s
 app.use('/api/git', gitRoutes);       // 🔁 Git sync, commits, diffs
 app.use('/api/posts', postRoutes);    // 📝 Posts, reactions, replies
 app.use('/api/quests', questRoutes);  // 📦 Quests, task maps
+app.use('/api/projects', projectRoutes); // 🗂 Projects
 app.use('/api/boards', boardRoutes);  // 🧭 Boards and view layouts
 app.use('/api/reviews', reviewRoutes); // ⭐ Reviews
 app.use('/api/users', userRoutes);    // 👥 Public user profiles

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -113,6 +113,21 @@ export interface TaskEdge {
   label?: string;
 }
 
+export interface DBProject {
+  id: string;
+  authorId: string;
+  title: string;
+  description?: string;
+  visibility: Visibility;
+  status: 'active' | 'completed' | 'archived';
+  tags?: string[];
+  createdAt?: string;
+  quests?: string[];
+  deliverables?: string[];
+  mapEdges?: TaskEdge[];
+  collaborators?: { userId?: string; roles?: string[]; pending?: string[] }[];
+}
+
 // types/db.ts
 export interface DBBoard {
   id: string;
@@ -262,6 +277,7 @@ export interface DBSchema {
   boards: DBBoard[];
   git: DBGitRepo[];
   posts: DBPost[];
+  projects: DBProject[];
   quests: DBQuest[];
   users: DBUser[];
   reviews: DBReview[];
@@ -270,7 +286,7 @@ export interface DBSchema {
 }
 
 // Optional utility type for referencing a single entry type by file
-export type DBFileName = keyof DBSchema; // 'boards' | 'git' | 'posts' | 'quests' | 'users' | 'reviews' | 'boardLogs' | 'notifications'
+export type DBFileName = keyof DBSchema; // 'boards' | 'git' | 'posts' | 'projects' | 'quests' | 'users' | 'reviews' | 'boardLogs' | 'notifications'
 
 /**
  * Generic type for file-based mock storage (can be used in utils/loaders.ts)

--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -26,6 +26,7 @@ const Privacy = lazy(() => import('./pages/Privacy'));
 const Terms = lazy(() => import('./pages/Terms'));
 const Profile = lazy(() => import('./pages/Profile'));
 const Quest = lazy(() => import('./pages/quest/[id]'));
+const Project = lazy(() => import('./pages/project/[id]'));
 const Post = lazy(() => import('./pages/post/[id]'));
 const Board = lazy(() => import('./pages/board/[id]'));
 const BoardType = lazy(() => import('./pages/board/[boardType]'));
@@ -77,6 +78,7 @@ const App: React.FC = () => {
                   <Route path={ROUTES.PROFILE} element={<Profile />} />
                   <Route path={ROUTES.NOTIFICATIONS} element={<Notifications />} />
                   <Route path={ROUTES.QUEST()} element={<Quest />} />
+                  <Route path={ROUTES.PROJECT()} element={<Project />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
                     <Route path="/board/quests" element={<Navigate to={ROUTES.BOARD('quest-board')} replace />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />

--- a/ethos-frontend/src/api/project.ts
+++ b/ethos-frontend/src/api/project.ts
@@ -1,0 +1,49 @@
+import { axiosWithAuth } from '../utils/authUtils';
+import type { Project, ProjectEdge } from '../types/projectTypes';
+
+const BASE_URL = '/projects';
+
+export const addProject = async (data: Partial<Project>): Promise<Project> => {
+  const res = await axiosWithAuth.post(BASE_URL, data);
+  return res.data;
+};
+
+export const fetchAllProjects = async (): Promise<Project[]> => {
+  const res = await axiosWithAuth.get(BASE_URL);
+  return res.data;
+};
+
+export const fetchProjectById = async (id: string): Promise<Project> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/${id}`);
+  return res.data;
+};
+
+export const updateProjectById = async (
+  id: string,
+  updates: Partial<Project>,
+): Promise<Project> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}`, updates);
+  return res.data;
+};
+
+export const removeProjectById = async (
+  id: string,
+): Promise<{ success: boolean }> => {
+  const res = await axiosWithAuth.delete(`${BASE_URL}/${id}`);
+  return res.data;
+};
+
+export const fetchProjectMap = async (
+  id: string,
+): Promise<{ edges: ProjectEdge[] }> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/${id}/map`);
+  return res.data;
+};
+
+export const updateProjectMap = async (
+  id: string,
+  edges: ProjectEdge[],
+): Promise<{ success: boolean; edges: ProjectEdge[] }> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}/map`, { edges });
+  return res.data;
+};

--- a/ethos-frontend/src/components/project/CreateProject.tsx
+++ b/ethos-frontend/src/components/project/CreateProject.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { addProject } from '../../api/project';
+import { Button, Input, TextArea, Label, FormSection } from '../ui';
+import type { Project } from '../../types/projectTypes';
+
+interface CreateProjectProps {
+  onSave?: (project: Project) => void;
+  onCancel: () => void;
+}
+
+const CreateProject: React.FC<CreateProjectProps> = ({ onSave, onCancel }) => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        title: title.trim(),
+        description: description.trim(),
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      };
+      const project = await addProject(payload);
+      onSave?.(project);
+      navigate(`/project/${project.id}`);
+    } catch (err) {
+      console.error('[CreateProject] Failed to create project:', err);
+      alert('Failed to create project');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <FormSection title="Project Details">
+        <Label htmlFor="project-title">Title</Label>
+        <Input
+          id="project-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Enter project title"
+          required
+        />
+        <Label htmlFor="project-description">Description</Label>
+        <TextArea
+          id="project-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe the project"
+        />
+        <Label htmlFor="project-tags">Tags</Label>
+        <Input
+          id="project-tags"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="tag1, tag2"
+        />
+      </FormSection>
+      <div className="flex justify-end gap-3">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="contrast" disabled={isSubmitting}>
+          {isSubmitting ? 'Creating...' : 'Create Project'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default CreateProject;

--- a/ethos-frontend/src/components/project/EditProject.tsx
+++ b/ethos-frontend/src/components/project/EditProject.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import type { Project } from '../../types/projectTypes';
+import { updateProjectById } from '../../api/project';
+import { Button, Label, TextArea, FormSection, Input } from '../ui';
+
+interface EditProjectProps {
+  project: Project;
+  onCancel: () => void;
+  onSave: (updated: Project) => void;
+}
+
+const EditProject: React.FC<EditProjectProps> = ({ project, onCancel, onSave }) => {
+  const [title, setTitle] = useState(project.title);
+  const [description, setDescription] = useState(project.description || '');
+  const [tags, setTags] = useState((project.tags || []).join(', '));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const updates: Partial<Project> = {
+        title,
+        description,
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      };
+      const updated = await updateProjectById(project.id, updates);
+      onSave(updated);
+    } catch (err) {
+      console.error('[EditProject] Failed to update:', err);
+      alert('Failed to update project');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <FormSection title="Project Details">
+        <Label htmlFor="project-title">Title</Label>
+        <Input
+          id="project-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <Label htmlFor="project-description">Description</Label>
+        <TextArea
+          id="project-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <Label htmlFor="project-tags">Tags</Label>
+        <Input
+          id="project-tags"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+      </FormSection>
+      <div className="flex justify-end gap-3">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default EditProject;

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -46,6 +46,12 @@ export const ROUTES = {
      * @returns A route string like `/quest/abc123`
      */
     QUEST: (id = ':id') => `/quest/${id}`,
+
+    /**
+     * Project page by ID
+     * @param id - Project ID
+     */
+    PROJECT: (id = ':id') => `/project/${id}`,
   
     /**
      * Post page by ID (private)

--- a/ethos-frontend/src/hooks/useProject.ts
+++ b/ethos-frontend/src/hooks/useProject.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { Project } from '../types/projectTypes';
+import { fetchProjectById, fetchAllProjects } from '../api/project';
+
+export const useProject = (projectId?: string) => {
+  const [project, setProject] = useState<Project | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(!!projectId);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const p = await fetchProjectById(projectId);
+        setProject(p);
+      } catch (err) {
+        setError('Failed to load project');
+        console.error('[useProject] Failed to load project:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, [projectId]);
+
+  const getAllProjects = useCallback(async (): Promise<Project[]> => {
+    try {
+      return await fetchAllProjects();
+    } catch (err) {
+      console.error('[useProject] Failed to fetch projects:', err);
+      return [];
+    }
+  }, []);
+
+  return { project, error, isLoading, getAllProjects };
+};

--- a/ethos-frontend/src/pages/project/[id].tsx
+++ b/ethos-frontend/src/pages/project/[id].tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useProject } from '../../hooks/useProject';
+import { fetchPostById } from '../../api/post';
+import { Spinner } from '../../components/ui';
+
+const ProjectPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { project, error, isLoading } = useProject(id ?? '');
+  const [deliverables, setDeliverables] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!project) return;
+      const posts = await Promise.all(
+        (project.deliverables || []).map((pid) =>
+          fetchPostById(pid).catch(() => null),
+        ),
+      );
+      setDeliverables(posts.filter(Boolean));
+    };
+    load();
+  }, [project]);
+
+  if (error) {
+    return <div className="p-6 text-center text-red-500">Project not found.</div>;
+  }
+  if (isLoading || !project) return <Spinner />;
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark text-primary">
+      <h1 className="text-2xl font-bold">{project.title}</h1>
+      <p>{project.description}</p>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Project Map</h2>
+        <pre className="text-xs bg-gray-100 p-2 rounded">
+          {JSON.stringify(project.mapEdges || [], null, 2)}
+        </pre>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Deliverables</h2>
+        {deliverables.length > 0 ? (
+          deliverables.map((p) => (
+            <div key={p.id} className="border p-2 mb-2 rounded">
+              {p.title || p.id}
+            </div>
+          ))
+        ) : (
+          <p className="text-sm text-secondary">No deliverables yet.</p>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default ProjectPage;

--- a/ethos-frontend/src/types/projectTypes.ts
+++ b/ethos-frontend/src/types/projectTypes.ts
@@ -1,0 +1,30 @@
+import type { Visibility } from './common';
+import type { Quest } from './questTypes';
+import type { Post } from './postTypes';
+
+export interface ProjectEdge {
+  from: string;
+  to: string;
+  type?: 'sub_project' | 'dependency';
+  label?: string;
+}
+
+export interface Project {
+  id: string;
+  authorId: string;
+  title: string;
+  description?: string;
+  visibility: Visibility;
+  status: 'active' | 'completed' | 'archived';
+  tags?: string[];
+  createdAt?: string;
+  quests: string[];
+  deliverables: string[];
+  mapEdges?: ProjectEdge[];
+  collaborators?: { userId?: string; roles?: string[]; pending?: string[] }[];
+}
+
+export interface EnrichedProject extends Project {
+  questsResolved?: Quest[];
+  deliverablesResolved?: Post[];
+}


### PR DESCRIPTION
## Summary
- define `DBProject` type and extend schema
- create project data store and project routes
- hook projects into server
- expose project API and hooks in frontend
- add simple project creation/editing components
- implement basic project page with map and deliverables sections

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a302cec832fb0132edb10615303