### PR TITLE
feat: show active quests on quest board

### DIFF
--- a/ethos-backend/src/data/boardContextDefaults.ts
+++ b/ethos-backend/src/data/boardContextDefaults.ts
@@ -16,7 +16,7 @@ export const DEFAULT_BOARDS: DBBoard[] = [
   {
     id: 'quest-board',
     title: 'Quest Board',
-    boardType: 'post',
+    boardType: 'quest',
     layout: 'grid',
     items: [],
     createdAt: new Date().toISOString(),

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -443,20 +443,27 @@ describe('route handlers', () => {
 
   });
 
-  it('GET /boards/quest-board/items excludes archived requests', async () => {
+  it('GET /boards/quest-board/items returns active quests', async () => {
 
     boardsStoreMock.read.mockReturnValue([
-      { id: 'quest-board', title: 'QB', boardType: 'post', description: '', layout: 'grid', items: [] }
+      { id: 'quest-board', title: 'QB', boardType: 'quest', description: '', layout: 'grid', items: [] }
     ]);
-    postsStoreMock.read.mockReturnValue([
-      { id: 'req1', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: ['archived'], collaborators: [], linkedItems: [], boardId: 'quest-board' },
-      { id: 'req2', authorId: 'u1', type: 'request', content: '', visibility: 'public', timestamp: '', tags: [], collaborators: [], linkedItems: [], boardId: 'quest-board' }
+    questsStoreMock.read.mockReturnValue([
+      {
+        id: 'q1', authorId: 'u1', title: 'Old Quest', visibility: 'public', approvalStatus: 'approved', status: 'archived',
+        headPostId: 'p1', linkedPosts: [], collaborators: [], createdAt: '2024-01-01'
+      },
+      {
+        id: 'q2', authorId: 'u2', title: 'Active Quest', visibility: 'public', approvalStatus: 'approved', status: 'active',
+        headPostId: 'p2', linkedPosts: [], collaborators: [], createdAt: '2024-01-02'
+      }
     ]);
+    postsStoreMock.read.mockReturnValue([]);
 
     const res = await request(app).get('/boards/quest-board/items');
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
-    expect(res.body[0].id).toBe('req2');
+    expect(res.body[0].id).toBe('q2');
   });
 });

--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -44,7 +44,7 @@ const Board: React.FC<BoardProps> = ({
 }) => {
   const [board, setBoard] = useState<BoardData | null>(boardProp ?? null);
   const [loading, setLoading] = useState(true);
-  const [items, setItems] = useState<Post[]>([]);
+  const [items, setItems] = useState<BoardItem[]>([]);
   const [viewMode, setViewMode] = useState<BoardLayout | null>(null);
 
   const isQuestBoard = (boardId || boardProp?.id || board?.id) === 'quest-board';
@@ -88,7 +88,7 @@ const Board: React.FC<BoardProps> = ({
   useEffect(() => {
     if (!board?.id) return;
     const enriched = boards[board.id]?.enrichedItems || [];
-    setItems(enriched as Post[]);
+    setItems(enriched as BoardItem[]);
   }, [board?.id, boardItemsKey]);
 
   const userId = user?.id;
@@ -114,7 +114,7 @@ const Board: React.FC<BoardProps> = ({
         setSelectedBoard(boardId);
 
         setBoard(boardData);
-        setItems(boardItems as Post[]);
+        setItems(boardItems as BoardItem[]);
       } catch (error) {
         console.error('Error loading board:', error);
       } finally {
@@ -125,7 +125,7 @@ const Board: React.FC<BoardProps> = ({
     if (boardProp) {
       setSelectedBoard(boardProp.id);
       setBoard(boardProp);
-      setItems((boardProp.enrichedItems || []) as Post[]);
+      setItems((boardProp.enrichedItems || []) as BoardItem[]);
       setLoading(false);
     } else {
       if (boardId) setSelectedBoard(boardId); // set early to avoid flicker
@@ -140,7 +140,7 @@ const Board: React.FC<BoardProps> = ({
 
     fetchBoard(board.id, { enrich: true, userId: user?.id }).then(setBoard);
     fetchBoardItems(board.id, { enrich: true, userId: user?.id }).then((items) =>
-      setItems(items as Post[])
+      setItems(items as BoardItem[])
     );
   });
 
@@ -171,15 +171,15 @@ const Board: React.FC<BoardProps> = ({
     }
 
     return result
-      .filter((item: Post) => {
-        const title = getDisplayTitle(item as Post) ?? '';
+      .filter((item: BoardItem) => {
+        const title = getDisplayTitle(item as any) ?? '';
         return title.toLowerCase().includes(filterText.toLowerCase());
       })
       .sort((a, b) => {
         const aVal =
-          sortKey === 'createdAt' ? a.createdAt ?? '' : getDisplayTitle(a as Post) ?? '';
+          sortKey === 'createdAt' ? a.createdAt ?? '' : getDisplayTitle(a as any) ?? '';
         const bVal =
-          sortKey === 'createdAt' ? b.createdAt ?? '' : getDisplayTitle(b as Post) ?? '';
+          sortKey === 'createdAt' ? b.createdAt ?? '' : getDisplayTitle(b as any) ?? '';
         return sortOrder === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
       });
   }, [items, filter, localFilter, filterText, sortKey, sortOrder]);
@@ -263,7 +263,7 @@ const Board: React.FC<BoardProps> = ({
   }, [mapGraphItems, quest?.taskGraph]);
 
   const handleAdd = async (item: Post | Quest) => {
-    setItems((prev) => [item as Post, ...prev]);
+    setItems((prev) => [item as BoardItem, ...prev]);
     setShowCreateForm(false);
     if (board) {
       appendToBoard(board.id, item as unknown as BoardItem);
@@ -465,7 +465,7 @@ const Board: React.FC<BoardProps> = ({
                   setBoard(updatedBoard);
                   setEditMode(false);
                   fetchBoardItems(board.id, { enrich: true, userId: user?.id }).then((items) =>
-                    setItems(items as Post[])
+                    setItems(items as BoardItem[])
                   );
                 });
             }}
@@ -478,8 +478,8 @@ const Board: React.FC<BoardProps> = ({
               ? mapGraphItems
               : resolvedStructure === 'graph' ||
                 resolvedStructure === 'graph-condensed'
-              ? (graphItems as Post[])
-              : (renderableItems as Post[])
+              ? (graphItems as BoardItem[])
+              : (renderableItems as BoardItem[])
           }
           compact={compact}
           user={user}

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -1,4 +1,5 @@
 import type { Post, PostType } from "../types/postTypes";
+import type { Quest } from "../types/questTypes";
 import { ROUTES } from "../constants/routes";
 
 export const toTitleCase = (str: string): string =>
@@ -66,10 +67,15 @@ export const getQuestLinkLabel = (
  * Used when a post isn’t specifically quest-linked.
  */
 export const getDisplayTitle = (
-  post: Post,
+  item: Post | Quest,
   questName?: string,
   includeQuestName = false,
 ): string => {
+  if ("headPostId" in item) {
+    return item.title;
+  }
+
+  const post = item as Post;
   if (post.nodeId || post.questId) {
     return getQuestLinkLabel(post, questName, includeQuestName);
   }


### PR DESCRIPTION
## Summary
- populate quest board with recent active quests and mark it as quest-type
- support quest items in board view and display utilities
- adjust tests for new quest board behavior

## Testing
- `npm test` in `ethos-backend`
- `npm test` in `ethos-frontend` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6897657a892c832fb4df57d0594769eb