### PR TITLE
chore: disable postgres in tests

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -3,16 +3,18 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-});
+export const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
+
+export const pool: Pool = usePg
+  ? new Pool({ connectionString: process.env.DATABASE_URL })
+  : ({} as Pool);
 
 /**
  * Ensure required tables and starter data exist when using PostgreSQL.
  * This allows fresh deployments to work without running separate migrations.
  */
 export async function initializeDatabase(): Promise<void> {
-  if (!process.env.DATABASE_URL) return;
+  if (!usePg) return;
 
   await pool.query(`
     CREATE TABLE IF NOT EXISTS users (

--- a/ethos-backend/src/routes/authRoutes.ts
+++ b/ethos-backend/src/routes/authRoutes.ts
@@ -19,9 +19,8 @@ import { error } from '../utils/logger';
 import { generateRandomUsername } from '../utils/usernameUtils';
 
 import type { AuthenticatedRequest } from '../types/express';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 
-const usePg = !!process.env.DATABASE_URL;
 
 
 

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -6,13 +6,12 @@ import { boardsStore, postsStore, questsStore, usersStore } from '../models/stor
 import { EMPTY_BOARD_CONTEXT } from '../data/boardContextDefaults';
 import { enrichBoard, enrichQuest } from '../utils/enrich';
 import { DEFAULT_PAGE_SIZE } from '../constants';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 import type { BoardData } from '../types/api';
 import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
 
 // Only request posts should appear on the quest board. Other post types can
 // generate request posts, but the board itself shows requests only.

--- a/ethos-backend/src/routes/gitRoutes.ts
+++ b/ethos-backend/src/routes/gitRoutes.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import path from 'path';
 import { error } from '../utils/logger';
 import { authMiddleware } from '../middleware/authMiddleware';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 import {
   getQuestRepoMeta,
   connectRepo,
@@ -23,7 +23,6 @@ import type { AuthenticatedRequest } from '../types/express';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
 
 //
 // ✅ GET /api/git/status/:questId

--- a/ethos-backend/src/routes/healthRoutes.ts
+++ b/ethos-backend/src/routes/healthRoutes.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 
 const router = Router();
 
-const usePg = !!process.env.DATABASE_URL;
 
 router.get('/', async (_req, res): Promise<void> => {
   if (usePg) {

--- a/ethos-backend/src/routes/notificationRoutes.ts
+++ b/ethos-backend/src/routes/notificationRoutes.ts
@@ -3,13 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
 import { notificationsStore } from '../models/stores';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 
 import type { DBNotification } from '../types/db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
 
 // GET /api/notifications - return notifications for current user
 router.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -3,13 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
 import { postsStore, usersStore, reactionsStore, questsStore, notificationsStore, boardsStore } from '../models/stores';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 import { enrichPost } from '../utils/enrich';
 import { generateNodeId } from '../utils/nodeIdUtils';
 import type { DBPost, DBQuest } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/projectRoutes.ts
+++ b/ethos-backend/src/routes/projectRoutes.ts
@@ -4,11 +4,10 @@ import { authMiddleware } from '../middleware/authMiddleware';
 import { projectsStore } from '../models/stores';
 import type { DBProject } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
 
 // GET all projects
 router.get('/', async (_req: Request, res: Response): Promise<void> => {

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
 import { boardsStore, questsStore, projectsStore, postsStore, usersStore, reactionsStore, notificationsStore } from '../models/stores';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 import { enrichQuest, enrichPost } from '../utils/enrich';
 import { generateNodeId } from '../utils/nodeIdUtils';
 import { logQuest404 } from '../utils/errorTracker';
@@ -11,7 +11,6 @@ import type { Quest, Project, LinkedItem, Visibility, TaskEdge } from '../types/
 import type { DBQuest, DBPost, DBProject } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
 
-const usePg = !!process.env.DATABASE_URL;
 
 const makeQuestNodeTitle = (content: string): string => {
   const text = content.trim();

--- a/ethos-backend/src/routes/reviewRoutes.ts
+++ b/ethos-backend/src/routes/reviewRoutes.ts
@@ -2,13 +2,12 @@ import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { reviewsStore } from '../models/stores';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 import type { AuthenticatedRequest } from '../types/express';
 import type { DBReview } from '../types/db';
 
 const router = express.Router();
 
-const usePg = !!process.env.DATABASE_URL;
 
 const bannedWords = ['badword'];
 

--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -3,9 +3,8 @@ import { v4 as uuidv4 } from 'uuid';
 import authOptional from '../middleware/authOptional';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { usersStore, notificationsStore } from '../models/stores';
-import { pool } from '../db';
+import { pool, usePg } from '../db';
 
-const usePg = !!process.env.DATABASE_URL;
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- avoid connecting to PostgreSQL during tests by exposing `usePg` flag
- use shared `usePg` flag across routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ec4183b0832fbba78288d74a767c