### PR TITLE
fix: type linked items in post validation

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -8,7 +8,7 @@ import { enrichPost } from '../utils/enrich';
 import { generateNodeId } from '../utils/nodeIdUtils';
 import type { DBPost, DBQuest } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
-import type { PostType } from '../types/api';
+import type { PostType, LinkedItem } from '../types/api';
 
 
 const makeQuestNodeTitle = (content: string): string => {
@@ -168,33 +168,38 @@ router.post(
     // Validate required links based on post type
     if (type === 'request') {
       const linkedTask = linkedItems
-        .filter(li => li.itemType === 'post')
-        .map(li => posts.find(p => p.id === li.itemId))
-        .find(p => p && p.type === 'task');
+        .filter((li: LinkedItem) => li.itemType === 'post')
+        .map((li: LinkedItem) => posts.find(p => p.id === li.itemId))
+        .find((p: DBPost | undefined) => p && p.type === 'task');
       if (!linkedTask) {
         res.status(400).json({ error: 'Requests must link to a task' });
         return;
       }
     } else if (type === 'task') {
-      const hasProject = linkedItems.some(li => li.itemType === 'project');
+      const hasProject = linkedItems.some(
+        (li: LinkedItem) => li.itemType === 'project'
+      );
       if (!hasProject) {
         res.status(400).json({ error: 'Tasks must link to a project' });
         return;
       }
     } else if (type === 'change') {
       const target = linkedItems
-        .filter(li => li.itemType === 'post')
-        .map(li => posts.find(p => p.id === li.itemId))
-        .find(p => p && (p.type === 'task' || p.type === 'request'));
+        .filter((li: LinkedItem) => li.itemType === 'post')
+        .map((li: LinkedItem) => posts.find(p => p.id === li.itemId))
+        .find(
+          (p: DBPost | undefined) =>
+            p && (p.type === 'task' || p.type === 'request')
+        );
       if (!target) {
         res.status(400).json({ error: 'Changes must link to a task or request' });
         return;
       }
     } else if (type === 'review') {
       const target = linkedItems
-        .filter(li => li.itemType === 'post')
-        .map(li => posts.find(p => p.id === li.itemId))
-        .find(p => p && p.type === 'change');
+        .filter((li: LinkedItem) => li.itemType === 'post')
+        .map((li: LinkedItem) => posts.find(p => p.id === li.itemId))
+        .find((p: DBPost | undefined) => p && p.type === 'change');
       if (!target) {
         res.status(400).json({ error: 'Reviews must link to a change' });
         return;

--- a/ethos-frontend/src/components/controls/LinkControls.test.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.test.tsx
@@ -25,6 +25,10 @@ jest.mock('../../api/quest', () => ({
   fetchAllQuests: jest.fn(() => Promise.resolve([])),
 }));
 
+jest.mock('../../api/project', () => ({
+  fetchAllProjects: jest.fn(() => Promise.resolve([])),
+}));
+
 describe('LinkControls', () => {
   it('shows free speech posts in options', async () => {
     await act(async () => {


### PR DESCRIPTION
## Summary
- add LinkedItem typing for linkedItems validation in post routes
- ensure callbacks use explicit DBPost types

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974d24486c832f8e3f0705159fc250