### PR TITLE
Ensure default board context exists for new users

### DIFF
--- a/ethos-backend/src/data/boardContextDefaults.ts
+++ b/ethos-backend/src/data/boardContextDefaults.ts
@@ -1,0 +1,15 @@
+import type { DBBoard } from '../types/db';
+
+// Board context returned when no boards exist in storage
+export const EMPTY_BOARD_CONTEXT: DBBoard = {
+  id: 'empty-board',
+  title: 'Empty Board',
+  boardType: 'post',
+  layout: 'grid',
+  items: [],
+  createdAt: new Date().toISOString(),
+  userId: '',
+};
+
+// Default board context saved for new users
+export const NEW_USER_BOARD_CONTEXT: DBBoard[] = [EMPTY_BOARD_CONTEXT];

--- a/ethos-backend/src/models/stores.ts
+++ b/ethos-backend/src/models/stores.ts
@@ -2,8 +2,9 @@
 // src/models/GitModel.ts
 import type { DBSchema } from '../types/db';
 import { createDataStore } from '../utils/loaders';
+import { NEW_USER_BOARD_CONTEXT } from '../data/boardContextDefaults';
 
-export const boardsStore = createDataStore<DBSchema['boards']>('boards.json', []);
+export const boardsStore = createDataStore<DBSchema['boards']>('boards.json', NEW_USER_BOARD_CONTEXT);
 export const gitStore = createDataStore<DBSchema['git']>('git.json', []);
 export const postsStore = createDataStore<DBSchema['posts']>('posts.json', []);
 export const questsStore = createDataStore<DBSchema['quests']>('quests.json', []);

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { logBoardAction } from '../utils/boardLogger';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { boardsStore, postsStore, questsStore, usersStore } from '../models/stores';
+import { EMPTY_BOARD_CONTEXT } from '../data/boardContextDefaults';
 import { enrichBoard, enrichQuest } from '../utils/enrich';
 import { DEFAULT_PAGE_SIZE } from '../constants';
 import { pool } from '../db';
@@ -57,7 +58,11 @@ router.get(
     }
 
     const { featured, enrich, userId } = req.query;
-    const boards = boardsStore.read();
+    let boards = boardsStore.read();
+    if (boards.length === 0) {
+      boards = [EMPTY_BOARD_CONTEXT];
+      boardsStore.write(boards);
+    }
     const posts = postsStore.read();
     const quests = questsStore.read();
 


### PR DESCRIPTION
## Summary
- add default empty board context and new user board context constants
- initialize boards store with new user board context and fallback to empty board when none exist

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_689566dbbc30832f861fcac3bbb7ab00