### PR TITLE
Fix RequestCard imports and types

### DIFF
--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Post } from '../../types/postTypes';
 import { Button, AvatarStack, SummaryTag } from '../ui';
 import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
@@ -6,6 +6,7 @@ import { getRank } from '../../utils/rankUtils';
 import { FaUserPlus, FaUserCheck } from 'react-icons/fa';
 import { useAuth } from '../../contexts/AuthContext';
 import { acceptRequest, unacceptRequest } from '../../api/post';
+import { ROUTES } from '../../constants/routes';
 
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
 

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -25,6 +25,8 @@ export interface Post {
 
   questId?: string | null;
   questNodeTitle?: string;
+  /** Title of the quest this post belongs to */
+  questTitle?: string;
   nodeId?: string;
 
   /** Optional rating value for review posts */


### PR DESCRIPTION
## Summary
- add missing `useState` and `ROUTES` imports in `RequestCard`
- include optional `questTitle` field in `Post` type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788732418c832faa623c78dd621100