### PR TITLE
Fix board API enrichment and pluralize DB tables

### DIFF
--- a/ethos-backend/prisma/migrations/20250726213532_add_ethos_tables/migration.sql
+++ b/ethos-backend/prisma/migrations/20250726213532_add_ethos_tables/migration.sql
@@ -1,154 +1,112 @@
--- CreateTable
-CREATE TABLE "User" (
-    "id" TEXT NOT NULL,
-    "email" TEXT NOT NULL,
-    "username" TEXT,
-    "password" TEXT NOT NULL,
-    "role" TEXT,
-    "status" TEXT,
-
-    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+-- Create tables with lowercase plural names
+CREATE TABLE users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL,
+    username TEXT,
+    password TEXT NOT NULL,
+    role TEXT,
+    status TEXT
 );
 
--- CreateTable
-CREATE TABLE "Post" (
-    "id" TEXT NOT NULL,
-    "authorId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "title" TEXT,
-    "content" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+CREATE TABLE posts (
+    id TEXT PRIMARY KEY,
+    authorId TEXT NOT NULL,
+    type TEXT NOT NULL,
+    title TEXT,
+    content TEXT NOT NULL,
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- CreateTable
-CREATE TABLE "Quest" (
-    "id" TEXT NOT NULL,
-    "authorId" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "description" TEXT,
-    "visibility" TEXT NOT NULL,
-    "approvalStatus" TEXT,
-    "status" TEXT,
-    "projectId" TEXT,
-    "headPostId" TEXT,
-    "linkedPosts" JSONB,
-    "collaborators" JSONB,
-    "gitRepo" JSONB,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "tags" TEXT[],
-    "displayOnBoard" BOOLEAN,
-    "defaultBoardId" TEXT,
-    "taskGraph" JSONB,
-    "helpRequest" BOOLEAN,
-    "followers" TEXT[],
-
-    CONSTRAINT "Quest_pkey" PRIMARY KEY ("id")
+CREATE TABLE quests (
+    id TEXT PRIMARY KEY,
+    authorId TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    visibility TEXT NOT NULL,
+    approvalStatus TEXT,
+    status TEXT,
+    projectId TEXT,
+    headPostId TEXT UNIQUE,
+    linkedPosts JSONB,
+    collaborators JSONB,
+    gitRepo JSONB,
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    tags TEXT[],
+    displayOnBoard BOOLEAN,
+    defaultBoardId TEXT,
+    taskGraph JSONB,
+    helpRequest BOOLEAN,
+    followers TEXT[]
 );
 
--- CreateTable
-CREATE TABLE "Board" (
-    "id" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "description" TEXT,
-    "boardType" TEXT NOT NULL,
-    "layout" TEXT NOT NULL,
-    "items" JSONB NOT NULL,
-    "filters" JSONB,
-    "featured" BOOLEAN,
-    "defaultFor" TEXT,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "category" TEXT,
-    "userId" TEXT NOT NULL,
-    "questId" TEXT,
-
-    CONSTRAINT "Board_pkey" PRIMARY KEY ("id")
+CREATE TABLE boards (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT,
+    boardType TEXT NOT NULL,
+    layout TEXT NOT NULL,
+    items JSONB NOT NULL,
+    filters JSONB,
+    featured BOOLEAN,
+    defaultFor TEXT,
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    category TEXT,
+    userId TEXT NOT NULL,
+    questId TEXT
 );
 
--- CreateTable
-CREATE TABLE "Project" (
-    "id" TEXT NOT NULL,
-    "authorId" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "description" TEXT,
-    "visibility" TEXT NOT NULL,
-    "status" TEXT,
-    "tags" TEXT[],
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "questIds" TEXT[],
-    "deliverables" TEXT[],
-    "mapEdges" JSONB,
-
-    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+CREATE TABLE projects (
+    id TEXT PRIMARY KEY,
+    authorId TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    visibility TEXT NOT NULL,
+    status TEXT,
+    tags TEXT[],
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    questIds TEXT[],
+    deliverables TEXT[],
+    mapEdges JSONB
 );
 
--- CreateTable
-CREATE TABLE "Review" (
-    "id" TEXT NOT NULL,
-    "reviewerId" TEXT NOT NULL,
-    "targetType" TEXT NOT NULL,
-    "rating" INTEGER NOT NULL,
-    "visibility" TEXT NOT NULL,
-    "status" TEXT NOT NULL,
-    "tags" TEXT[],
-    "feedback" TEXT,
-    "repoUrl" TEXT,
-    "modelId" TEXT,
-    "questId" TEXT,
-    "postId" TEXT,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "Review_pkey" PRIMARY KEY ("id")
+CREATE TABLE reviews (
+    id TEXT PRIMARY KEY,
+    reviewerId TEXT NOT NULL,
+    targetType TEXT NOT NULL,
+    rating INTEGER NOT NULL,
+    visibility TEXT NOT NULL,
+    status TEXT NOT NULL,
+    tags TEXT[],
+    feedback TEXT,
+    repoUrl TEXT,
+    modelId TEXT,
+    questId TEXT,
+    postId TEXT,
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- CreateTable
-CREATE TABLE "Notification" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "message" TEXT NOT NULL,
-    "link" TEXT,
-    "read" BOOLEAN NOT NULL DEFAULT false,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+CREATE TABLE notifications (
+    id TEXT PRIMARY KEY,
+    userId TEXT NOT NULL,
+    message TEXT NOT NULL,
+    link TEXT,
+    read BOOLEAN NOT NULL DEFAULT false,
+    createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+-- Indexes
+CREATE UNIQUE INDEX users_email_key ON users(email);
+CREATE UNIQUE INDEX quests_headPostId_key ON quests(headPostId);
 
--- CreateIndex
-CREATE UNIQUE INDEX "Quest_headPostId_key" ON "Quest"("headPostId");
-
--- AddForeignKey
-ALTER TABLE "Post" ADD CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Quest" ADD CONSTRAINT "Quest_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Quest" ADD CONSTRAINT "Quest_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Quest" ADD CONSTRAINT "Quest_headPostId_fkey" FOREIGN KEY ("headPostId") REFERENCES "Post"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Board" ADD CONSTRAINT "Board_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Board" ADD CONSTRAINT "Board_questId_fkey" FOREIGN KEY ("questId") REFERENCES "Quest"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Project" ADD CONSTRAINT "Project_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Review" ADD CONSTRAINT "Review_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Review" ADD CONSTRAINT "Review_questId_fkey" FOREIGN KEY ("questId") REFERENCES "Quest"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Review" ADD CONSTRAINT "Review_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- Foreign keys
+ALTER TABLE posts ADD CONSTRAINT posts_authorId_fkey FOREIGN KEY (authorId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE quests ADD CONSTRAINT quests_authorId_fkey FOREIGN KEY (authorId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE quests ADD CONSTRAINT quests_projectId_fkey FOREIGN KEY (projectId) REFERENCES projects(id) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE quests ADD CONSTRAINT quests_headPostId_fkey FOREIGN KEY (headPostId) REFERENCES posts(id) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE boards ADD CONSTRAINT boards_userId_fkey FOREIGN KEY (userId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE boards ADD CONSTRAINT boards_questId_fkey FOREIGN KEY (questId) REFERENCES quests(id) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE projects ADD CONSTRAINT projects_authorId_fkey FOREIGN KEY (authorId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE reviews ADD CONSTRAINT reviews_reviewerId_fkey FOREIGN KEY (reviewerId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE reviews ADD CONSTRAINT reviews_questId_fkey FOREIGN KEY (questId) REFERENCES quests(id) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE reviews ADD CONSTRAINT reviews_postId_fkey FOREIGN KEY (postId) REFERENCES posts(id) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE notifications ADD CONSTRAINT notifications_userId_fkey FOREIGN KEY (userId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/ethos-backend/prisma/schema.prisma
+++ b/ethos-backend/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   projects Project[]
   reviews  Review[]
   notifications Notification[]
+  @@map("users")
 }
 
 model Post {
@@ -33,6 +34,7 @@ model Post {
   author User @relation(fields: [authorId], references: [id])
   reviews Review[]
   headOfQuest Quest? @relation("QuestHeadPost")
+  @@map("posts")
 }
 
 model Quest {
@@ -61,6 +63,7 @@ model Quest {
   headPost Post?   @relation("QuestHeadPost", fields: [headPostId], references: [id])
   boards   Board[]
   reviews  Review[]
+  @@map("quests")
 }
 
 model Board {
@@ -80,6 +83,7 @@ model Board {
 
   user  User  @relation(fields: [userId], references: [id])
   quest Quest? @relation(fields: [questId], references: [id])
+  @@map("boards")
 }
 
 model Project {
@@ -97,6 +101,7 @@ model Project {
 
   author User   @relation(fields: [authorId], references: [id])
   quests Quest[]
+  @@map("projects")
 }
 
 model Review {
@@ -117,6 +122,7 @@ model Review {
   reviewer User  @relation(fields: [reviewerId], references: [id])
   quest    Quest? @relation(fields: [questId], references: [id])
   post     Post?  @relation(fields: [postId], references: [id])
+  @@map("reviews")
 }
 
 model Notification {
@@ -128,4 +134,5 @@ model Notification {
   createdAt DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
+  @@map("notifications")
 }


### PR DESCRIPTION
## Summary
- Ensure boards fetched via PostgreSQL include their items and enrichment data
- Map Prisma models and migration to lowercase plural table names

## Testing
- `npm test` *(fails: Cannot find module 'supertest'; Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6897a78d9994832f8b2ab686f0541638