### PR TITLE
Restrict post creation to typed, linked posts

### DIFF
--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -42,7 +42,9 @@ describe('post routes', () => {
   it("POST /posts defaults task status to 'To Do'", async () => {
     postsStoreMock.read.mockReturnValue([]);
     postsStoreMock.write.mockClear();
-    const res = await request(app).post('/posts').send({ type: 'task' });
+    const res = await request(app)
+      .post('/posts')
+      .send({ type: 'task', linkedItems: [{ itemId: 'proj1', itemType: 'project' }] });
     expect(res.status).toBe(201);
     const written = postsStoreMock.write.mock.calls[0][0][0];
     expect(written.status).toBe('To Do');
@@ -54,7 +56,11 @@ describe('post routes', () => {
     postsStoreMock.write.mockClear();
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'task', status: 'Blocked' });
+      .send({
+        type: 'task',
+        status: 'Blocked',
+        linkedItems: [{ itemId: 'proj1', itemType: 'project' }],
+      });
     expect(res.status).toBe(201);
     const written = postsStoreMock.write.mock.calls[0][0][0];
     expect(written.status).toBe('Blocked');
@@ -76,7 +82,13 @@ describe('post routes', () => {
     postsStoreMock.write.mockClear();
     questsStoreMock.write.mockClear();
 
-    const res = await request(app).post('/posts').send({ type: 'task', questId: 'q1' });
+    const res = await request(app)
+      .post('/posts')
+      .send({
+        type: 'task',
+        questId: 'q1',
+        linkedItems: [{ itemId: 'proj1', itemType: 'project' }],
+      });
 
     expect(res.status).toBe(201);
     const newPost = postsStoreMock.write.mock.calls[0][0][0];
@@ -113,7 +125,12 @@ describe('post routes', () => {
 
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'task', questId: 'q1', replyTo: 't1' });
+      .send({
+        type: 'task',
+        questId: 'q1',
+        replyTo: 't1',
+        linkedItems: [{ itemId: 'proj1', itemType: 'project' }],
+      });
 
     expect(res.status).toBe(201);
     const newPost = postsStoreMock.write.mock.calls[0][0][1];
@@ -420,13 +437,26 @@ describe('post routes', () => {
   });
 
   it('allows request post on quest board', async () => {
-    postsStoreMock.read.mockReturnValue([]);
+    postsStoreMock.read.mockReturnValue([
+      {
+        id: 't1',
+        authorId: 'u1',
+        type: 'task',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+      },
+    ]);
     postsStoreMock.write.mockClear();
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'request', boardId: 'quest-board' });
+      .send({
+        type: 'request',
+        boardId: 'quest-board',
+        linkedItems: [{ itemId: 't1', itemType: 'post' }],
+      });
     expect(res.status).toBe(201);
-    const written = postsStoreMock.write.mock.calls[0][0][0];
+    const written = postsStoreMock.write.mock.calls[0][0][1];
     expect(written.helpRequest).toBe(true);
     expect(written.boardId).toBe('quest-board');
   });

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -28,7 +28,6 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },
   { value: 'request', label: 'Request' },
   { value: 'project', label: 'Project' },
-  { value: 'quest', label: 'Quest' },
   { value: 'task', label: 'Task' },
   { value: 'change', label: 'Change' },
   { value: 'review', label: 'Review' },

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -38,6 +38,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Quest', 'Free Speech', 'Request', 'Review', 'Project', 'Change']);
+    expect(options).toEqual(['Free Speech', 'Request', 'Review', 'Project', 'Change']);
   });
 });


### PR DESCRIPTION
## Summary
- limit API and UI post types to free speech, request, project, task, change and review
- enforce server-side link requirements: tasks link to projects, requests link to tasks, changes link to tasks or requests, reviews link to changes
- update creation form and tests for new validation rules

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68968fcf3c14832f85580e54b07a0ca1