### PR TITLE
Display author tags and restructure post pages

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
@@ -52,7 +52,8 @@ it('hides status controls and shows only request tag', () => {
     </BrowserRouter>
   );
 
-  expect(screen.getByText('Request: @u1')).toBeInTheDocument();
+  expect(screen.getByText('Request')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: '@u1' })).toBeInTheDocument();
   expect(screen.queryByText('In Progress')).toBeNull();
   expect(screen.queryByRole('combobox')).toBeNull();
   expect(screen.getByText('1 day ago')).toBeInTheDocument();

--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -36,15 +36,20 @@ const post: Post = {
   linkedItems: [],
 } as unknown as Post;
 
-describe.skip('PostCard summary tags', () => {
-  it('renders summary tags with quest title and node id', () => {
+describe('PostCard summary tags', () => {
+  it('renders type, quest, status, and username tags', () => {
+    const enriched = { ...post, author: { id: 'u1', username: 'alice' } } as Post;
     render(
       <BrowserRouter>
-        <PostCard post={post} questTitle="Quest A" />
+        <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
+    expect(screen.getByText('Task')).toBeInTheDocument();
     expect(screen.getByText('Quest: Quest A')).toBeInTheDocument();
-    expect(screen.getByText('Task: T1')).toBeInTheDocument();
     expect(screen.getByText('In Progress')).toBeInTheDocument();
+    const userLink = screen.getByRole('link', { name: '@alice' });
+    expect(userLink).toHaveAttribute('href', '/user/u1');
+    const typeLink = screen.getByRole('link', { name: 'Task' });
+    expect(typeLink).toHaveAttribute('href', '/post/p1');
   });
 });

--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -69,12 +69,9 @@ describe('PostListItem', () => {
         <PostListItem post={reviewPost} />
       </BrowserRouter>
     );
-
-    expect(
-      screen.getAllByText((_, element) =>
-        element?.textContent === 'Review: Quest B @u1'
-      ).length
-    ).toBeGreaterThan(0);
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Quest: Quest B')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '@u1' })).toBeInTheDocument();
   });
 
   it('renders generic review tag when quest title missing', () => {
@@ -89,11 +86,7 @@ describe('PostListItem', () => {
         <PostListItem post={reviewPost} />
       </BrowserRouter>
     );
-
-    expect(
-      screen.getAllByText((_, element) =>
-        element?.textContent === 'Review @u1'
-      ).length
-    ).toBeGreaterThan(0);
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '@u1' })).toBeInTheDocument();
   });
 });

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -15,6 +15,9 @@ import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
 
 import type { Post, PostType } from '../../types/postTypes';
 import type { BoardData } from '../../types/boardTypes';
+import QuestNodeInspector from '../../components/quest/QuestNodeInspector';
+import GitFileBrowserInline from '../../components/git/GitFileBrowserInline';
+import TeamPanel from '../../components/quest/TeamPanel';
 
 const PostPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -32,6 +35,7 @@ const PostPage: React.FC = () => {
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(1);
   const [showReplyForm, setShowReplyForm] = useState(false);
+  const [parentPost, setParentPost] = useState<Post | null>(null);
 
   const boardWithPost = useMemo<BoardData | null>(() => {
     if (!replyBoard || !post) return null;
@@ -43,11 +47,32 @@ const PostPage: React.FC = () => {
     };
   }, [replyBoard, post]);
 
+  const taskBoard = useMemo<BoardData | null>(() => {
+    if (!replyBoard) return null;
+    const tasks = replyBoard.enrichedItems?.filter(p => p.type === 'task') || [];
+    if (!tasks.length) return null;
+    return {
+      ...replyBoard,
+      items: tasks.map(t => t.id),
+      enrichedItems: tasks,
+    };
+  }, [replyBoard]);
+
   useEffect(() => {
     if (searchParams.get('reply') === '1') {
       setShowReplyForm(true);
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    if (post?.type === 'review' && post.replyTo) {
+      fetchPostById(post.replyTo)
+        .then(setParentPost)
+        .catch(() => setParentPost(null));
+    } else {
+      setParentPost(null);
+    }
+  }, [post]);
 
   const fetchPostData = useCallback(async () => {
     if (!id) return;
@@ -121,13 +146,12 @@ const PostPage: React.FC = () => {
 
   return (
     <main className="container mx-auto max-w-3xl px-4 py-10 space-y-12 bg-soft dark:bg-soft-dark text-primary">
-      {post.repostedFrom && (
-        <section className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4 text-sm text-secondary">
-          ♻️ Reposted from @{post.repostedFrom.username}
-        </section>
-      )}
-
       <section>
+        {post.repostedFrom && (
+          <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4 text-sm text-secondary">
+            ♻️ Reposted from @{post.repostedFrom.username}
+          </div>
+        )}
         <PostCard post={post} showDetails />
         {showReplyForm && (
           <div className="mt-4">
@@ -153,6 +177,33 @@ const PostPage: React.FC = () => {
         )}
       </section>
 
+      <section>
+        {post.type === 'request' && taskBoard && (
+          <Board
+            boardId={`tasks-${id}`}
+            board={taskBoard}
+            layout="grid"
+            editable={false}
+            compact={true}
+            user={user as User}
+          />
+        )}
+        {post.type === 'task' && post.questId && (
+          <div className="grid md:grid-cols-2 gap-4">
+            <QuestNodeInspector questId={post.questId} node={post} user={user as User} showPost={false} />
+            <div className="space-y-4">
+              <GitFileBrowserInline questId={post.questId} />
+              <TeamPanel questId={post.questId} node={post} canEdit={!!user} />
+            </div>
+          </div>
+        )}
+        {post.type === 'change' && post.questId && (
+          <GitFileBrowserInline questId={post.questId} />
+        )}
+        {post.type === 'review' && parentPost && (
+          <PostCard post={parentPost} />
+        )}
+      </section>
 
       <section>
         {boardWithPost ? (


### PR DESCRIPTION
## Summary
- show post type and author username as separate summary tags
- link type tags to post pages and usernames to public profiles
- restructure post page into main, supplementary, and reply sections

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898988b57c4832fb992514e91541fd5