### PR TITLE
Fix lint error in useSocket

### DIFF
--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -11,7 +11,7 @@ interface SocketEvents {
   'auth:reset-page-visited': (payload: { token: string }) => void;
   'auth:password-reset-success': (payload: { userId: string }) => void;
   'navigation:404': (payload: { userId: string | null }) => void;
-  [event: string]: (...args: any[]) => void;
+  [event: string]: (...args: unknown[]) => void;
 }
 
 // ---------------------------


### PR DESCRIPTION
## Summary
- remove `any` typing from socket event handler map to satisfy eslint

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e443cae8832fa6799e03cb8b5196