### PR TITLE
Fix request post filtering on home boards

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -24,6 +24,7 @@ export default {
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/tests/CreatePostReply.test.tsx',
     '<rootDir>/tests/CreatePostRequestNoTask.test.tsx',
+    '<rootDir>/tests/BoardUtilsRequestPosts.test.ts',
     '<rootDir>/tests/PostTypeFilterOptions.test.tsx',
     '<rootDir>/tests/ThemeProvider.test.js',
     '<rootDir>/tests/TimelineBoardPostTypes.test.tsx'

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -19,18 +19,31 @@ const HomePage: React.FC = () => {
 
   const questBoard = boards['quest-board'];
   const timelineBoard = boards['timeline-board'];
-  const showQuestSeeAll = (questBoard?.enrichedItems?.length || 0) > BOARD_PREVIEW_LIMIT;
-  const showTimelineSeeAll =
-    (timelineBoard?.enrichedItems?.length || 0) >= BOARD_PREVIEW_LIMIT;
+
+  const questItems = useMemo(
+    () => getRenderableBoardItems(questBoard?.enrichedItems || []),
+    [questBoard?.enrichedItems]
+  );
+
+  const timelineItems = useMemo(
+    () => getRenderableBoardItems(timelineBoard?.enrichedItems || []),
+    [timelineBoard?.enrichedItems]
+  );
+
+  const showQuestSeeAll = questItems.length > BOARD_PREVIEW_LIMIT;
+  const showTimelineSeeAll = timelineItems.length >= BOARD_PREVIEW_LIMIT;
+
   const postTypes = useMemo(() => {
-    if (!questBoard?.enrichedItems) return [] as string[];
+    if (!questItems.length) return [] as string[];
     const types = new Set<string>();
-    getRenderableBoardItems(questBoard.enrichedItems).forEach((it) => {
+    questItems.forEach((it) => {
       if ('type' in it) types.add((it as { type?: string }).type as string);
     });
     return Array.from(types);
-  }, [questBoard?.enrichedItems]);
-  const showPostFilter = postTypes.length > 1 && (questBoard?.enrichedItems?.length || 0) > 0;
+  }, [questItems]);
+  const showPostFilter = postTypes.length > 1 && questItems.length > 0;
+  const hasQuestItems = questItems.length > 0;
+  const hasTimelineItems = timelineItems.length > 0;
 
   if (authLoading) {
     return (
@@ -51,40 +64,44 @@ const HomePage: React.FC = () => {
         </p>
       </header>
 
-      <section className="space-y-4">
-        {showPostFilter && (
-          <PostTypeFilter value={postType} onChange={setPostType} />
-        )}
-        <Board
-          boardId="quest-board"
-          title="🗺️ Quest Board"
-          layout="grid"
-          gridLayout="horizontal"
-          compact
-          user={user as User}
-          hideControls
-          filter={postType ? { postType } : {}}
-        />
-        {showQuestSeeAll && (
-          <div className="text-right">
-            <Link to={ROUTES.BOARD('quest-board')} className="text-blue-600 underline text-sm">
-              → See all
-            </Link>
-          </div>
-        )}
-      </section>
+      {hasQuestItems && (
+        <section className="space-y-4">
+          {showPostFilter && (
+            <PostTypeFilter value={postType} onChange={setPostType} />
+          )}
+          <Board
+            boardId="quest-board"
+            title="🗺️ Quest Board"
+            layout="grid"
+            gridLayout="horizontal"
+            compact
+            user={user as User}
+            hideControls
+            filter={postType ? { postType } : {}}
+          />
+          {showQuestSeeAll && (
+            <div className="text-right">
+              <Link to={ROUTES.BOARD('quest-board')} className="text-blue-600 underline text-sm">
+                → See all
+              </Link>
+            </div>
+          )}
+        </section>
+      )}
 
-      <section>
-        <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>
-        <RecentActivityBoard />
-        {showTimelineSeeAll && (
-          <div className="text-right">
-            <Link to={ROUTES.BOARD('timeline-board')} className="text-blue-600 underline text-sm">
-              → See all
-            </Link>
-          </div>
-        )}
-      </section>
+      {hasTimelineItems && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>
+          <RecentActivityBoard />
+          {showTimelineSeeAll && (
+            <div className="text-right">
+              <Link to={ROUTES.BOARD('timeline-board')} className="text-blue-600 underline text-sm">
+                → See all
+              </Link>
+            </div>
+          )}
+        </section>
+      )}
 
     </main>
   );

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -69,12 +69,16 @@ export const getRenderableBoardItems = (
     seen.add(item.id);
 
     if (!('headPostId' in item)) {
-      const questId = (item as Post).questId;
-      const linkedQuest = (item as Post).linkedItems?.find(
-        (l: LinkedItem) => l.itemType === 'quest' && questIds.has(l.itemId)
-      );
-      if ((questId && questIds.has(questId)) || linkedQuest) {
-        continue;
+      const post = item as Post;
+      // Allow request posts to always render even if a linked quest is present
+      if (post.type !== 'request') {
+        const questId = post.questId;
+        const linkedQuest = post.linkedItems?.find(
+          (l: LinkedItem) => l.itemType === 'quest' && questIds.has(l.itemId)
+        );
+        if ((questId && questIds.has(questId)) || linkedQuest) {
+          continue;
+        }
       }
     }
 

--- a/ethos-frontend/tests/BoardUtilsRequestPosts.test.ts
+++ b/ethos-frontend/tests/BoardUtilsRequestPosts.test.ts
@@ -1,0 +1,26 @@
+import { getRenderableBoardItems } from '../src/utils/boardUtils';
+import type { Post } from '../src/types/postTypes';
+import type { Quest } from '../src/types/questTypes';
+
+const quest = { id: 'q1', headPostId: 'hp1' } as unknown as Quest;
+
+const requestPost = {
+  id: 'p1',
+  authorId: 'u1',
+  type: 'request',
+  content: 'need help',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+  questId: 'q1',
+} as unknown as Post;
+
+describe('getRenderableBoardItems', () => {
+  it('keeps request posts even when linked to a quest', () => {
+    const items = getRenderableBoardItems([quest, requestPost]);
+    expect(items).toHaveLength(2);
+    expect(items.map(i => i.id)).toContain('p1');
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure request posts are never filtered out when linked to quests
- Only render home quest and timeline sections when data exists
- Add unit test for request post visibility in board utils

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68988f84f7c0832fa0dc7b15b8c2a148