### PR TITLE
Fix dev request spam by disabling rate limit

### DIFF
--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -55,12 +55,15 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   next();
 });
 app.use(helmet());
-app.use(
-  rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 100,
-  })
-);
+// Apply rate limiting only in production to prevent local development issues
+if (process.env.NODE_ENV === 'production') {
+  app.use(
+    rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    })
+  );
+}
 app.use(express.json());
 app.use(cookieParser());
 app.use(requestLogger);


### PR DESCRIPTION
## Summary
- apply rate limiting middleware only in production

## Testing
- `./setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685bc9ca3e00832fa496ba430332fb25