### PR TITLE
Fix ts errors in Graph and Grid layout components

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -266,7 +266,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       };
       setLocalItems((prev) => [...prev, newNode]);
       setEdgeList((prev) => {
-        const updated = [...prev, { from: parentId, to: newId }];
+        const newEdge: TaskEdge = { from: parentId, to: newId };
+        const updated: TaskEdge[] = [...prev, newEdge];
         onEdgesChange?.(updated);
         return updated;
       });
@@ -294,7 +295,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
           (e) => e.from === targetId && e.to === nodeId && e.type === 'abstract'
         );
         if (exists) return prev;
-        const updated = [...prev, { from: targetId, to: nodeId, type: 'abstract' }];
+        const newEdge: TaskEdge = { from: targetId, to: nodeId, type: 'abstract' };
+        const updated: TaskEdge[] = [...prev, newEdge];
         onEdgesChange?.(updated);
         return updated;
       });
@@ -306,7 +308,8 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       const exists = filtered.some(
         (e) => e.from === targetId && e.to === nodeId,
       );
-      const updated = exists ? filtered : [...filtered, { from: targetId, to: nodeId }];
+      const newEdge: TaskEdge = { from: targetId, to: nodeId };
+      const updated: TaskEdge[] = exists ? filtered : [...filtered, newEdge];
       if (updated !== prev) onEdgesChange?.(updated);
       return updated;
     });


### PR DESCRIPTION
## Summary
- fix edge list state updates by casting new edges to `TaskEdge`
- remove unused props and imports from `GridLayout`
- cast board update items to `BoardItem`
- handle custom events with correct listener type

## Testing
- `npx tsc -b --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687885f68728832f9473aa6b57a5bc89