### PR TITLE
Fix board type defaults

### DIFF
--- a/ethos-frontend/src/hooks/useBoard.ts
+++ b/ethos-frontend/src/hooks/useBoard.ts
@@ -96,6 +96,7 @@ export const useBoard = (
       : {
           id: 'my-quests',
           title: 'Quests',
+          boardType: 'quest',
           layout: 'grid',
           items: quests.map(q => q.id),
           createdAt: '',
@@ -107,6 +108,7 @@ export const useBoard = (
       : {
           id: 'my-posts',
           title: 'Posts',
+          boardType: 'post',
           layout: 'grid',
           items: posts.map(p => p.id),
           createdAt: '',


### PR DESCRIPTION
## Summary
- specify boardType when creating placeholder boards

## Testing
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_687887a406b0832fa3aef4daf7ad4886