### PR TITLE
Include request posts on quest and timeline boards

### DIFF
--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -451,7 +451,7 @@ describe('route handlers', () => {
     postsStoreMock.read.mockReturnValue([
       {
         id: 'r1', authorId: 'u2', type: 'request', content: '', visibility: 'public',
-        timestamp: '2024-01-02', boardId: 'quest-board', tags: [], collaborators: [], linkedItems: []
+        timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
       },
       {
         id: 't1', authorId: 'u2', type: 'task', content: '', visibility: 'public',


### PR DESCRIPTION
## Summary
- show request posts on the quest board regardless of boardId or author
- allow non-private requests to appear on quest board and timeline board
- add test ensuring quest board returns request posts

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68995284d0d0832f8589173172b159ed