### PR TITLE
Fix registration error when DATABASE_URL missing

### DIFF
--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -21,7 +21,7 @@ import { generateRandomUsername } from '../utils/usernameUtils';
 import type { AuthenticatedRequest } from '../types/express';
 import { pool } from '../db';
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 
 

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -11,7 +11,7 @@ import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 // Only request posts should appear on the quest board. Other post types can
 // generate request posts, but the board itself shows requests only.

--- a/ethos-backend/src/routes/gitRoutes.ts
+++ b/ethos-backend/src/routes/gitRoutes.ts
@@ -23,7 +23,7 @@ import type { AuthenticatedRequest } from '../types/express';
 
 const router = express.Router();
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 //
 // ✅ GET /api/git/status/:questId

--- a/ethos-backend/src/routes/healthRoutes.ts
+++ b/ethos-backend/src/routes/healthRoutes.ts
@@ -3,7 +3,7 @@ import { pool } from '../db';
 
 const router = Router();
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 router.get('/', async (_req, res): Promise<void> => {
   if (usePg) {

--- a/ethos-backend/src/routes/notificationRoutes.ts
+++ b/ethos-backend/src/routes/notificationRoutes.ts
@@ -9,7 +9,7 @@ import type { DBNotification } from '../types/db';
 
 const router = express.Router();
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 // GET /api/notifications - return notifications for current user
 router.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -9,7 +9,7 @@ import { generateNodeId } from '../utils/nodeIdUtils';
 import type { DBPost, DBQuest } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/projectRoutes.ts
+++ b/ethos-backend/src/routes/projectRoutes.ts
@@ -8,7 +8,7 @@ import { pool } from '../db';
 
 const router = express.Router();
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 // GET all projects
 router.get('/', async (_req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -11,7 +11,7 @@ import type { Quest, Project, LinkedItem, Visibility, TaskEdge } from '../types/
 import type { DBQuest, DBPost, DBProject } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/reviewRoutes.ts
+++ b/ethos-backend/src/routes/reviewRoutes.ts
@@ -8,7 +8,7 @@ import type { DBReview } from '../types/db';
 
 const router = express.Router();
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 const bannedWords = ['badword'];
 

--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from '../middleware/authMiddleware';
 import { usersStore, notificationsStore } from '../models/stores';
 import { pool } from '../db';
 
-const usePg = process.env.NODE_ENV !== 'test';
+const usePg = process.env.NODE_ENV !== 'test' && !!process.env.DATABASE_URL;
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- fall back to JSON file storage when a database is not configured

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_687bae989928832f8117b3ba0609b60c