### PR TITLE
Display request posts on timeline and quest boards

### DIFF
--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -466,4 +466,46 @@ describe('route handlers', () => {
     expect(res.body).toHaveLength(1);
     expect(res.body[0].id).toBe('r1');
   });
+
+  it('GET /boards/timeline-board/items includes request posts', async () => {
+    boardsStoreMock.read.mockReturnValue([
+      { id: 'timeline-board', title: 'TL', boardType: 'post', description: '', layout: 'grid', items: [] }
+    ]);
+    postsStoreMock.read.mockReturnValue([
+      {
+        id: 'r1', authorId: 'u1', type: 'request', content: '', visibility: 'public',
+        timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
+      },
+      {
+        id: 'p1', authorId: 'u2', type: 'free_speech', content: '', visibility: 'public',
+        timestamp: '2024-01-03', boardId: '', tags: [], collaborators: [], linkedItems: []
+      }
+    ]);
+    questsStoreMock.read.mockReturnValue([]);
+
+    const res = await request(app).get('/boards/timeline-board/items');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const types = res.body.map((p: any) => p.type);
+    expect(types).toContain('request');
+  });
+
+  it('GET /boards?enrich=true returns timeline board with request posts', async () => {
+    boardsStoreMock.read.mockReturnValue([
+      { id: 'timeline-board', title: 'TL', boardType: 'post', description: '', layout: 'grid', items: [] }
+    ]);
+    postsStoreMock.read.mockReturnValue([
+      {
+        id: 'r1', authorId: 'u1', type: 'request', content: '', visibility: 'public',
+        timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
+      }
+    ]);
+    questsStoreMock.read.mockReturnValue([]);
+
+    const res = await request(app).get('/boards?enrich=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].enrichedItems[0].type).toBe('request');
+  });
 });

--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -3,9 +3,10 @@
 import React from 'react';
 import PostCard from '../post/PostCard';
 import QuestCard from '../quest/QuestCard';
+import RequestCard from '../request/RequestCard';
 import { ErrorBoundary } from '../ui';
 
-import type { Post } from '../../types/postTypes';
+import type { Post, EnrichedPost } from '../../types/postTypes';
 import type { EnrichedQuest } from '../../types/questTypes';
 import type { BoardData } from '../../types/boardTypes';
 import type { User } from '../../types/userTypes';
@@ -72,12 +73,14 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   // ✅ Render Post types
   if ('type' in contribution) {
     const post = contribution as Post;
+    if (post.type === 'request' && boardId === 'quest-board') {
+      return <RequestCard post={post as EnrichedPost} onUpdate={onEdit ? (p) => onEdit(p.id) : undefined} />;
+    }
     return (
       <PostCard
         post={post}
         questId={questId}
         {...sharedProps}
-        headerOnly={headerOnly || post.type === 'request'}
         boardId={boardId}
       />
     );

--- a/ethos-frontend/tests/RequestPostRendering.test.tsx
+++ b/ethos-frontend/tests/RequestPostRendering.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ContributionCard from '../src/components/contribution/ContributionCard';
+import type { EnrichedPost } from '../src/types/postTypes';
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
+  updateReaction: jest.fn(() => Promise.resolve()),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+}));
+
+const requestPost: EnrichedPost = {
+  id: 'r1',
+  authorId: 'u1',
+  type: 'request',
+  content: 'Need help',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+  author: { id: 'u1', username: 'u1' },
+  enrichedCollaborators: [],
+};
+
+describe('Request post rendering', () => {
+  it('uses RequestCard on quest board', () => {
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={requestPost} boardId="quest-board" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Need help')).toBeInTheDocument();
+    expect(screen.getByText(/Accept/i)).toBeInTheDocument();
+  });
+
+  it('uses PostCard on timeline board', () => {
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={requestPost} boardId="timeline-board" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Need help')).toBeInTheDocument();
+    expect(screen.getByText('Expand View')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- include request posts when building timeline boards with a new helper
- show RequestCard for quest-board requests and full PostCard elsewhere
- test request post rendering on boards and backend endpoints

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e2146dcc832f8c1365dba1f4f0c4