### PR TITLE
feat(ui): add node type badges

### DIFF
--- a/ethos-frontend/src/components/layout/GraphNode.tsx
+++ b/ethos-frontend/src/components/layout/GraphNode.tsx
@@ -5,6 +5,7 @@ import ContributionCard from '../contribution/ContributionCard';
 import GitDiffViewer from '../git/GitDiffViewer';
 import EditPost from '../post/EditPost';
 import { Spinner } from '../ui';
+import NodeTypeBadge from '../ui/NodeTypeBadge';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import type { TaskEdge } from '../../types/questTypes';
@@ -57,8 +58,6 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   onRemoveEdge,
   boardId,
 }) => {
-  const isFolder = node.type === 'quest' || node.tags.includes('quest');
-  const icon = isFolder ? '📁' : '📄';
 
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: node.id });
   const {
@@ -167,7 +166,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
             }}
             title={snippet}
           >
-            <span className="mr-1 select-none">{icon}</span>
+            <NodeTypeBadge post={node} className="mr-1 flex-shrink-0" />
             <span className="truncate">{snippet}{node.content && node.content.length > 30 ? '…' : ''}</span>
             {edge && (
               <span className="text-[10px] text-gray-500 dark:text-gray-400 ml-1 flex items-center">
@@ -263,7 +262,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
           }}
         >
           <span
-            className="text-xl select-none cursor-grab"
+            className="cursor-grab"
             {...attributes}
             {...listeners}
             onDoubleClick={() => {
@@ -277,7 +276,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
               }
             }}
           >
-            {icon}
+            <NodeTypeBadge post={node} />
           </span>
           <ContributionCard
             contribution={node}

--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -8,6 +8,7 @@ import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 import type { TaskEdge } from '../../types/questTypes';
 import { getDisplayTitle } from '../../utils/displayUtils';
+import { getNodeStyle } from '../ui/NodeTypeBadge';
 
 interface MapGraphLayoutProps {
   items: Post[];
@@ -97,6 +98,21 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
         linkDirectionalArrowLength={6}
         linkDirectionalArrowRelPos={1}
         nodeLabel={(node: unknown) => getDisplayTitle(node as Post)}
+        nodeCanvasObject={(node: unknown, ctx, globalScale) => {
+          const n = node as Post & { x: number; y: number };
+          const { label, bgColor, textColor } = getNodeStyle(n);
+          const size = 8 / globalScale; // keep size consistent during zoom
+          ctx.fillStyle = bgColor;
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, size, 0, 2 * Math.PI, false);
+          ctx.fill();
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.font = `${10}px sans-serif`;
+          ctx.fillStyle = textColor;
+          ctx.fillText(label, n.x, n.y);
+        }}
+        nodeCanvasObjectMode={() => 'replace'}
         onNodeClick={handleNodeClick}
         onNodeDragEnd={handleNodeDragEnd}
       />

--- a/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
+++ b/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { Post } from '../../types/postTypes';
+
+export type NodeVisualType =
+  | 'project'
+  | 'quest'
+  | 'task'
+  | 'subtask'
+  | 'request-open'
+  | 'request-accepted';
+
+interface NodeStyle {
+  label: string;
+  bgClass: string;
+  textClass: string;
+  bgColor: string;
+  textColor: string;
+}
+
+const NODE_STYLES: Record<NodeVisualType, NodeStyle> = {
+  project: {
+    label: 'P',
+    bgClass: 'bg-blue-200',
+    textClass: 'text-blue-800',
+    bgColor: '#bfdbfe',
+    textColor: '#1e3a8a',
+  },
+  quest: {
+    label: 'Q',
+    bgClass: 'bg-purple-200',
+    textClass: 'text-purple-800',
+    bgColor: '#e9d5ff',
+    textColor: '#5b21b6',
+  },
+  task: {
+    label: 'T',
+    bgClass: 'bg-orange-200',
+    textClass: 'text-orange-800',
+    bgColor: '#fed7aa',
+    textColor: '#9a3412',
+  },
+  subtask: {
+    label: 'C',
+    bgClass: 'bg-rose-200',
+    textClass: 'text-rose-800',
+    bgColor: '#fecdd3',
+    textColor: '#9f1239',
+  },
+  'request-open': {
+    label: 'R+',
+    bgClass: 'bg-yellow-200',
+    textClass: 'text-yellow-800',
+    bgColor: '#fef08a',
+    textColor: '#854d0e',
+  },
+  'request-accepted': {
+    label: 'R✓',
+    bgClass: 'bg-green-200',
+    textClass: 'text-green-800',
+    bgColor: '#bbf7d0',
+    textColor: '#166534',
+  },
+};
+
+export function getNodeVisualType(post: Post): NodeVisualType {
+  if (post.type === 'request') {
+    return post.needsHelp === false ? 'request-accepted' : 'request-open';
+  }
+  if (post.type === 'quest') {
+    return (post.tags || []).includes('project') ? 'project' : 'quest';
+  }
+  if (post.type === 'task') return 'task';
+  if (post.type === 'commit' || post.type === 'log' || post.type === 'issue') return 'subtask';
+  return 'task';
+}
+
+export function getNodeStyle(post: Post): NodeStyle {
+  return NODE_STYLES[getNodeVisualType(post)];
+}
+
+const NodeTypeBadge: React.FC<{ post: Post; className?: string }> = ({ post, className }) => {
+  const style = getNodeStyle(post);
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center justify-center rounded-full w-5 h-5 text-xs font-bold select-none',
+        style.bgClass,
+        style.textClass,
+        className
+      )}
+    >
+      {style.label}
+    </span>
+  );
+};
+
+export default NodeTypeBadge;

--- a/ethos-frontend/src/components/ui/index.tsx
+++ b/ethos-frontend/src/components/ui/index.tsx
@@ -18,3 +18,4 @@ export { default as MarkdownEditor } from './MarkdownEditor';
 export { default as AvatarStack } from './AvatarStack';
 export { default as SummaryTag } from './SummaryTag';
 export { default as ErrorBoundary } from "./ErrorBoundary";
+export { default as NodeTypeBadge } from './NodeTypeBadge';


### PR DESCRIPTION
## Summary
- add NodeTypeBadge component for P/Q/T/C/R icons with color backgrounds
- render NodeTypeBadge in graph nodes and map layout

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c1590568c832f9a9e1a6241e9b2fc