### PR TITLE
Fix backend compile step by skipping lib check

### DIFF
--- a/ethos-backend/tsconfig.json
+++ b/ethos-backend/tsconfig.json
@@ -14,6 +14,7 @@
     "types": [
       "node",
       "jest"
-    ]
+    ],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary
- skip TypeScript lib checking in the backend tsconfig to avoid incompatible
  `@types/cors` errors during compilation

## Testing
- `npx tsc -p tsconfig.json`
- `npm test -- -w=1` in `ethos-backend`
- `npx tsc -p tsconfig.json` in `ethos-frontend`
- `npm test -- -w=1` in `ethos-frontend`
- `npm run build` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6882e195f4e8832fad9eb833a869b9bd