### PR TITLE
Fix auto login issue

### DIFF
--- a/ethos-frontend/src/contexts/AuthContext.tsx
+++ b/ethos-frontend/src/contexts/AuthContext.tsx
@@ -19,8 +19,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch current user on initial load
+  // Fetch current user on initial load if an access token exists
   useEffect(() => {
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+
     const fetchUser = async () => {
       try {
         const userData = await fetchCurrentUser();


### PR DESCRIPTION
## Summary
- only attempt to fetch current user if `accessToken` exists in local storage

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `cd ethos-frontend && npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6882da3c3a78832fad77f04124490b00