### PR TITLE
Fix quest board to show request posts

### DIFF
--- a/ethos-backend/src/data/boardContextDefaults.ts
+++ b/ethos-backend/src/data/boardContextDefaults.ts
@@ -16,7 +16,7 @@ export const DEFAULT_BOARDS: DBBoard[] = [
   {
     id: 'quest-board',
     title: 'Quest Board',
-    boardType: 'quest',
+    boardType: 'post',
     layout: 'grid',
     items: [],
     createdAt: new Date().toISOString(),

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -443,27 +443,27 @@ describe('route handlers', () => {
 
   });
 
-  it('GET /boards/quest-board/items returns active quests', async () => {
+  it('GET /boards/quest-board/items returns request posts', async () => {
 
     boardsStoreMock.read.mockReturnValue([
-      { id: 'quest-board', title: 'QB', boardType: 'quest', description: '', layout: 'grid', items: [] }
+      { id: 'quest-board', title: 'QB', boardType: 'post', description: '', layout: 'grid', items: [] }
     ]);
-    questsStoreMock.read.mockReturnValue([
+    postsStoreMock.read.mockReturnValue([
       {
-        id: 'q1', authorId: 'u1', title: 'Old Quest', visibility: 'public', approvalStatus: 'approved', status: 'archived',
-        headPostId: 'p1', linkedPosts: [], collaborators: [], createdAt: '2024-01-01'
+        id: 'r1', authorId: 'u2', type: 'request', content: '', visibility: 'public',
+        timestamp: '2024-01-02', boardId: 'quest-board', tags: [], collaborators: [], linkedItems: []
       },
       {
-        id: 'q2', authorId: 'u2', title: 'Active Quest', visibility: 'public', approvalStatus: 'approved', status: 'active',
-        headPostId: 'p2', linkedPosts: [], collaborators: [], createdAt: '2024-01-02'
+        id: 't1', authorId: 'u2', type: 'task', content: '', visibility: 'public',
+        timestamp: '2024-01-03', boardId: '', tags: [], collaborators: [], linkedItems: []
       }
     ]);
-    postsStoreMock.read.mockReturnValue([]);
+    questsStoreMock.read.mockReturnValue([]);
 
     const res = await request(app).get('/boards/quest-board/items');
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
-    expect(res.body[0].id).toBe('q2');
+    expect(res.body[0].id).toBe('r1');
   });
 });


### PR DESCRIPTION
## Summary
- display request posts on the quest board and recent activity board
- default quest board to boardType `post`
- add test ensuring quest board items return requests

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_6897c26ebdfc832f98e843d26b804e8f