### PR TITLE
feat: add VS Code git graph extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It’s a new operating system for solving problems together.
 * **Interactive Task Lists** – Check off markdown tasks directly within posts.
 * **Freelancer-Oriented** – Designed to support real client work, solo projects, and peer-based micro-teams.
 * **Web3-Ready (Future)** – Enable decentralized contracts and token-based achievements.
+* **VS Code Git Graph Extension** – Visualize repository history directly inside Visual Studio Code.
 
 ---
 
@@ -74,6 +75,15 @@ ethos-backend/
 ├── .env
 ├── package.json
 └── prisma/             # PostgreSQL if used
+```
+
+### VS Code Extension (`vscode-git-graph/`)
+
+```bash
+vscode-git-graph/
+├── extension.js     # Command implementation
+├── package.json     # Extension manifest
+└── test.js          # Placeholder test script
 ```
 
 ---

--- a/vscode-git-graph/extension.js
+++ b/vscode-git-graph/extension.js
@@ -1,0 +1,36 @@
+const vscode = require('vscode');
+const cp = require('child_process');
+
+function activate(context) {
+  let disposable = vscode.commands.registerCommand('ethos.showGitGraph', () => {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders) {
+      vscode.window.showErrorMessage('No workspace folder open.');
+      return;
+    }
+    const cwd = workspaceFolders[0].uri.fsPath;
+    cp.exec('git log --graph --decorate --oneline --all', { cwd }, (err, stdout, stderr) => {
+      if (err) {
+        vscode.window.showErrorMessage('Failed to run git log: ' + stderr);
+        return;
+      }
+      const panel = vscode.window.createWebviewPanel(
+        'ethosGitGraph',
+        'Ethos Git Graph',
+        vscode.ViewColumn.Active,
+        {}
+      );
+      const escaped = stdout.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      panel.webview.html = `<!DOCTYPE html><html><body><pre>${escaped}</pre></body></html>`;
+    });
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate
+};

--- a/vscode-git-graph/test.js
+++ b/vscode-git-graph/test.js
@@ -1,0 +1,1 @@
+console.log('No tests specified for ethos-git-graph extension');


### PR DESCRIPTION
## Summary
- add simple VS Code extension that displays `git log --graph` in a webview
- document the extension and how it fits into the repo

## Testing
- `npm test` (fails: Missing script)
- `(cd vscode-git-graph && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_6891ff4f18f0832f9177a058fc82223a