### PR TITLE
fix: persist PostgreSQL across tests

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -3,7 +3,11 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-export const usePg = !!process.env.DATABASE_URL && process.env.NODE_ENV !== 'test';
+// Use PostgreSQL whenever a DATABASE_URL is provided. This now applies even
+// when NODE_ENV is set to `test` so that test runs can exercise the same
+// persistence layer. Previous logic disabled Postgres during tests, which led
+// to data being stored in the transient JSON fallback and not persisting.
+export const usePg = !!process.env.DATABASE_URL;
 
 export const pool: Pool = usePg
   ? new Pool({ connectionString: process.env.DATABASE_URL })


### PR DESCRIPTION
## Summary
- always use PostgreSQL when `DATABASE_URL` is provided, even during tests

## Testing
- `npm test` *(fails: ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_689775081000832f945d267bd1523508