### PR TITLE
Ensure frontend reads .env configuration

### DIFF
--- a/ethos-frontend/README.md
+++ b/ethos-frontend/README.md
@@ -7,6 +7,17 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Environment variables
+
+The development server reads settings from a local `.env` file. Make sure to create `ethos-frontend/.env` with the API and socket URLs:
+
+```env
+VITE_API_URL=http://localhost:4173/api
+VITE_SOCKET_URL=http://localhost:4173
+```
+
+These variables are used by the frontend to connect to the backend during development.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/ethos-frontend/src/utils/authUtils.ts
+++ b/ethos-frontend/src/utils/authUtils.ts
@@ -4,17 +4,12 @@ import axios, { type AxiosInstance, AxiosError, type AxiosRequestConfig } from '
 /**
  * 📡 Base API URL — should be environment-configurable
  */
-const metaEnv = (() => {
-  try {
-    return Function('return import.meta.env')() as ImportMetaEnv;
-  } catch {
-    return {} as ImportMetaEnv;
-  }
-})();
-
 const API_BASE =
-  metaEnv.VITE_API_URL ||
-  (typeof process !== 'undefined' ? process.env.VITE_API_URL : undefined) ||
+  // Prefer Vite's injected environment variable when available
+  (import.meta as any)?.env?.VITE_API_URL ||
+  // Fall back to Node's process.env when running outside the browser
+  (typeof process !== 'undefined' ? process.env?.VITE_API_URL : undefined) ||
+  // Otherwise derive the API path from the current window location
   (typeof window !== 'undefined'
     ? `${window.location.origin}/api`
     : 'http://localhost:4173/api');

--- a/ethos-frontend/vite.config.ts
+++ b/ethos-frontend/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const root = fileURLToPath(new URL('.', import.meta.url))
+  const env = loadEnv(mode, root, '')
   return {
+    envDir: root,
     plugins: [react()],
     define: {
       VITE_API_URL: JSON.stringify(env.VITE_API_URL),


### PR DESCRIPTION
## Summary
- Load environment variables from the frontend directory by setting `envDir` in Vite config
- Document required `VITE_API_URL` and `VITE_SOCKET_URL` entries in the frontend README
- Resolve API base URL using `import.meta.env` with fallbacks for Node and browser contexts

## Testing
- `npx jest tests/ThemeProvider.test.js --runInBand --testTimeout=30000`


------
https://chatgpt.com/codex/tasks/task_e_689569bf4d90832fbc46a63f0bd7192f