### PR TITLE
Fix auth provider login race

### DIFF
--- a/ethos-frontend/src/contexts/AuthContext.tsx
+++ b/ethos-frontend/src/contexts/AuthContext.tsx
@@ -27,7 +27,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setUser(userData as AuthUser);
       } catch {
         setUser(null);
-        setAccessToken(null);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- fix race condition in AuthContext when fetching user

## Testing
- `npm test --silent` *(fails: Cannot find module 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_6882aecaac8c832fa46f536a59e187c1