### PR TITLE
Fix logout cookie clearing

### DIFF
--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -399,7 +399,9 @@ router.post('/logout', (_req: Request, res: Response) => {
   res.clearCookie('refreshToken', {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
+    // Use the same SameSite setting as the login cookie so
+    // the browser properly removes it on logout
+    sameSite: 'lax',
   });
   res.sendStatus(204);
 });


### PR DESCRIPTION
## Summary
- ensure logout uses SameSite `lax`

## Testing
- `bash setup.sh`
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6882a9cecf1c832f897e87cd759d9047