### PR TITLE
Fix local API defaults

### DIFF
--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -134,6 +134,6 @@ const PORT: number = parseInt(process.env.PORT || '4173', 10);
  * Logs a message with the active port and frontend origin
  */
 app.listen(PORT, () => {
-  info(`🚀 Backend server running at http://18.118.173.176:${PORT}`);
+  info(`🚀 Backend server running at http://localhost:${PORT}`);
   info(`🌐 Accepting requests from: ${ALLOWED_ORIGINS.join(', ')}`);
 });

--- a/ethos-frontend/jest.setup.ts
+++ b/ethos-frontend/jest.setup.ts
@@ -15,6 +15,6 @@ if (typeof global.TextDecoder === 'undefined') {
 }
 
 // Provide a default API base for modules that read from import.meta.env
-process.env.VITE_API_URL = 'http://18.118.173.176:4173/api';
+process.env.VITE_API_URL = 'http://localhost:4173/api';
 
 

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -35,7 +35,7 @@ export const getSocket = (): Socket => {
     const SOCKET_URL =
       getEnv().VITE_SOCKET_URL ||
       (typeof process !== 'undefined' ? process.env.VITE_SOCKET_URL : undefined) ||
-      'http://18.118.173.176:4173';
+      'http://localhost:4173';
     socket = io(SOCKET_URL, {
       autoConnect: false,
       transports: ['websocket'],

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -15,7 +15,7 @@ const getEnv = () => {
 const API_BASE =
   getEnv().VITE_API_URL ||
   (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
-  'http://18.118.173.176:4173/api';
+  'http://localhost:4173/api';
 
 /**
  * 🔐 In-memory access token used for Authorization header


### PR DESCRIPTION
## Summary
- default to localhost when environment URLs aren't set
- adjust backend startup log

## Testing
- `npm test --silent --prefix ethos-backend`
- `npm test --silent --prefix ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad8aceb48832fb831469288ce3f94