### PR TITLE
refactor: streamline post types

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -211,7 +211,7 @@ const Board: React.FC<BoardProps> = ({
 
   const postTypes = useMemo(() => {
     if (board?.id === 'quest-board') {
-      return ['request', 'review', 'issue'];
+      return ['request', 'review'];
     }
     const types = new Set<string>();
     renderableItems.forEach((it) => {

--- a/ethos-frontend/src/components/board/PostTypeFilter.tsx
+++ b/ethos-frontend/src/components/board/PostTypeFilter.tsx
@@ -10,7 +10,6 @@ const options = [
   { value: '', label: 'All Posts' },
   { value: 'request', label: 'Requests' },
   { value: 'review', label: 'Reviews' },
-  { value: 'issue', label: 'Issues' },
 ];
 
 const PostTypeFilter: React.FC<PostTypeFilterProps> = ({ value, onChange }) => {

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -308,7 +308,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           </button>
         )}
 
-        {!isQuestRequest && ['task', 'issue'].includes(post.type) && (
+        {!isQuestRequest && post.type === 'task' && (
           <button
             className={clsx('flex items-center gap-1', helpRequested && 'text-indigo-600')}
             onClick={handleRequestHelp}

--- a/ethos-frontend/src/components/git/GitFileBrowser.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowser.tsx
@@ -50,7 +50,7 @@ const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => 
       const diff = await fetchGitDiff(questId, editingFile.path);
       const commitMsg = message || `Update ${editingFile.path}`;
       await addPost({
-        type: 'commit',
+        type: 'change',
         questId,
         content: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
         commitSummary: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,

--- a/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
@@ -52,7 +52,7 @@ const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, on
       const diff = await fetchGitDiff(questId, editingFile.path);
       const commitMsg = message || `Update ${editingFile.path}`;
       await addPost({
-        type: 'commit',
+        type: 'change',
         questId,
         content: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
         commitSummary: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -42,7 +42,7 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
       title: type === 'task' ? content : title || undefined,
       content,
       ...(type === 'task' && details ? { details } : {}),
-      ...(type === 'task' || type === 'issue'
+      ...(type === 'task'
         ? { status }
         : {}),
       linkedItems,
@@ -71,12 +71,12 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (['task', 'issue'].includes(val)) setStatus('To Do');
+            if (val === 'task') setStatus('To Do');
           }}
           options={POST_TYPES.map(({ value, label }) => ({ value, label }))}
         />
 
-        {['task', 'issue'].includes(type) && (
+        {type === 'task' && (
           <>
             <Label htmlFor="task-status">Status</Label>
             <Select

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -472,7 +472,7 @@ const PostCard: React.FC<PostCardProps> = ({
           {post.type === 'review' && post.rating && renderStars(post.rating)}
           {!isQuestBoardRequest &&
             canEdit &&
-            ['task', 'request', 'issue'].includes(post.type) &&
+            ['task', 'request'].includes(post.type) &&
             showStatusControl && (
             <div className="ml-1 w-28">
               <Select

--- a/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
+++ b/ethos-frontend/src/components/quest/StatusBoardPanel.tsx
@@ -28,7 +28,7 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
   initialOpen = false,
 }) => {
   const [items, setItems] = useState<Post[]>([]);
-  const [filter, setFilter] = useState<'all' | 'issues' | 'tasks'>('all');
+  const [filter, setFilter] = useState<'all' | 'tasks'>('all');
   const [showForm, setShowForm] = useState(false);
   const [open, setOpen] = useState(initialOpen);
 
@@ -40,8 +40,8 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
         setItems(
           posts.filter(
             (p) =>
-              (p.type === 'issue' && p.linkedNodeId === linkedNodeId) ||
-              (p.type === 'task' && p.replyTo === linkedNodeId),
+              p.type === 'task' &&
+              (p.linkedNodeId === linkedNodeId || p.replyTo === linkedNodeId),
           ),
         );
       })
@@ -51,7 +51,6 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
   }, [questId, linkedNodeId]);
 
   const filtered = items.filter((i) => {
-    if (filter === 'issues') return i.type === 'issue';
     if (filter === 'tasks') return i.type === 'task';
     return true;
   });
@@ -89,14 +88,6 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
                 onClick={() => setFilter('all')}
               >
                 All
-              </button>
-              <button
-                className={`px-2 py-0.5 rounded border ${
-                  filter === 'issues' ? 'bg-accent text-white border-accent' : 'border-secondary'
-                }`}
-                onClick={() => setFilter('issues')}
-              >
-                Issues
               </button>
               <button
                 className={`px-2 py-0.5 rounded border ${
@@ -144,22 +135,22 @@ const StatusBoardPanel: React.FC<StatusBoardPanelProps> = ({
                 {grouped[value].length === 0 ? (
                   <div className="text-xs text-secondary">No items</div>
                 ) : (
-                  grouped[value].map((issue) => (
+                  grouped[value].map((task) => (
                     <div
-                      key={issue.id}
+                      key={task.id}
                       className="text-xs border border-secondary rounded p-1 bg-background space-y-1"
                     >
                       <span
-                        title={issue.title || issue.content}
+                        title={task.title || task.content}
                         className="block truncate"
                       >
                         <SummaryTag
-                          type={issue.type as 'task' | 'issue'}
-                          label={getQuestLinkLabel(issue, '', false)}
-                          link={ROUTES.POST(issue.id)}
+                          type="task"
+                          label={getQuestLinkLabel(task, '', false)}
+                          link={ROUTES.POST(task.id)}
                         />
                       </span>
-                      {issue.status && <StatusBadge status={issue.status} />}
+                      {task.status && <StatusBadge status={task.status} />}
                     </div>
                   ))
                 )}

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -71,7 +71,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         )}
         {post.nodeId && (
           <SummaryTag
-            type={post.type === 'issue' || post.subtype === 'issue' ? 'issue' : 'task'}
+            type="task"
             label={post.nodeId.replace(/^Q:[^:]+:/, '')}
             detailLink={ROUTES.POST(post.id)}
           />

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import {
   FaBookOpen,
   FaTasks,
-  FaBug,
   FaStickyNote,
   FaStar,
   FaCommentAlt,
@@ -12,7 +11,6 @@ import {
   FaUserCheck,
   FaCog,
   FaBullhorn,
-  FaCodeBranch,
   FaCheckCircle,
   FaUsers,
   FaExchangeAlt

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -23,7 +23,6 @@ import { TAG_BASE, TAG_TRUNCATED } from '../../constants/styles';
 export type SummaryTagType =
   | 'quest'
   | 'task'
-  | 'issue'
   | 'log'
   | 'review'
   | 'category'
@@ -34,7 +33,6 @@ export type SummaryTagType =
   | 'change'
   | 'party_request'
   | 'quest_task'
-  | 'commit'
   | 'meta_system'
   | 'meta_announcement'
   | 'solved';
@@ -56,7 +54,6 @@ export interface SummaryTagData {
 const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> = {
   quest: FaBookOpen,
   task: FaTasks,
-  issue: FaBug,
   log: FaStickyNote,
   review: FaStar,
   category: FaStickyNote,
@@ -67,7 +64,6 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
   change: FaExchangeAlt,
   party_request: FaUsers,
   quest_task: FaUserCheck,
-  commit: FaCodeBranch,
   meta_system: FaCog,
   meta_announcement: FaBullhorn,
   solved: FaCheckCircle,
@@ -76,7 +72,6 @@ const icons: Record<SummaryTagType, React.ComponentType<{className?: string}>> =
 const colors: Record<SummaryTagType, string> = {
   quest: 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200',
   task: 'bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-200',
-  issue: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
   log: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200',
   review: 'bg-teal-100 text-teal-800 dark:bg-teal-800 dark:text-teal-200',
   category: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
@@ -87,7 +82,6 @@ const colors: Record<SummaryTagType, string> = {
   change: 'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-200',
   party_request: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   quest_task: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-800 dark:text-cyan-200',
-  commit: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   meta_system: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',
   meta_announcement: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
   solved: 'bg-lime-100 text-lime-800 dark:bg-lime-800 dark:text-lime-200',

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -189,9 +189,7 @@ export type PostType =
   | 'request'
   | 'task'
   | 'change'
-  | 'review'
-  | 'issue'
-  | 'commit';
+  | 'review';
   
 /**
  * Supported tags for labeling and filtering posts.

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -12,8 +12,6 @@ export const POST_TYPE_LABELS: Record<PostType, string> = {
   task: "Task",
   change: "Change",
   review: "Review",
-  issue: "Issue",
-  commit: "Commit",
 };
 
 /**

--- a/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
+++ b/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
@@ -7,6 +7,6 @@ describe('PostTypeFilter options', () => {
     render(<PostTypeFilter value="" onChange={() => {}} />);
     const select = screen.getByRole('combobox');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['All Posts', 'Requests', 'Reviews', 'Issues']);
+    expect(options).toEqual(['All Posts', 'Requests', 'Reviews']);
   });
 });


### PR DESCRIPTION
## Summary
- align post type definitions with core categories
- update UI and filtering to drop issue/commit types
- create change posts for git file operations

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899249f3d48832fa93d3f51032f6b09