### PR TITLE
feat: show root tasks on active quest board

### DIFF
--- a/ethos-frontend/src/api/quest.ts
+++ b/ethos-frontend/src/api/quest.ts
@@ -66,6 +66,11 @@ export const fetchActiveQuests = async (userId?: string): Promise<Quest[]> => {
   return res.data;
 };
 
+export const fetchActiveQuestBoard = async (): Promise<{ quests: Quest[]; tasks: Post[] }> => {
+  const res = await axiosWithAuth.get(`${BASE_URL}/active?includeTasks=1`);
+  return res.data;
+};
+
 /**
  * Update a quest by ID  
  * @function updateQuestById  


### PR DESCRIPTION
## Summary
- include root tasks with no parents in `/quests/active` endpoint
- enforce single-parent relationships when linking tasks to quests
- display root tasks alongside quests on Active Quest board

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689919c90af4832f8ad9d667bfff18e2