### PR TITLE
Fix PostListItem type usage

### DIFF
--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostListItem from './PostListItem';
-import type { Post } from '../../types/postTypes';
+import type { PostWithQuestTitle } from '../../utils/displayUtils';
 import { ROUTES } from '../../constants/routes';
 
 const navMock = jest.fn();
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-const basePost: Post = {
+const basePost: PostWithQuestTitle = {
   id: 'p1',
   authorId: 'u1',
   type: 'free_speech',
@@ -25,7 +25,7 @@ const basePost: Post = {
   tags: [],
   collaborators: [],
   linkedItems: [],
-} as unknown as Post;
+} as unknown as PostWithQuestTitle;
 
 describe('PostListItem', () => {
   it('navigates to post page on click', () => {
@@ -40,11 +40,11 @@ describe('PostListItem', () => {
   });
 
   it('renders quest tag when quest info is provided', () => {
-    const questPost: Post = {
+    const questPost: PostWithQuestTitle = {
       ...basePost,
       questId: 'q1',
       questTitle: 'Quest A',
-    } as Post;
+    } as unknown as PostWithQuestTitle;
 
     render(
       <BrowserRouter>
@@ -56,13 +56,13 @@ describe('PostListItem', () => {
   });
 
   it('renders review summary tag', () => {
-    const reviewPost: Post = {
+    const reviewPost: PostWithQuestTitle = {
       ...basePost,
       id: 'r1',
       type: 'review',
       questId: 'q2',
       questTitle: 'Quest B',
-    } as Post;
+    } as unknown as PostWithQuestTitle;
 
     render(
       <BrowserRouter>
@@ -78,11 +78,11 @@ describe('PostListItem', () => {
   });
 
   it('renders generic review tag when quest title missing', () => {
-    const reviewPost: Post = {
+    const reviewPost: PostWithQuestTitle = {
       ...basePost,
       id: 'r2',
       type: 'review',
-    } as Post;
+    } as unknown as PostWithQuestTitle;
 
     render(
       <BrowserRouter>

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
-import type { Post } from '../../types/postTypes';
+import type { PostWithQuestTitle } from '../../utils/displayUtils';
 import { getDisplayTitle, buildSummaryTags } from '../../utils/displayUtils';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
@@ -23,7 +23,7 @@ const renderStars = (count: number) => (
 );
 
 interface PostListItemProps {
-  post: Post;
+  post: PostWithQuestTitle;
 }
 
 const PostListItem: React.FC<PostListItemProps> = ({ post }) => {


### PR DESCRIPTION
## Summary
- use `PostWithQuestTitle` in `PostListItem`
- update `PostListItem.test` to match new prop type

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68788686b000832f9002da281fd4d95a