### PR TITLE
Fix dev request spam by disabling rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ npm install
 npx ts-node src/server.ts       # or: npm run dev
 ```
 
+Running the standalone TypeScript compiler requires the typings from
+`node_modules`. If you encounter errors about missing type definitions,
+ensure you've installed dependencies with `npm install` or run the
+provided `setup.sh` script first.
+
 For production builds, run `npm run build` and then start with `node dist/server.js`.
 
 ### Running Tests

--- a/ethos-backend/.env.example
+++ b/ethos-backend/.env.example
@@ -6,7 +6,7 @@ REFRESH_SECRET=supersecretrefreshkey456
 PORT=3001
 CLIENT_URL=http://localhost:5173
 DATABASE_URL=
-NODE_ENV=production
+NODE_ENV=development
 
 # Email SMTP (used for password reset emails)
 EMAIL_USER=youremail@example.com

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -55,12 +55,15 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   next();
 });
 app.use(helmet());
-app.use(
-  rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 100,
-  })
-);
+// Apply rate limiting only in production to prevent local development issues
+if (process.env.NODE_ENV === 'production') {
+  app.use(
+    rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    })
+  );
+}
 app.use(express.json());
 app.use(cookieParser());
 app.use(requestLogger);


### PR DESCRIPTION
## Summary
- apply rate limiting middleware only in production
- set NODE_ENV to development in example env

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom missing)*



------
https://chatgpt.com/codex/tasks/task_e_685bc9ca3e00832fa496ba430332fb25