### PR TITLE
Ensure DB init and default data

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -1,7 +1,106 @@
 import { Pool } from 'pg';
 import dotenv from 'dotenv';
+
 dotenv.config();
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
+
+/**
+ * Ensure required tables and starter data exist when using PostgreSQL.
+ * This allows fresh deployments to work without running separate migrations.
+ */
+export async function initializeDatabase(): Promise<void> {
+  if (!process.env.DATABASE_URL) return;
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id UUID PRIMARY KEY,
+      username TEXT,
+      email TEXT UNIQUE,
+      password TEXT,
+      role TEXT,
+      status TEXT
+    );
+    CREATE TABLE IF NOT EXISTS posts (
+      id UUID PRIMARY KEY,
+      authorid TEXT,
+      type TEXT,
+      content TEXT,
+      title TEXT,
+      createdat TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE TABLE IF NOT EXISTS quests (
+      id UUID PRIMARY KEY,
+      authorid TEXT,
+      title TEXT,
+      description TEXT,
+      visibility TEXT
+    );
+    CREATE TABLE IF NOT EXISTS boards (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      description TEXT,
+      boardType TEXT,
+      layout TEXT,
+      items JSONB,
+      filters JSONB,
+      featured BOOLEAN,
+      defaultFor TEXT,
+      createdAt TIMESTAMPTZ DEFAULT NOW(),
+      userId TEXT,
+      questId TEXT
+    );
+    CREATE TABLE IF NOT EXISTS projects (
+      id UUID PRIMARY KEY,
+      authorid TEXT,
+      title TEXT,
+      description TEXT,
+      visibility TEXT,
+      tags TEXT[]
+    );
+    CREATE TABLE IF NOT EXISTS reviews (
+      id UUID PRIMARY KEY,
+      reviewerid TEXT,
+      targettype TEXT,
+      rating INT,
+      visibility TEXT,
+      status TEXT,
+      tags TEXT[],
+      feedback TEXT,
+      repourl TEXT,
+      modelid TEXT,
+      questid TEXT,
+      postid TEXT,
+      createdat TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE TABLE IF NOT EXISTS notifications (
+      id UUID PRIMARY KEY,
+      userid TEXT,
+      message TEXT,
+      link TEXT,
+      read BOOLEAN,
+      createdat TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+
+  const { rows } = await pool.query(
+    "SELECT id FROM boards WHERE id IN ('quest-board','timeline-board','my-posts','my-quests')"
+  );
+  const existing = rows.map((r) => r.id);
+  const defaults = [
+    { id: 'quest-board', title: 'Quest Board' },
+    { id: 'timeline-board', title: 'Timeline' },
+    { id: 'my-posts', title: 'My Posts' },
+    { id: 'my-quests', title: 'My Quests' },
+  ];
+  for (const board of defaults) {
+    if (!existing.includes(board.id)) {
+      await pool.query(
+        `INSERT INTO boards (id,title,boardType,layout,items,createdAt,userId) VALUES ($1,$2,'post','grid','[]',NOW(),'')`,
+        [board.id, board.title]
+      );
+    }
+  }
+}

--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -21,7 +21,7 @@ import { generateRandomUsername } from '../utils/usernameUtils';
 import type { AuthenticatedRequest } from '../types/express';
 import { pool } from '../db';
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 
 

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -11,7 +11,7 @@ import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 // Only request posts should appear on the quest board. Other post types can
 // generate request posts, but the board itself shows requests only.

--- a/ethos-backend/src/routes/gitRoutes.ts
+++ b/ethos-backend/src/routes/gitRoutes.ts
@@ -23,7 +23,7 @@ import type { AuthenticatedRequest } from '../types/express';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 //
 // ✅ GET /api/git/status/:questId

--- a/ethos-backend/src/routes/healthRoutes.ts
+++ b/ethos-backend/src/routes/healthRoutes.ts
@@ -3,7 +3,7 @@ import { pool } from '../db';
 
 const router = Router();
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 router.get('/', async (_req, res): Promise<void> => {
   if (usePg) {

--- a/ethos-backend/src/routes/notificationRoutes.ts
+++ b/ethos-backend/src/routes/notificationRoutes.ts
@@ -9,7 +9,7 @@ import type { DBNotification } from '../types/db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 // GET /api/notifications - return notifications for current user
 router.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -9,7 +9,7 @@ import { generateNodeId } from '../utils/nodeIdUtils';
 import type { DBPost, DBQuest } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/projectRoutes.ts
+++ b/ethos-backend/src/routes/projectRoutes.ts
@@ -8,7 +8,7 @@ import { pool } from '../db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 // GET all projects
 router.get('/', async (_req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -11,7 +11,7 @@ import type { Quest, Project, LinkedItem, Visibility, TaskEdge } from '../types/
 import type { DBQuest, DBPost, DBProject } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/reviewRoutes.ts
+++ b/ethos-backend/src/routes/reviewRoutes.ts
@@ -8,7 +8,7 @@ import type { DBReview } from '../types/db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 const bannedWords = ['badword'];
 

--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from '../middleware/authMiddleware';
 import { usersStore, notificationsStore } from '../models/stores';
 import { pool } from '../db';
 
-const usePg = !!process.env.DATABASE_URL;
+const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
 
 const router = express.Router();
 

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -19,9 +19,13 @@ import reviewRoutes from './routes/reviewRoutes';
 import userRoutes from './routes/userRoutes';
 import notificationRoutes from './routes/notificationRoutes';
 import healthRoutes from './routes/healthRoutes';
+import { initializeDatabase } from './db';
 
 // Load environment variables from `.env` file
 dotenv.config();
+initializeDatabase().catch((err) =>
+  console.error('[DB INIT ERROR]', err)
+);
 
 /**
  * Initialize the Express app.


### PR DESCRIPTION
## Summary
- auto-create tables and default boards when using PostgreSQL
- skip PostgreSQL in tests by ignoring DATABASE_URL when NODE_ENV is `test`

## Testing
- `npm test` in `ethos-backend`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68829e52e31c832fa9e4e9d63416ab73