### PR TITLE
Gracefully fall back to JSON boards when PostgreSQL fails

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -18,6 +18,15 @@ export let pool: Pool = usePg
   : ({} as Pool);
 
 /**
+ * Disable PostgreSQL usage and fall back to the JSON store.
+ * This helper is useful if a database error occurs after startup.
+ */
+export function disablePg(): void {
+  usePg = false;
+  pool = {} as Pool;
+}
+
+/**
  * Ensure required tables and starter data exist when using PostgreSQL.
  * This allows fresh deployments to work without running separate migrations.
  */
@@ -30,8 +39,7 @@ export async function initializeDatabase(): Promise<void> {
     await pool.query('SELECT 1');
   } catch (_err) {
     console.warn('PostgreSQL not available, using JSON store instead');
-    usePg = false;
-    pool = {} as Pool;
+    disablePg();
     return;
   }
 

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -6,7 +6,7 @@ import { boardsStore, postsStore, questsStore, usersStore } from '../models/stor
 import { DEFAULT_BOARDS } from '../data/boardContextDefaults';
 import { enrichBoard, enrichQuest } from '../utils/enrich';
 import { DEFAULT_PAGE_SIZE } from '../constants';
-import { pool, usePg } from '../db';
+import { pool, usePg, disablePg } from '../db';
 import type { BoardData } from '../types/api';
 import type { DBPost, DBQuest } from '../types/db';
 import type { EnrichedBoard } from '../types/enriched';
@@ -172,8 +172,8 @@ router.get(
         return;
       } catch (err) {
         console.error(err);
-        res.status(500).json({ error: 'Database error' });
-        return;
+        disablePg();
+        // fall back to JSON store below
       }
     }
 


### PR DESCRIPTION
## Summary
- add `disablePg` helper to flip off PostgreSQL and use JSON store
- handle database errors in board routes by disabling PG and falling back to JSON boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68991c4824bc832f8432e252a067d726