### PR TITLE
Fix NavBar notifications filtering

### DIFF
--- a/ethos-frontend/src/components/ui/NavBar.tsx
+++ b/ethos-frontend/src/components/ui/NavBar.tsx
@@ -41,7 +41,7 @@ const NavBar: React.FC = () => {
             <>
               <Link to="/notifications" className="relative hover:text-accent transition" aria-label="Notifications">
                 <FaBell />
-                {notifications.filter(n => !n.read).length > 0 && (
+                {Array.isArray(notifications) && notifications.filter(n => !n.read).length > 0 && (
                   <span className="absolute -top-2 -right-2 text-xs bg-red-600 text-white rounded-full px-1">
                     {notifications.filter(n => !n.read).length}
                   </span>


### PR DESCRIPTION
## Summary
- make NavBar check that notifications is an array before filtering

## Testing
- `npm test --prefix ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_687fdbab6a18832fa78cc2dc71b244e4