### PR TITLE
Fix TypeScript issues

### DIFF
--- a/ethos-frontend/src/components/feed/RecentActivityBoard.tsx
+++ b/ethos-frontend/src/components/feed/RecentActivityBoard.tsx
@@ -23,14 +23,17 @@ import { useSocketListener } from '../../hooks/useSocket';
 import { fetchBoard } from '../../api/board';
 import { Spinner } from '../ui';
 import Board from '../board/Board';
-import PostListItem from '../post/PostListItem';
 
 /**
  * RecentActivityBoard renders a board showing the latest activity for the
  * homepage. It loads data using the `useBoard` hook and listens for
  * `board:update` events via websockets to stay up to date.
  */
-const RecentActivityBoard = ({ boardId = 'timeline-board' }) => {
+interface RecentActivityBoardProps {
+  boardId?: string;
+}
+
+const RecentActivityBoard: React.FC<RecentActivityBoardProps> = ({ boardId = 'timeline-board' }) => {
   const { user } = useAuth();
   const { board, setBoard } = useBoard(boardId);
   const [page, setPage] = useState(1);
@@ -79,7 +82,7 @@ const RecentActivityBoard = ({ boardId = 'timeline-board' }) => {
     fetchBoard(boardId, { enrich: true, userId: user?.id }).then(setBoard);
   });
 
-  const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/ethos-frontend/src/pages/PublicProfile.tsx
+++ b/ethos-frontend/src/pages/PublicProfile.tsx
@@ -56,26 +56,28 @@ const PublicProfilePage: React.FC = () => {
   }, [userId]);
 
   // 🔁 Real-time board updates (via WebSocket)
-  useSocketListener('board:update', async (updatedBoard: BoardData) => {
+  useSocketListener('board:update', (updatedBoard: BoardData) => {
     if (!userId || updatedBoard.userId !== userId) return;
 
-    try {
-      // 🧭 If it's a quest board
-      if (updatedBoard.id === questBoard?.id) {
-        const quests = await fetchQuestsForBoard(updatedBoard.id, userId);
-        const enriched = await enrichQuests(quests);
-        setQuestBoard({ ...updatedBoard, enrichedItems: enriched });
-      }
+    (async () => {
+      try {
+        // 🧭 If it's a quest board
+        if (updatedBoard.id === questBoard?.id) {
+          const quests = await fetchQuestsForBoard(updatedBoard.id, userId);
+          const enriched = await enrichQuests(quests);
+          setQuestBoard({ ...updatedBoard, enrichedItems: enriched });
+        }
 
-      // 📬 If it's a post board
-      if (updatedBoard.id === postBoard?.id) {
-        const posts = await fetchPostsForBoard(updatedBoard.id, userId);
-        const enriched = await enrichPosts(posts);
-        setPostBoard({ ...updatedBoard, enrichedItems: enriched });
+        // 📬 If it's a post board
+        if (updatedBoard.id === postBoard?.id) {
+          const posts = await fetchPostsForBoard(updatedBoard.id, userId);
+          const enriched = await enrichPosts(posts);
+          setPostBoard({ ...updatedBoard, enrichedItems: enriched });
+        }
+      } catch (err) {
+        console.error('[Socket board:update] Failed to fetch or enrich items:', err);
       }
-    } catch (err) {
-      console.error('[Socket board:update] Failed to fetch or enrich items:', err);
-    }
+    })();
   });
 
   if (error) {

--- a/ethos-frontend/src/pages/__tests__/PostPageReply.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/PostPageReply.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostPage from '../post/[id]';
@@ -18,8 +17,8 @@ const fetchReplyBoard = jest.fn(() => Promise.resolve({ id: 'thread-p1', items: 
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
-  fetchPostById: (...args: unknown[]) => fetchPostById(...args),
-  fetchReplyBoard: (...args: unknown[]) => fetchReplyBoard(...args),
+  fetchPostById: (...args: Parameters<typeof fetchPostById>) => fetchPostById(...args),
+  fetchReplyBoard: (...args: Parameters<typeof fetchReplyBoard>) => fetchReplyBoard(...args),
 }));
 
 jest.mock('../../components/board/Board', () => ({

--- a/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/QuestLogPermissions.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import QuestPage from '../quest/[id]';
 

--- a/ethos-frontend/src/pages/board/team-[questId].tsx
+++ b/ethos-frontend/src/pages/board/team-[questId].tsx
@@ -5,7 +5,7 @@ import { fetchUserById } from '../../api/auth';
 import { Spinner, AvatarStack } from '../../components/ui';
 
 interface Collaborator {
-  userId: string;
+  userId?: string;
   username?: string;
   roles?: string[];
   avatarUrl?: string;

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -164,7 +164,7 @@ const PostPage: React.FC = () => {
             editable={false}
             compact={true}
             initialExpanded={true}
-            user={user || undefined}
+            user={user as User}
           />
         ) : (
           <Spinner />

--- a/ethos-frontend/src/pages/project/[id].tsx
+++ b/ethos-frontend/src/pages/project/[id].tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useProject } from '../../hooks/useProject';
 import { fetchPostById } from '../../api/post';
 import { Spinner } from '../../components/ui';
+import type { Project } from '../../types/projectTypes';
 
 const ProjectPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,7 +14,7 @@ const ProjectPage: React.FC = () => {
     const load = async () => {
       if (!project) return;
       const posts = await Promise.all(
-        (project.deliverables || []).map((pid) =>
+        (project.deliverables || []).map((pid: string) =>
           fetchPostById(pid).catch(() => null),
         ),
       );

--- a/ethos-frontend/src/pages/quest/[id].tsx
+++ b/ethos-frontend/src/pages/quest/[id].tsx
@@ -120,15 +120,15 @@ const QuestPage: React.FC = () => {
       <section>
         <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">🗺 Quest Map</h2>
         {mapBoard && boardContextAvailable && process.env.NODE_ENV !== 'test' ? (
-          <Board
-            boardId={`map-${id}`}
-            board={mapBoard}
-            layout="map-graph"
-            editable={user?.id === quest.ownerId}
-            quest={quest}
-            user={user as User}
-            showCreate
-          />
+            <Board
+              boardId={`map-${id}`}
+              board={mapBoard}
+              layout="map-graph"
+              editable={user?.id === quest.authorId}
+              quest={quest}
+              user={user as User}
+              showCreate
+            />
         ) : (
           <Spinner />
         )}

--- a/ethos-frontend/src/pages/review/[entityType]/[id].tsx
+++ b/ethos-frontend/src/pages/review/[entityType]/[id].tsx
@@ -39,7 +39,7 @@ const ReviewSummaryPage: React.FC = () => {
           </div>
           <ul className="list-disc list-inside text-sm">
             {Object.entries(summary.tagCounts).map(([tag, count]) => (
-              <li key={tag}>{tag}: {count}</li>
+              <li key={tag}>{tag}: {count as number}</li>
             ))}
           </ul>
         </div>

--- a/ethos-frontend/src/types/projectTypes.ts
+++ b/ethos-frontend/src/types/projectTypes.ts
@@ -6,4 +6,6 @@ export type ProjectEdge = TaskEdge;
 
 export interface Project extends Quest {
   questIds: string[];
+  deliverables?: string[];
+  mapEdges?: ProjectEdge[];
 }

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -31,7 +31,9 @@ export const createMockBoard = (
     boardType,
     layout: 'grid',
     items: itemIds,
-    enrichedItems: items,
+    enrichedItems: items.filter(
+      (it): it is Post | Quest => typeof it === 'object' && it !== null
+    ),
     createdAt: new Date().toISOString(),
   };
 };
@@ -66,8 +68,8 @@ export const getRenderableBoardItems = (
     seen.add(item.id);
 
     if (!('headPostId' in item)) {
-      const questId = item.questId;
-      const linkedQuest = item.linkedItems?.find(
+      const questId = (item as Post | RenderableItem).questId;
+      const linkedQuest = (item as Post | RenderableItem).linkedItems?.find(
         (l: LinkedItem) => l.itemType === 'quest' && questIds.has(l.itemId)
       );
       if ((questId && questIds.has(questId)) || linkedQuest) {

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -97,7 +97,9 @@ export interface SummaryTagData {
     | "quest_task"
     | "meta_system"
     | "meta_announcement"
-    | "solved";
+    | "solved"
+    | "request"
+    | "party_request";
   label: string;
   link?: string;
   username?: string;


### PR DESCRIPTION
## Summary
- fix `useSocketListener` callback return types
- convert `RecentActivityBoard` to TypeScript and clean up props
- adjust quest page author check and board utils types
- extend `Project` type and project page usage
- handle optional collaborator ids
- allow new tag types in `displayUtils`
- update tests for TS compatibility

## Testing
- `npx tsc --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68789137c224832f895b3094e361f308