### PR TITLE
Fix ReactionControls test types

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
 import ReactionControls from './ReactionControls';
 import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
@@ -15,7 +17,9 @@ jest.mock('../../api/post', () => ({
 
 const navigateMock = jest.fn();
 
-const useBoardContextMock = jest.fn(() => ({ selectedBoard: null }));
+const useBoardContextMock = jest.fn(
+  (): { selectedBoard: string | null } => ({ selectedBoard: null })
+);
 
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
@@ -44,11 +48,22 @@ describe.skip('ReactionControls', () => {
     linkedItems: [],
     questId: 'q1',
   };
+  const user = {
+    id: 'u1',
+    email: 'u1@example.com',
+    username: 'u1',
+    password: 'pw',
+    role: 'user',
+    bio: '',
+    tags: [],
+    links: {},
+    experienceTimeline: [],
+  } as User;
 
   it('shows Quest Log for task posts', async () => {
     render(
       <BrowserRouter>
-        <ReactionControls post={basePost} user={{ id: 'u1' }} />
+        <ReactionControls post={basePost} user={user} />
       </BrowserRouter>
     );
     expect(await screen.findByText('Quest Log')).toBeInTheDocument();
@@ -58,7 +73,7 @@ describe.skip('ReactionControls', () => {
     const commitPost = { ...basePost, type: 'commit' } as Post;
     render(
       <BrowserRouter>
-        <ReactionControls post={commitPost} user={{ id: 'u1' }} />
+        <ReactionControls post={commitPost} user={user} />
       </BrowserRouter>
     );
     expect(await screen.findByText('File Change View')).toBeInTheDocument();
@@ -68,7 +83,7 @@ describe.skip('ReactionControls', () => {
     const fsPost = { ...basePost, type: 'free_speech' } as Post;
     render(
       <BrowserRouter>
-        <ReactionControls post={fsPost} user={{ id: 'u1' }} />
+        <ReactionControls post={fsPost} user={user} />
       </BrowserRouter>
     );
     expect(await screen.findByText('Reply')).toBeInTheDocument();
@@ -77,7 +92,7 @@ describe.skip('ReactionControls', () => {
   it('toggles expanded view for tasks', async () => {
     render(
       <BrowserRouter>
-        <ReactionControls post={basePost} user={{ id: 'u1' }} />
+        <ReactionControls post={basePost} user={user} />
       </BrowserRouter>
     );
     const expand = await screen.findByText('Expand View');
@@ -91,7 +106,7 @@ describe.skip('ReactionControls', () => {
       <BrowserRouter>
         <ReactionControls
           post={{ ...basePost, type: 'free_speech' } as Post}
-          user={{ id: 'u1' }}
+          user={user}
           replyOverride={{ label: 'Add Item', onClick: handler }}
         />
       </BrowserRouter>
@@ -106,7 +121,7 @@ describe.skip('ReactionControls', () => {
     const fsPost = { ...basePost, type: 'free_speech' } as Post;
     render(
       <BrowserRouter>
-        <ReactionControls post={fsPost} user={{ id: 'u1' }} />
+        <ReactionControls post={fsPost} user={user} />
       </BrowserRouter>
     );
     fireEvent.click(screen.getByText('Reply'));

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -43,6 +43,7 @@ import {
 import type { Post, ReactionType, ReactionCountMap, Reaction, PostType } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import type { Quest } from '../../types/questTypes';
+import type { BoardItem } from '../../contexts/BoardContextTypes';
 
 interface ReactionControlsProps {
   post: Post;
@@ -197,11 +198,11 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           post.id,
           post.type
         );
-        appendToBoard?.('quest-board', reqPost);
-        appendToBoard?.('timeline-board', reqPost);
+        appendToBoard?.('quest-board', reqPost as unknown as BoardItem);
+        appendToBoard?.('timeline-board', reqPost as unknown as BoardItem);
         subRequests.forEach(sr => {
-          appendToBoard?.('quest-board', sr);
-          appendToBoard?.('timeline-board', sr);
+          appendToBoard?.('quest-board', sr as unknown as BoardItem);
+          appendToBoard?.('timeline-board', sr as unknown as BoardItem);
           onUpdate?.(sr);
         });
         setHelpRequested(true);
@@ -425,8 +426,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         <div className="mt-3">
           <CreatePost
             replyTo={post}
-            onSave={(newReply: Post) => {
-              onUpdate?.(newReply);
+            onSave={(newReply) => {
+              onUpdate?.(newReply as Post);
               setShowReplyPanel(false);
             }}
             onCancel={() => setShowReplyPanel(false)}


### PR DESCRIPTION
## Summary
- tweak ReactionControls to cast board items
- relax CreatePost save handler typing
- update ReactionControls test to use typed mock user and jest-dom

## Testing
- `npm --prefix ethos-frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_6878859ed9c8832fa7a1c5acce497b73