### PR TITLE
Fix ActivityFeed user typing

### DIFF
--- a/ethos-frontend/src/components/feed/ActivityFeed.tsx
+++ b/ethos-frontend/src/components/feed/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import { fetchRecentPosts } from '../../api/post';
 import PostCard from '../post/PostCard';
 import { Spinner } from '../ui';
 import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
 
 const ActivityFeed: React.FC = () => {
   const { user } = useAuth();
@@ -32,7 +33,7 @@ const ActivityFeed: React.FC = () => {
   return (
     <div className="space-y-4">
       {posts.map(p => (
-        <PostCard key={p.id} post={p} user={user} />
+        <PostCard key={p.id} post={p} user={user as User} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- correct user type passed to `PostCard` in `ActivityFeed`

## Testing
- `npm test --silent` within `ethos-frontend` *(fails: Jest unable to process some ESM modules)*
- `npm test --silent` within `ethos-backend` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_687885b2d51c832fa65339b492a8222d