### PR TITLE
feat: track quest board requests

### DIFF
--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -21,8 +21,13 @@ const getQuestBoardItems = (
   const ids = posts
     .filter((p) => {
       if (p.type !== 'request') return false;
+      if (p.boardId !== 'quest-board') return false;
       if (p.tags?.includes('archived')) return false;
-      return p.visibility === 'public' || p.visibility === 'request_board';
+      return (
+        p.visibility === 'public' ||
+        p.visibility === 'request_board' ||
+        p.needsHelp === true
+      );
     })
     .map((p) => p.id);
   return ids;
@@ -435,6 +440,7 @@ router.get(
         if ('type' in item) {
           const p = item as DBPost;
           if (p.type !== 'request') return false;
+          if (p.boardId !== 'quest-board') return false;
           if (p.tags?.includes('archived')) return false;
           return (
             p.visibility === 'public' ||

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -164,6 +164,8 @@ router.post(
       }
     }
 
+    const effectiveBoardId = boardId || (type === 'request' ? 'quest-board' : undefined);
+
     const newPost: DBPost = {
       id: uuidv4(),
       authorId: req.user!.id,
@@ -186,6 +188,7 @@ router.post(
       helpRequest: type === 'request' || helpRequest,
       needsHelp: type === 'request' ? needsHelp ?? true : undefined,
       nodeId: quest ? generateNodeId({ quest, posts, postType: type, parentPost: parent }) : undefined,
+      boardId: effectiveBoardId,
     };
 
     if (questId && (!newPost.questNodeTitle || newPost.questNodeTitle.trim() === '')) {
@@ -561,6 +564,7 @@ router.post(
       questId: task.questId || null,
       helpRequest: true,
       needsHelp: true,
+      boardId: 'quest-board',
     };
 
     task.helpRequest = true;
@@ -592,6 +596,7 @@ router.post(
       questId: task.questId || null,
       helpRequest: true,
       needsHelp: true,
+      boardId: 'quest-board',
     }));
 
     posts.push(requestPost, ...subRequests);
@@ -637,6 +642,7 @@ router.post(
       questId: original.questId || null,
       helpRequest: true,
       needsHelp: true,
+      boardId: 'quest-board',
     };
 
     original.helpRequest = true;

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -110,6 +110,9 @@ export interface Post {
   questTitle?: string;
   nodeId?: string;
 
+  /** Optional board association */
+  boardId?: string;
+
   tags: PostTag[];
   status?: QuestTaskStatus;
   /** Optional classification for task posts */

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -62,6 +62,9 @@ export interface DBPost {
   questNodeTitle?: string;
   nodeId?: string;
 
+  /** Optional board association */
+  boardId?: string;
+
   /** Optional rating value for review posts */
   rating?: number;
 

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -376,6 +376,8 @@ describe('post routes', () => {
     expect(store).toHaveLength(4);
     expect(store[1].type).toBe('request');
     expect(store[2].replyTo).toBe(store[1].id);
+    expect(store[1].boardId).toBe('quest-board');
+    expect(store[2].boardId).toBe('quest-board');
   });
 
   it('POST /:id/request-help creates request post', async () => {
@@ -392,7 +394,7 @@ describe('post routes', () => {
       questId: null,
       helpRequest: false,
       needsHelp: false,
-    };
+    } as any;
 
     const store = [post];
     postsStoreMock.read.mockReturnValue(store);
@@ -407,6 +409,7 @@ describe('post routes', () => {
     expect((store[1].linkedItems as any[])[0].itemId).toBe('p2');
     expect(store[0].helpRequest).toBe(true);
     expect(store[0].needsHelp).toBe(true);
+    expect(store[1].boardId).toBe('quest-board');
   });
 
   it('rejects non-request posts on quest board', async () => {
@@ -425,6 +428,7 @@ describe('post routes', () => {
     expect(res.status).toBe(201);
     const written = postsStoreMock.write.mock.calls[0][0][0];
     expect(written.helpRequest).toBe(true);
+    expect(written.boardId).toBe('quest-board');
   });
 
   it('rejects task post on quest board', async () => {

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -449,8 +449,8 @@ describe('route handlers', () => {
       { id: 'quest-board', title: 'QB', boardType: 'post', description: '', layout: 'grid', items: [] }
     ]);
     postsStoreMock.read.mockReturnValue([
-      { id: 'req1', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: ['archived'], collaborators: [], linkedItems: [] },
-      { id: 'req2', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [] }
+      { id: 'req1', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: ['archived'], collaborators: [], linkedItems: [], boardId: 'quest-board' },
+      { id: 'req2', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [], boardId: 'quest-board' }
     ]);
 
     const res = await request(app).get('/boards/quest-board/items');


### PR DESCRIPTION
## Summary
- allow posts to specify an optional `boardId`
- default request posts to the main `quest-board`
- filter quest board to only show its request posts
- test request-help flow includes quest board metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891f2f92a84832fabfa56040cfa8191