### PR TITLE
Seed default boards for board item retrieval

### DIFF
--- a/ethos-backend/src/data/boardContextDefaults.ts
+++ b/ethos-backend/src/data/boardContextDefaults.ts
@@ -11,5 +11,45 @@ export const EMPTY_BOARD_CONTEXT: DBBoard = {
   userId: '',
 };
 
+// Built-in boards that should always exist
+export const DEFAULT_BOARDS: DBBoard[] = [
+  {
+    id: 'quest-board',
+    title: 'Quest Board',
+    boardType: 'post',
+    layout: 'grid',
+    items: [],
+    createdAt: new Date().toISOString(),
+    userId: '',
+  },
+  {
+    id: 'timeline-board',
+    title: 'Timeline',
+    boardType: 'post',
+    layout: 'grid',
+    items: [],
+    createdAt: new Date().toISOString(),
+    userId: '',
+  },
+  {
+    id: 'my-posts',
+    title: 'My Posts',
+    boardType: 'post',
+    layout: 'grid',
+    items: [],
+    createdAt: new Date().toISOString(),
+    userId: '',
+  },
+  {
+    id: 'my-quests',
+    title: 'My Quests',
+    boardType: 'quest',
+    layout: 'grid',
+    items: [],
+    createdAt: new Date().toISOString(),
+    userId: '',
+  },
+];
+
 // Default board context saved for new users
-export const NEW_USER_BOARD_CONTEXT: DBBoard[] = [EMPTY_BOARD_CONTEXT];
+export const NEW_USER_BOARD_CONTEXT: DBBoard[] = DEFAULT_BOARDS;

--- a/ethos-backend/src/models/stores.ts
+++ b/ethos-backend/src/models/stores.ts
@@ -2,9 +2,9 @@
 // src/models/GitModel.ts
 import type { DBSchema } from '../types/db';
 import { createDataStore } from '../utils/loaders';
-import { NEW_USER_BOARD_CONTEXT } from '../data/boardContextDefaults';
+import { DEFAULT_BOARDS } from '../data/boardContextDefaults';
 
-export const boardsStore = createDataStore<DBSchema['boards']>('boards.json', NEW_USER_BOARD_CONTEXT);
+export const boardsStore = createDataStore<DBSchema['boards']>('boards.json', DEFAULT_BOARDS);
 export const gitStore = createDataStore<DBSchema['git']>('git.json', []);
 export const postsStore = createDataStore<DBSchema['posts']>('posts.json', []);
 export const questsStore = createDataStore<DBSchema['quests']>('quests.json', []);

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { logBoardAction } from '../utils/boardLogger';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { boardsStore, postsStore, questsStore, usersStore } from '../models/stores';
-import { EMPTY_BOARD_CONTEXT } from '../data/boardContextDefaults';
+import { DEFAULT_BOARDS } from '../data/boardContextDefaults';
 import { enrichBoard, enrichQuest } from '../utils/enrich';
 import { DEFAULT_PAGE_SIZE } from '../constants';
 import { pool, usePg } from '../db';
@@ -59,7 +59,7 @@ router.get(
     const { featured, enrich, userId } = req.query;
     let boards = boardsStore.read();
     if (boards.length === 0) {
-      boards = [EMPTY_BOARD_CONTEXT];
+      boards = DEFAULT_BOARDS;
       boardsStore.write(boards);
     }
     const posts = postsStore.read();
@@ -236,7 +236,7 @@ router.get(
     const posts = postsStore.read();
     const quests = questsStore.read();
 
-    const board = boards.find(b => b.id === id);
+    const board = boards.find(b => b.id === id) || DEFAULT_BOARDS.find(b => b.id === id);
     if (!board) {
       res.status(404).json({ error: 'Board not found' });
       return;
@@ -350,7 +350,7 @@ router.get(
     const posts = postsStore.read();
     const quests = questsStore.read();
 
-    const board = boards.find((b) => b.id === id);
+    const board = boards.find((b) => b.id === id) || DEFAULT_BOARDS.find(b => b.id === id);
     if (!board) {
       res.status(404).json({ error: 'Board not found' });
       return;
@@ -485,7 +485,7 @@ router.get(
     const quests = questsStore.read();
     const users = usersStore.read();
 
-    const board = boards.find((b) => b.id === id);
+    const board = boards.find((b) => b.id === id) || DEFAULT_BOARDS.find(b => b.id === id);
     if (!board) {
       res.status(404).json({ error: 'Board not found' });
       return;


### PR DESCRIPTION
## Summary
- add a set of built-in boards (quest, timeline, my-posts, my-quests)
- initialize board store with built-in boards and fall back to them when reading
- avoid 404 on quest board requests when storage is empty

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6895f07ebcc0832fabadbe012aba4c66