### PR TITLE
Improve login error handling

### DIFF
--- a/ethos-frontend/src/pages/Login.tsx
+++ b/ethos-frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 // src/pages/Login.tsx
 import { useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
+import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { login, fetchCurrentUser, addUserAccount, addResetPasswordRequest } from '../api/auth';
 import { useAuth } from '../contexts/AuthContext';
@@ -119,7 +120,11 @@ const Login: React.FC = () => {
       }
     } catch (err: unknown) {
       console.error('Auth failed:', err);
-      const msg = (err as { response?: { data?: { error?: string } } }).response?.data?.error;
+      const axiosErr = err as AxiosError & { response?: { data?: { error?: string } } };
+      const msg =
+        axiosErr.code === 'ERR_NETWORK'
+          ? 'Unable to reach the server. Please ensure the backend is running and accessible.'
+          : axiosErr.response?.data?.error;
       setError(msg || 'An error occurred. Please try again.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- improve login error message when the backend is unreachable

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6886105786d4832f82918857a4ba2c1f