### PR TITLE
Fix promote quest route and update docs

### DIFF
--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -61,4 +61,10 @@ Tab labels reflect the selected type: selecting **file** shows a *File* tab, **f
 
 File tasks display the latest Git diff and an inline file editor. Planner nodes render their child tasks as a checklist so progress can be tracked when exporting the repo or downloading a specific file.
 
+## Project ⇄ Quest Evolution
+
+* Any large quest (Q::XX) can be promoted to a project
+* Auto-assigns its current ID as P::Q00
+* All its internal quests become children
+* Maintains continuity for links, posts, and deliverables
 

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -540,7 +540,7 @@ router.get(
 router.post(
   '/:id/promote',
   authMiddleware,
-  (req: AuthRequest<{ id: string }>, res: Response<Project>): void => {
+  (req: AuthRequest<{ id: string }>, res: Response): void => {
     const { id } = req.params;
 
     const quests = questsStore.read();


### PR DESCRIPTION
## Summary
- fix response type in the quest `promote` route
- document how quests can be promoted to projects

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685b117f78e8832fa9378ad1a074c7d9