### PR TITLE
Fix Select option typing for readonly arrays

### DIFF
--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -157,7 +157,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
           <Select
             value={status}
             onChange={handleStatusChange}
-            options={STATUS_OPTIONS as option[]}
+            options={STATUS_OPTIONS}
             className="text-xs"
           />
         </div>
@@ -165,7 +165,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
           <Select
             value={taskType}
             onChange={handleTypeChange}
-            options={TASK_TYPE_OPTIONS as option[]}
+            options={TASK_TYPE_OPTIONS}
             className="text-xs"
           />
         </div>
@@ -241,7 +241,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
         <Select
           value={status}
           onChange={handleStatusChange}
-          options={STATUS_OPTIONS as option[]}
+          options={STATUS_OPTIONS}
           className="text-xs"
         />
       </div>
@@ -249,7 +249,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
         <Select
           value={taskType}
           onChange={handleTypeChange}
-          options={TASK_TYPE_OPTIONS as option[]}
+          options={TASK_TYPE_OPTIONS}
           className="text-xs"
         />
       </div>

--- a/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
+++ b/ethos-frontend/src/components/quest/QuestNodeInspector.tsx
@@ -181,13 +181,13 @@ const QuestNodeInspector: React.FC<QuestNodeInspectorProps> = ({
               id="task-type"
               value={type}
               onChange={handleChange}
-              options={TASK_TYPE_OPTIONS as option[]}
+              options={TASK_TYPE_OPTIONS}
             />
             <Select
               id="task-status"
               value={statusVal}
               onChange={handleStatusSelect}
-              options={STATUS_OPTIONS as option[]}
+              options={STATUS_OPTIONS}
             />
           </div>
         )}

--- a/ethos-frontend/src/components/ui/Select.tsx
+++ b/ethos-frontend/src/components/ui/Select.tsx
@@ -7,7 +7,7 @@ export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElemen
   id?: string;
   value: string;
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
-  options: option[];
+  options: readonly option[];
   className?: string;
   helperText?: string;
   error?: boolean;


### PR DESCRIPTION
## Summary
- allow `Select` to accept readonly option arrays
- remove unnecessary `as option[]` casts when providing constant options

## Testing
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime' and other deps)*
- `npm test` *(fails: Jest environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_687886b82644832f8b309a38bdb4c346