### PR TITLE
Fix board loading errors and font imports

### DIFF
--- a/ethos-frontend/src/contexts/BoardContext.tsx
+++ b/ethos-frontend/src/contexts/BoardContext.tsx
@@ -77,7 +77,11 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     const loadBoards = async () => {
       setLoading(true);
       try {
-        const boardList = await fetchBoardsAPI({ userId: user?.id, enrich: true });
+        const rawList = await fetchBoardsAPI({ userId: user?.id, enrich: true });
+        const boardList = Array.isArray(rawList) ? rawList : [];
+        if (!Array.isArray(rawList)) {
+          console.warn('[BoardContext] Expected boards array but received', rawList);
+        }
         const boardMap: BoardMap = {};
         boardList.forEach((b: BoardData) => {
           boardMap[b.id] = b;
@@ -168,7 +172,11 @@ export const BoardProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   const refreshBoards = async () => {
     if (!user) return;
     try {
-      const boardList = await fetchBoardsAPI({ userId: user.id, enrich: true });
+      const rawList = await fetchBoardsAPI({ userId: user.id, enrich: true });
+      const boardList = Array.isArray(rawList) ? rawList : [];
+      if (!Array.isArray(rawList)) {
+        console.warn('[BoardContext] Expected boards array but received', rawList);
+      }
       const boardMap: BoardMap = {};
       boardList.forEach((b: BoardData) => {
         boardMap[b.id] = b;

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -1,4 +1,4 @@
-@import "@fontsource/inter/index.css";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 @import "tailwindcss";
 @import 'highlight.js/styles/github.css';
 @tailwind base;


### PR DESCRIPTION
## Summary
- prevent crashes when fetching boards returns unexpected data
- load Inter font via Google Fonts to avoid invalid woff path

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68797e73ecc0832f84292e300a5ba51a