### PR TITLE
Ensure frontend reads .env configuration

### DIFF
--- a/ethos-frontend/README.md
+++ b/ethos-frontend/README.md
@@ -7,6 +7,17 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Environment variables
+
+The development server reads settings from a local `.env` file. Make sure to create `ethos-frontend/.env` with the API and socket URLs:
+
+```env
+VITE_API_URL=http://localhost:4173/api
+VITE_SOCKET_URL=http://localhost:4173
+```
+
+These variables are used by the frontend to connect to the backend during development.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/ethos-frontend/src/api/auth.ts
+++ b/ethos-frontend/src/api/auth.ts
@@ -10,7 +10,7 @@ import type { User } from '../types/userTypes';
  * @param password - User password
  */
 export const addUserAccount = async (email: string, password: string): Promise<void> => {
-  await axiosWithAuth.post('/auth/register', { email, password });
+  await axiosWithAuth.post('auth/register', { email, password });
 };
 
 /**
@@ -24,7 +24,7 @@ export const login = async (
   email: string,
   password: string
 ): Promise<{ accessToken: string }> => {
-  const res = await axiosWithAuth.post('/auth/login', { email, password });
+  const res = await axiosWithAuth.post('auth/login', { email, password });
   // Store access token for subsequent authenticated requests
   if (res.data?.accessToken) {
     setAccessToken(res.data.accessToken);
@@ -37,7 +37,7 @@ export const login = async (
  * 🚪 Logout and clear the user's session cookie
  */
 export const logout = async (): Promise<void> => {
-  await axiosWithAuth.post('/auth/logout');
+  await axiosWithAuth.post('auth/logout');
   setAccessToken(null);
 };
 
@@ -47,7 +47,7 @@ export const logout = async (): Promise<void> => {
  * @returns Authenticated user data
  */
 export const fetchCurrentUser = async (): Promise<User> => {
-  const res = await axiosWithAuth.get('/auth/me');
+  const res = await axiosWithAuth.get('auth/me');
   return res.data;
 };
 
@@ -60,7 +60,7 @@ export const fetchCurrentUser = async (): Promise<User> => {
 export const addResetPasswordRequest = async (
   email: string
 ): Promise<{ message: string }> => {
-  const res = await axiosWithAuth.post('/auth/forgot-password', { email });
+  const res = await axiosWithAuth.post('auth/forgot-password', { email });
   return res.data;
 };
 
@@ -75,7 +75,7 @@ export const updatePasswordViaToken = async (
   token: string,
   newPassword: string
 ): Promise<{ user: User }> => {
-  const res = await axiosWithAuth.post('/auth/forgot-password/confirm', {
+  const res = await axiosWithAuth.post('auth/forgot-password/confirm', {
     token,
     newPassword,
   });
@@ -91,7 +91,7 @@ export const updatePasswordViaToken = async (
 export const updateUserInfo = async (
   updates: Partial<Omit<User, 'id' | 'email' | 'role'>>
 ): Promise<User> => {
-  const res = await axiosWithAuth.patch('/auth/me', updates);
+  const res = await axiosWithAuth.patch('auth/me', updates);
   return res.data;
 };
 
@@ -101,7 +101,7 @@ export const updateUserInfo = async (
  * @returns Success status
  */
 export const archiveUserAccount = async (): Promise<{ success: boolean }> => {
-  const res = await axiosWithAuth.post('/auth/archive');
+  const res = await axiosWithAuth.post('auth/archive');
   return res.data;
 };
 
@@ -111,7 +111,7 @@ export const archiveUserAccount = async (): Promise<{ success: boolean }> => {
  * @returns Success status
  */
 export const deleteUserAccount = async (): Promise<{ success: boolean }> => {
-  const res = await axiosWithAuth.delete('/auth/me');
+  const res = await axiosWithAuth.delete('auth/me');
   return res.data;
 };
 
@@ -123,7 +123,7 @@ export const deleteUserAccount = async (): Promise<{ success: boolean }> => {
  * @returns A full User object (public fields only)
  */
 export const fetchUserById = async (userId: string): Promise<User> => {
-  const res = await axiosWithAuth.get(`/users/${userId}`);
+  const res = await axiosWithAuth.get(`users/${userId}`);
   return res.data;
 };
 
@@ -138,7 +138,7 @@ export const searchUsers = async (
 ): Promise<{ id: string; username: string }[]> => {
   const params = new URLSearchParams();
   if (query) params.set('search', query);
-  const url = `/users${params.toString() ? `?${params.toString()}` : ''}`;
+  const url = `users${params.toString() ? `?${params.toString()}` : ''}`;
   const res = await axiosWithAuth.get(url);
   return res.data;
 };

--- a/ethos-frontend/vite.config.ts
+++ b/ethos-frontend/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const root = fileURLToPath(new URL('.', import.meta.url))
+  const env = loadEnv(mode, root, '')
   return {
+    envDir: root,
     plugins: [react()],
     define: {
       VITE_API_URL: JSON.stringify(env.VITE_API_URL),


### PR DESCRIPTION
## Summary
- Resolve API base URL from Vite defines, runtime env, or window origin and normalize with a trailing slash
- Strip leading slashes from axios requests and adjust auth API paths to respect the configured base URL
- Type `import.meta` environment access to avoid `any`

## Testing
- `npm run lint`
- `npm test -- --runInBand tests/ThemeProvider.test.js --testTimeout=30000`


------
https://chatgpt.com/codex/tasks/task_e_689569bf4d90832fbc46a63f0bd7192f