### PR TITLE
Fix board utils null item check

### DIFF
--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -57,13 +57,14 @@ export const getRenderableBoardItems = (
   const seen = new Set<string>();
   const questIds = new Set<string>();
   items.forEach((item) => {
-    if ('headPostId' in item) {
+    if (item && typeof item === 'object' && 'headPostId' in item) {
       questIds.add(item.id);
     }
   });
 
   const result: BoardItem[] = [];
   for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
     if (seen.has(item.id)) continue;
     seen.add(item.id);
 


### PR DESCRIPTION
## Summary
- handle null or invalid items when filtering board items

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_687fe6d007ec832fa08f659b756ced84