### PR TITLE
Add Express server entry point

### DIFF
--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
+import dotenv from 'dotenv';
+import { initializeDatabase } from './db';
+import { requestLogger } from './utils/logger';
+
+// Load environment variables
+dotenv.config();
+
+// Create the Express application
+const app = express();
+
+// Global middleware
+app.use(helmet());
+app.use(cors({ origin: process.env.CORS_ORIGIN || true, credentials: true }));
+app.use(express.json());
+app.use(cookieParser());
+app.use(requestLogger);
+
+// Basic health check route
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+
+// Initialize database then start the server
+initializeDatabase()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to initialize database', err);
+    process.exit(1);
+  });
+
+export default app;


### PR DESCRIPTION
## Summary
- add Express server with basic middleware and health route
- initialize database before starting listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993a36d8f4832f8748960b736781ec