### PR TITLE
Fix quest fetch type

### DIFF
--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -57,7 +57,10 @@ const LinkControls: React.FC<LinkControlsProps> = ({
       let idx = 0;
       if (itemTypes.includes('quest')) {
         const questRes = results[idx++];
-        if (questRes.status === 'fulfilled') setQuests(questRes.value || []);
+        if (questRes.status === 'fulfilled') {
+          const list = (questRes.value as Quest[]) || [];
+          setQuests(list);
+        }
       }
       if (itemTypes.includes('post')) {
         const postRes = results[idx++];


### PR DESCRIPTION
## Summary
- fix type error when loading quests in `LinkControls`

## Testing
- `npm test -- src/components/controls/LinkControls.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6878857ffc48832faf51229eadb07090