### PR TITLE
Fix frontend env utilities

### DIFF
--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -23,10 +23,16 @@ let socket: Socket | null = null;
  */
 export const getSocket = (): Socket => {
   if (!socket) {
+    const metaEnv = (() => {
+      try {
+        return Function('return import.meta.env')() as ImportMetaEnv;
+      } catch {
+        return {} as ImportMetaEnv;
+      }
+    })();
+
     const SOCKET_URL =
-      (typeof import.meta !== 'undefined'
-        ? import.meta.env?.VITE_SOCKET_URL
-        : undefined) ||
+      metaEnv.VITE_SOCKET_URL ||
       (typeof process !== 'undefined' ? process.env.VITE_SOCKET_URL : undefined) ||
       (typeof window !== 'undefined'
         ? window.location.origin

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -23,16 +23,10 @@ let socket: Socket | null = null;
  */
 export const getSocket = (): Socket => {
   if (!socket) {
-    const getEnv = () => {
-      try {
-        return Function('return import.meta.env')();
-      } catch {
-        return {};
-      }
-    };
-
     const SOCKET_URL =
-      getEnv().VITE_SOCKET_URL ||
+      (typeof import.meta !== 'undefined'
+        ? (import.meta as any).env?.VITE_SOCKET_URL
+        : undefined) ||
       (typeof process !== 'undefined' ? process.env.VITE_SOCKET_URL : undefined) ||
       (typeof window !== 'undefined'
         ? window.location.origin

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -25,7 +25,7 @@ export const getSocket = (): Socket => {
   if (!socket) {
     const SOCKET_URL =
       (typeof import.meta !== 'undefined'
-        ? (import.meta as any).env?.VITE_SOCKET_URL
+        ? import.meta.env?.VITE_SOCKET_URL
         : undefined) ||
       (typeof process !== 'undefined' ? process.env.VITE_SOCKET_URL : undefined) ||
       (typeof window !== 'undefined'

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -4,10 +4,16 @@ import axios, { type AxiosInstance, AxiosError, type AxiosRequestConfig } from '
 /**
  * 📡 Base API URL — should be environment-configurable
  */
+const metaEnv = (() => {
+  try {
+    return Function('return import.meta.env')() as ImportMetaEnv;
+  } catch {
+    return {} as ImportMetaEnv;
+  }
+})();
+
 const API_BASE =
-  (typeof import.meta !== 'undefined'
-    ? import.meta.env?.VITE_API_URL
-    : undefined) ||
+  metaEnv.VITE_API_URL ||
   (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
   (typeof window !== 'undefined'
     ? `${window.location.origin}/api`

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -6,7 +6,7 @@ import axios, { type AxiosInstance, AxiosError, type AxiosRequestConfig } from '
  */
 const API_BASE =
   (typeof import.meta !== 'undefined'
-    ? (import.meta as any).env?.VITE_API_URL
+    ? import.meta.env?.VITE_API_URL
     : undefined) ||
   (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
   (typeof window !== 'undefined'

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -4,16 +4,10 @@ import axios, { type AxiosInstance, AxiosError, type AxiosRequestConfig } from '
 /**
  * 📡 Base API URL — should be environment-configurable
  */
-const getEnv = () => {
-  try {
-    return Function('return import.meta.env')();
-  } catch {
-    return {};
-  }
-};
-
 const API_BASE =
-  getEnv().VITE_API_URL ||
+  (typeof import.meta !== 'undefined'
+    ? (import.meta as any).env?.VITE_API_URL
+    : undefined) ||
   (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
   (typeof window !== 'undefined'
     ? `${window.location.origin}/api`

--- a/ethos-frontend/src/vite-env.d.ts
+++ b/ethos-frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+  readonly VITE_SOCKET_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- clean up env lookup for API calls
- update socket utility to use new environment method

## Testing
- `npm test --prefix ethos-frontend` *(fails: Cannot find module '../lib' from 'react-icons/fa/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6883fb731bd4832f892cc6249fb86bbf