### PR TITLE
fix missing ProjectEdge type

### DIFF
--- a/ethos-frontend/src/types/projectTypes.ts
+++ b/ethos-frontend/src/types/projectTypes.ts
@@ -1,5 +1,8 @@
 
-import type { Quest } from './questTypes';
+import type { Quest, TaskEdge } from './questTypes';
+
+// Alias the quest task edge type for project maps
+export type ProjectEdge = TaskEdge;
 
 export interface Project extends Quest {
   questIds: string[];


### PR DESCRIPTION
## Summary
- restore `ProjectEdge` in project types to align with `TaskEdge`
- run backend and frontend tests

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68788528fae4832fa49a6ced16aa1f3c