### PR TITLE
Fix Prisma schema optional list issue

### DIFF
--- a/ethos-backend/prisma/schema.prisma
+++ b/ethos-backend/prisma/schema.prisma
@@ -85,7 +85,7 @@ model Project {
   tags        String[]
   createdAt   DateTime @default(now())
   questIds    String[]
-  deliverables String[]?
+  deliverables String[]
   mapEdges    Json?
 
   author User   @relation(fields: [authorId], references: [id])


### PR DESCRIPTION
## Summary
- remove optional list from `Project` model in Prisma schema

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`
- `npx prisma migrate dev --skip-generate` *(fails: Failed to fetch checksum)*

------
https://chatgpt.com/codex/tasks/task_e_688503a5ff38832faf338eefecfb25db