### PR TITLE
Allow request creation without linking tasks

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -23,6 +23,7 @@ export default {
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/tests/CreatePostReply.test.tsx',
+    '<rootDir>/tests/CreatePostRequestNoTask.test.tsx',
     '<rootDir>/tests/PostTypeFilterOptions.test.tsx',
     '<rootDir>/tests/ThemeProvider.test.js',
     '<rootDir>/tests/TimelineBoardPostTypes.test.tsx'

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -357,9 +357,8 @@ function validateLinks(type: PostType, items: LinkedItem[]): {
 } {
   switch (type) {
     case 'request':
-      return items.some(i => i.itemType === 'post')
-        ? { valid: true }
-        : { valid: false, message: 'Please link a task before submitting.' };
+      // Requests no longer require a linked task
+      return { valid: true };
     case 'task':
       return items.some(i => i.itemType === 'project')
         ? { valid: true }

--- a/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
+++ b/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({
+    selectedBoard: null,
+    boards: {},
+    appendToBoard: jest.fn(),
+  }),
+}));
+
+// Avoid LinkControls side effects
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('../src/components/controls/LinkControls', () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+import CreatePost from '../src/components/post/CreatePost';
+import { addPost } from '../src/api/post';
+
+describe('CreatePost request without task', () => {
+  it('submits request without requiring a linked task', async () => {
+    window.alert = jest.fn();
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} initialType="request" />
+      </BrowserRouter>
+    );
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Need help' } });
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Assist me' } });
+    fireEvent.click(screen.getByText('Create Post'));
+    await waitFor(() => expect(addPost).toHaveBeenCalled());
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Allow creating requests without linking them to tasks
- Add regression test for request creation without task links

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b5777c3c832f8eb86b9a1b49c70e