### PR TITLE
Fix frontend lint errors

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -181,7 +181,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || makeHeader(post.content);
-  let summaryTags = buildSummaryTags(post, questTitle, questId);
+  const summaryTags = buildSummaryTags(post, questTitle, questId);
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 

--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -4,6 +4,7 @@ import { Select, StatusBadge, SummaryTag } from '../ui';
 import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
 import { buildSummaryTags } from '../../utils/displayUtils';
+import type { SummaryTagData } from '../ui/SummaryTag';
 import { ROUTES } from '../../constants/routes';
 import { updatePost } from '../../api/post';
 import { createRepoFolder } from '../../api/git';
@@ -120,7 +121,9 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
   };
 
   const summaryTags = buildSummaryTags(post);
-  let taskTag = summaryTags.find(t => t.type === 'task');
+  let taskTag: SummaryTagData | undefined = summaryTags.find(
+    t => t.type === 'task',
+  );
   if (taskTag) {
     taskTag = {
       ...taskTag,
@@ -130,7 +133,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
       username: undefined,
       usernameLink: undefined,
       link: ROUTES.POST(post.id),
-    } as any;
+    };
   } else {
     const label = post.nodeId ? post.nodeId.replace(/^Q:[^:]+:/, '') : 'Task';
     taskTag = {
@@ -138,7 +141,7 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
       label,
       detailLink: ROUTES.POST(post.id),
       link: ROUTES.POST(post.id),
-    } as any;
+    };
   }
 
   const tagNode = !hideSummaryTag && taskTag ? (

--- a/ethos-frontend/src/components/quest/QuestCard.tsx
+++ b/ethos-frontend/src/components/quest/QuestCard.tsx
@@ -396,7 +396,7 @@ const QuestCard: React.FC<QuestCardProps> = ({
       selectedNode.taskType === 'folder' ||
       selectedNode.id === rootNode?.id ||
       children.length > 0;
-    const isPlanner = Boolean((selectedNode as any).planner);
+    const isPlanner = Boolean(selectedNode.planner);
 
     const statusBoard = (
       <StatusBoardPanel

--- a/ethos-frontend/src/components/quest/TeamPanel.tsx
+++ b/ethos-frontend/src/components/quest/TeamPanel.tsx
@@ -79,7 +79,10 @@ const TeamPanel: React.FC<TeamPanelProps> = ({ questId, node, canEdit = true }) 
           <AvatarStack
             users={(quest.collaborators || [])
               .filter(c => c.userId)
-              .map(c => ({ avatarUrl: (c as any).avatarUrl, username: c.username }))}
+              .map(c => ({
+                avatarUrl: (c as { avatarUrl?: string }).avatarUrl,
+                username: c.username,
+              }))}
           />
           <Link
             to={ROUTES.TEAM_BOARD(quest.id)}

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import type { Post } from '../../types/postTypes';
+import type { Post, EnrichedPost } from '../../types/postTypes';
 import { Button, AvatarStack, SummaryTag } from '../ui';
 import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
 import { getRank } from '../../utils/rankUtils';
@@ -11,15 +11,15 @@ import { ROUTES } from '../../constants/routes';
 const RANK_ORDER: Record<string, number> = { E: 0, D: 1, C: 2, B: 3, A: 4, S: 5 };
 
 interface RequestCardProps {
-  post: Post;
+  post: EnrichedPost;
   onUpdate?: (post: Post) => void;
   className?: string;
 }
 
 const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) => {
   const { user } = useAuth();
-  const collaboratorUsers = (post as any).enrichedCollaborators || [];
-  const collaboratorCount = collaboratorUsers.filter((c: any) => c.userId).length || 0;
+  const collaboratorUsers = post.enrichedCollaborators || [];
+  const collaboratorCount = collaboratorUsers.filter(c => c.userId).length || 0;
   const [joining, setJoining] = useState(false);
   const [joined, setJoined] = useState(
     !!user && post.tags?.includes(`pending:${user.id}`)

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -11,7 +11,7 @@ interface SocketEvents {
   'auth:reset-page-visited': (payload: { token: string }) => void;
   'auth:password-reset-success': (payload: { userId: string }) => void;
   'navigation:404': (payload: { userId: string | null }) => void;
-  [event: string]: (...args: any[]) => void;
+  [event: string]: (...args: unknown[]) => void;
 }
 
 // ---------------------------

--- a/ethos-frontend/src/pages/project/[id].tsx
+++ b/ethos-frontend/src/pages/project/[id].tsx
@@ -3,11 +3,12 @@ import { useParams } from 'react-router-dom';
 import { useProject } from '../../hooks/useProject';
 import { fetchPostById } from '../../api/post';
 import { Spinner } from '../../components/ui';
+import type { Post } from '../../types/postTypes';
 
 const ProjectPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { project, error, isLoading } = useProject(id ?? '');
-  const [deliverables, setDeliverables] = useState<any[]>([]);
+  const [deliverables, setDeliverables] = useState<Post[]>([]);
 
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- fix lint error for prefer-const
- eliminate explicit `any` usages in the frontend
- update types in quest and request related components
- replace open `any` in socket type map
- type deliverables array in project page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_687af7ccc710832fa49fe3ddf6098fc1