### PR TITLE
Fix TypeScript errors in MapGraphLayout

### DIFF
--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -13,8 +13,6 @@ interface MapGraphLayoutProps {
   compact?: boolean;
   onScrollEnd?: () => void;
   loadingMore?: boolean;
-  /** Notify parent when the edge list updates */
-  onEdgesChange?: (edges: TaskEdge[]) => void;
   /** Custom handler when a node is clicked */
   onNodeClick?: (node: Post) => void;
 }
@@ -22,10 +20,9 @@ interface MapGraphLayoutProps {
 const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
   items,
   edges = [],
-  onEdgesChange,
   onNodeClick,
 }) => {
-  const fgRef = useRef<ForceGraphMethods>();
+  const fgRef = useRef<ForceGraphMethods>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges);
 
@@ -48,33 +45,6 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
     };
   }, [items, edgeList]);
 
-  const emitEdges = (updated: TaskEdge[]) => {
-    if (onEdgesChange) {
-      onEdgesChange(updated);
-    } else {
-      window.dispatchEvent(
-        new CustomEvent('questGraphUpdate', { detail: { edges: updated } }),
-      );
-    }
-  };
-
-  const isDescendant = (parentId: string, childId: string): boolean => {
-    const visited = new Set<string>();
-    const stack = [parentId];
-    while (stack.length > 0) {
-      const current = stack.pop()!;
-      if (current === childId) return true;
-      edgeList
-        .filter((e) => e.from === current)
-        .forEach((e) => {
-          if (!visited.has(e.to)) {
-            visited.add(e.to);
-            stack.push(e.to);
-          }
-        });
-    }
-    return false;
-  };
 
   const handleNodeClick = (node: unknown) => {
     const n = node as Post;

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -378,7 +378,6 @@ const QuestCard: React.FC<QuestCardProps> = ({
       <MapGraphLayout
         items={logs}
         edges={questData.taskGraph}
-        onEdgesChange={handleEdgesSave}
       />
     );
 

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -149,7 +149,6 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
             <MapGraphLayout
               items={displayNodes}
               edges={displayEdges}
-              onEdgesChange={handleEdgesSave}
               {...(!isHeadNode && {
                 onNodeClick: (n: Post) => {
                   if (n.id !== task.id) navigate(ROUTES.POST(n.id));


### PR DESCRIPTION
## Summary
- remove unused helpers in `MapGraphLayout`
- stop passing `onEdgesChange` to `MapGraphLayout`
- fix `useRef` initialization

## Testing
- `npm test` in `ethos-frontend`
- `npm run lint` *(fails: 36 errors, 38 warnings)*
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_68788609be7c832faa9fd2bce4078ae6