### PR TITLE
Fix Postgres user ID generation for registration

### DIFF
--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -148,7 +148,7 @@ router.post(
           ]);
         }
 
-        const userId = `u_${uuidv4()}`;
+        const userId = uuidv4();
         const hashed = await hashPassword(password);
         await pool.query(
           'INSERT INTO users (id, username, email, password, role) VALUES ($1, $2, $3, $4, $5)',


### PR DESCRIPTION
## Summary
- generate valid UUIDs for Postgres user IDs during registration

## Testing
- `cd ethos-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68956248a4b8832fa51e27d92d2e5e8f