### PR TITLE
Fix Banner type

### DIFF
--- a/ethos-frontend/src/components/ui/Banner.tsx
+++ b/ethos-frontend/src/components/ui/Banner.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { TAG_BASE } from '../../constants/styles';
 import type { User } from '../../types/userTypes';
 import { getRank } from '../../utils/rankUtils';
-import type { Quest } from '../../types/questTypes';
+import type { EnrichedQuest } from '../../types/questTypes';
 import type { CollaberatorRoles } from '../../types/postTypes';
 
 interface BannerProps {
   user?: User;
-  quest?: Quest;
+  quest?: EnrichedQuest;
   /** Optional quest creator display name */
   creatorName?: string;
   readOnly?: boolean;


### PR DESCRIPTION
## Summary
- import `EnrichedQuest` in `Banner`
- update `BannerProps` to use `EnrichedQuest`

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm test`
- `npm run build` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878874073cc832f956db57d080577c5