### PR TITLE
Ensure backend data store creates data directory

### DIFF
--- a/ethos-backend/src/utils/loaders.ts
+++ b/ethos-backend/src/utils/loaders.ts
@@ -5,16 +5,18 @@ import type { DataStore } from '../types/db';
 
 export function createDataStore<T>(filename: string, defaultData: T): DataStore<T> {
   const filepath = path.join(__dirname, '../data', filename);
+  const directory = path.dirname(filepath);
 
-  const ensureFile = (): void => {
-    if (!fs.existsSync(filepath) || fs.readFileSync(filepath, 'utf-8').trim() === '') {
-      fs.writeFileSync(filepath, '[]');
+  const ensureDir = (): void => {
+    if (!fs.existsSync(directory)) {
+      fs.mkdirSync(directory, { recursive: true });
     }
   };
 
   return {
     read: () => {
       try {
+        ensureDir();
         if (!fs.existsSync(filepath)) {
           fs.writeFileSync(filepath, JSON.stringify(defaultData, null, 2));
           return defaultData;
@@ -29,7 +31,10 @@ export function createDataStore<T>(filename: string, defaultData: T): DataStore<
         return defaultData;
       }
     },
-    write: (data) => fs.writeFileSync(filepath, JSON.stringify(data, null, 2)),
+    write: (data) => {
+      ensureDir();
+      fs.writeFileSync(filepath, JSON.stringify(data, null, 2));
+    },
     filepath,
   };
 }


### PR DESCRIPTION
## Summary
- Create data directory when initializing data stores to prevent file write errors

## Testing
- `cd ethos-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897633ea17c832f8bdb6d0c0a10e88c