### PR TITLE
Fix inconsistent dev port numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ cd ethos-frontend
 npm install
 npm run dev
 ```
+The Vite dev server runs at http://localhost:5173 by default.
+
 
 Vite looks for `postcss.config.cjs` in this directory. If you encounter
 "Failed to load PostCSS config" errors, ensure there is no leftover
@@ -169,6 +171,8 @@ This runs the frontend Jest tests in `ethos-frontend/tests`.
 
 ```env
 PORT=4173
+CLIENT_URL=http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
 ACCESS_SECRET=your_access_secret
 REFRESH_SECRET=your_refresh_secret
 DATABASE_URL=your_postgresql_uri

--- a/ethos-backend/.env
+++ b/ethos-backend/.env
@@ -4,8 +4,8 @@ REFRESH_SECRET=supersecretrefreshkey456
 
 # App Config
 PORT=4173
-CLIENT_URL=http://18.118.173.176:5173
-ALLOWED_ORIGINS=http://18.118.173.176:5173,http://18.118.173.176:4173
+CLIENT_URL=http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
 
 # Email SMTP (used for password reset emails)
 EMAIL_USER=youremail@example.com

--- a/ethos-backend/.env.example
+++ b/ethos-backend/.env.example
@@ -4,8 +4,8 @@ REFRESH_SECRET=supersecretrefreshkey456
 
 # App Config
 PORT=4173
-CLIENT_URL=http://localhost:4173
-ALLOWED_ORIGINS=http://localhost:4173,http://18.118.173.176:4173
+CLIENT_URL=http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
 DATABASE_URL=
 NODE_ENV=development
 

--- a/ethos-backend/dist/src/server.js
+++ b/ethos-backend/dist/src/server.js
@@ -30,9 +30,9 @@ const app = (0, express_1.default)();
 /**
  * Define allowed frontend origin.
  * @constant
- * @default 'http://localhost:4173'
+ * @default 'http://localhost:5173'
  */
-const CLIENT_URL = process.env.CLIENT_URL || 'http://18.118.173.176:4173';
+const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
 /**
  * Comma separated list of allowed origins for CORS.
  * Allows multiple frontends in different environments.

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -31,9 +31,9 @@ const app: Express = express();
 /**
  * Define allowed frontend origin.
  * @constant
- * @default 'http://localhost:4173'
+ * @default 'http://localhost:5173'
  */
-const CLIENT_URL: string = process.env.CLIENT_URL || 'http://18.118.173.176:4173';
+const CLIENT_URL: string = process.env.CLIENT_URL || 'http://localhost:5173';
 
 /**
  * Comma separated list of allowed origins for CORS.


### PR DESCRIPTION
## Summary
- document default dev server port in the README
- note correct backend environment variables
- update backend env examples
- set backend default client URL to port 5173

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_687a579855c4832f9af311c473af8e93