### PR TITLE
feat: add task expanded view panels

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+
+jest.mock('../layout/MapGraphLayout', () => () => <div data-testid="map" />);
+jest.mock('../git/GitFileBrowserInline', () => () => <div>File Browser</div>);
+jest.mock('../quest/TeamPanel', () => () => <div>Team Panel</div>);
+jest.mock('../../hooks/useGraph', () => ({ useGraph: () => ({ nodes: [], edges: [], loadGraph: jest.fn() }) }));
+
+const task: Post = {
+  id: 't1',
+  authorId: 'u1',
+  type: 'task',
+  content: 'Task content',
+  visibility: 'public',
+  timestamp: '',
+  tags: [],
+  collaborators: [],
+  linkedItems: [],
+  status: 'To Do',
+  questId: 'q1',
+};
+
+test('shows map and file browser in expanded view', () => {
+  render(<PostCard post={task} expanded />);
+  expect(screen.getByTestId('map')).toBeInTheDocument();
+  expect(screen.getByText('File Browser')).toBeInTheDocument();
+  expect(screen.getByText('Options')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show quest map and file/options panels when expanding task posts
- add tests for expanded task view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899edefe9a4832fa7b93b690363f036