### PR TITLE
Fix type errors with post structures

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -220,7 +220,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
         <CreateQuest
           onSave={(q) => onSave?.(q)}
           onCancel={onCancel}
-          boardId={boardId || selectedBoard}
+          boardId={boardId || selectedBoard || undefined}
         />
       </div>
     );

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -7,6 +7,7 @@ import MarkdownRenderer from '../ui/MarkdownRenderer';
 import { updatePost } from '../../api/post';
 import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
 import { useBoardContext } from '../../contexts/BoardContext';
+import type { BoardItem } from '../../contexts/BoardContextTypes';
 import type { PostType, Post, CollaberatorRoles, LinkedItem } from '../../types/postTypes';
 
 import { Select, Button, Label, FormSection, Input, MarkdownEditor } from '../ui';
@@ -60,7 +61,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
 
     try {
       const updatedPost = await updatePost(post.id, payload);
-      if (selectedBoard) updateBoardItem(selectedBoard, updatedPost);
+      if (selectedBoard) updateBoardItem(selectedBoard, updatedPost as BoardItem);
       if (onUpdated) onUpdated(updatedPost);
     } catch (error) {
       console.error('[EditPost] Failed to update post:', error);

--- a/ethos-frontend/src/components/post/NestedReply.tsx
+++ b/ethos-frontend/src/components/post/NestedReply.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import PostCard from './PostCard';
-import type { Post } from '../../types/postTypes';
+import type { Post, EnrichedPost } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
 interface NestedReplyProps {
-  post: Post;
+  post: Post | EnrichedPost;
   user?: User;
   depth?: number;
   onUpdate?: (post: Post) => void;
@@ -22,7 +22,8 @@ const NestedReply: React.FC<NestedReplyProps> = ({
   onDelete,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const content = post.renderedContent || post.content;
+  const enriched = post as EnrichedPost;
+  const content = enriched.renderedContent || post.content;
   const isLong = content.length > PREVIEW_LIMIT;
 
   const indent = Math.min(depth * 16, MAX_INDENT);

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -71,6 +71,8 @@ export interface Post {
 
   /** UI hint used when a post is part of a highlighted task path */
   highlight?: boolean;
+
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add index signature to `Post` so it conforms to `BoardItem`
- pass an undefined boardId when none is selected
- cast updated posts to `BoardItem` when updating boards
- allow enriched posts in `NestedReply`

## Testing
- `npm test --prefix ethos-frontend`
- `npm test --prefix ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_687886487c3c832fa41a8484397785ce