### PR TITLE
Include request posts on quest and timeline boards

### DIFF
--- a/ethos-backend/dist/src/db.js
+++ b/ethos-backend/dist/src/db.js
@@ -1,49 +1,51 @@
-import { Pool } from 'pg';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.pool = exports.usePg = void 0;
+exports.disablePg = disablePg;
+exports.initializeDatabase = initializeDatabase;
+const pg_1 = require("pg");
+const dotenv_1 = __importDefault(require("dotenv"));
+dotenv_1.default.config();
 /**
  * Flag indicating whether the application should use PostgreSQL.
  * Initially set based on the presence of a `DATABASE_URL`, but if a connection
  * cannot be established (e.g. during tests where no DB is available) the flag
  * is flipped off and the app gracefully falls back to the JSON store.
  */
-export let usePg =
-  !!process.env.DATABASE_URL &&
-  (process.env.NODE_ENV !== 'test' || process.env.USE_PG === 'true');
-
-export let pool: Pool = usePg
-  ? new Pool({ connectionString: process.env.DATABASE_URL })
-  : ({} as Pool);
-
+exports.usePg = !!process.env.DATABASE_URL &&
+    (process.env.NODE_ENV !== 'test' || process.env.USE_PG === 'true');
+exports.pool = exports.usePg
+    ? new pg_1.Pool({ connectionString: process.env.DATABASE_URL })
+    : {};
 /**
  * Disable PostgreSQL usage and fall back to the JSON store.
  * This helper is useful if a database error occurs after startup.
  */
-export function disablePg(): void {
-  usePg = false;
-  pool = {} as Pool;
+function disablePg() {
+    exports.usePg = false;
+    exports.pool = {};
 }
-
 /**
  * Ensure required tables and starter data exist when using PostgreSQL.
  * This allows fresh deployments to work without running separate migrations.
  */
-export async function initializeDatabase(): Promise<void> {
-  if (!usePg) return;
-
-  try {
-    // Verify the connection is usable. If it fails we gracefully fall back to
-    // the JSON store so tests or offline environments can continue working.
-    await pool.query('SELECT 1');
-  } catch (_err) {
-    console.warn('PostgreSQL not available, using JSON store instead');
-    disablePg();
-    return;
-  }
-
-  await pool.query(`
+async function initializeDatabase() {
+    if (!exports.usePg)
+        return;
+    try {
+        // Verify the connection is usable. If it fails we gracefully fall back to
+        // the JSON store so tests or offline environments can continue working.
+        await exports.pool.query('SELECT 1');
+    }
+    catch (_err) {
+        console.warn('PostgreSQL not available, using JSON store instead');
+        disablePg();
+        return;
+    }
+    await exports.pool.query(`
     CREATE TABLE IF NOT EXISTS users (
       id UUID PRIMARY KEY,
       username TEXT,
@@ -122,23 +124,17 @@ export async function initializeDatabase(): Promise<void> {
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS timestamp TIMESTAMPTZ;
     ALTER TABLE quests ADD COLUMN IF NOT EXISTS tags TEXT[];
   `);
-
-  const { rows } = await pool.query(
-    "SELECT id FROM boards WHERE id IN ('quest-board','timeline-board','my-posts','my-quests')"
-  );
-  const existing = rows.map((r) => r.id);
-  const defaults = [
-    { id: 'quest-board', title: 'Quest Board' },
-    { id: 'timeline-board', title: 'Timeline' },
-    { id: 'my-posts', title: 'My Posts' },
-    { id: 'my-quests', title: 'My Quests' },
-  ];
-  for (const board of defaults) {
-    if (!existing.includes(board.id)) {
-      await pool.query(
-        `INSERT INTO boards (id,title,boardType,layout,items,createdAt,userId) VALUES ($1,$2,'post','grid','[]',NOW(),'')`,
-        [board.id, board.title]
-      );
+    const { rows } = await exports.pool.query("SELECT id FROM boards WHERE id IN ('quest-board','timeline-board','my-posts','my-quests')");
+    const existing = rows.map((r) => r.id);
+    const defaults = [
+        { id: 'quest-board', title: 'Quest Board' },
+        { id: 'timeline-board', title: 'Timeline' },
+        { id: 'my-posts', title: 'My Posts' },
+        { id: 'my-quests', title: 'My Quests' },
+    ];
+    for (const board of defaults) {
+        if (!existing.includes(board.id)) {
+            await exports.pool.query(`INSERT INTO boards (id,title,boardType,layout,items,createdAt,userId) VALUES ($1,$2,'post','grid','[]',NOW(),'')`, [board.id, board.title]);
+        }
     }
-  }
 }

--- a/ethos-backend/dist/src/routes/boardRoutes.js
+++ b/ethos-backend/dist/src/routes/boardRoutes.js
@@ -12,29 +12,70 @@ const boardContextDefaults_1 = require("../data/boardContextDefaults");
 const enrich_1 = require("../utils/enrich");
 const constants_1 = require("../constants");
 const db_1 = require("../db");
+const toMs = (value) => {
+    const t = new Date(value ?? 0).getTime();
+    return Number.isNaN(t) ? 0 : t;
+};
 // Gather active quests for the quest board. Returns up to 10 recent quests
 // excluding those authored by the requesting user.
 const getQuestBoardQuests = (quests, userId) => {
     return quests
         .filter(q => q.status === 'active' && q.visibility === 'public')
         .filter(q => !userId || q.authorId !== userId)
-        .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''))
+        .sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt))
         .slice(0, 10)
         .map(q => q.id);
 };
-// Gather recent request posts for the quest board. Excludes the requesting user
-// and archived requests. Returns up to DEFAULT_PAGE_SIZE recent requests.
-const getQuestBoardRequests = (posts, userId) => {
+// Gather recent request posts for the quest board. Returns up to DEFAULT_PAGE_SIZE
+// recent requests excluding archived or private ones.
+const getQuestBoardRequests = (posts) => {
     return posts
-        .filter(p => p.type === 'request' && p.boardId === 'quest-board')
+        .filter(p => p.type === 'request')
+        .filter(p => p.visibility !== 'private')
         .filter(p => !p.tags?.includes('archived'))
-        .filter(p => (p.visibility === 'public' ||
-        p.visibility === 'request_board' ||
-        p.needsHelp === true))
-        .filter(p => !userId || p.authorId !== userId)
-        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
+        .sort((a, b) => toMs(b.timestamp) - toMs(a.timestamp))
         .slice(0, constants_1.DEFAULT_PAGE_SIZE)
         .map(p => p.id);
+};
+// Gather posts for the timeline board. Includes all public/request posts
+// visible to the requesting user and sorts them with highlight metadata.
+const getTimelineBoardItems = (posts, quests, userId) => {
+    const userQuestIds = userId
+        ? quests
+            .filter(q => q.authorId === userId ||
+            (q.collaborators || []).some(c => c.userId === userId) ||
+            posts.some(p => p.questId === q.id && p.authorId === userId))
+            .map(q => q.id)
+        : [];
+    const userTaskIds = userId
+        ? posts
+            .filter(p => p.authorId === userId && p.type === 'task')
+            .map(p => p.id)
+        : [];
+    const withMeta = posts
+        .filter(p => p.visibility !== 'private')
+        .map(p => {
+        let weight = 0;
+        let highlight = false;
+        if (userId) {
+            if (p.questId && userQuestIds.includes(p.questId)) {
+                weight = p.type === 'task' ? 3 : 2;
+                if (p.type === 'task')
+                    highlight = true;
+            }
+            else if (p.linkedItems?.some(li => (li.itemType === 'quest' && userQuestIds.includes(li.itemId)) ||
+                (li.itemType === 'post' && userTaskIds.includes(li.itemId)))) {
+                weight = 1;
+                highlight = true;
+            }
+        }
+        return { id: p.id, timestamp: toMs(p.timestamp || p.createdAt), weight, highlight };
+    })
+        .sort((a, b) => b.weight - a.weight || b.timestamp - a.timestamp);
+    return {
+        items: withMeta.map(it => it.id),
+        highlightMap: Object.fromEntries(withMeta.map(it => [it.id, it.highlight])),
+    };
 };
 const router = express_1.default.Router();
 //
@@ -53,6 +94,8 @@ router.get('/', async (req, res) => {
                 ...r,
                 authorId: r.authorid,
                 createdAt: r.createdat,
+                boardId: r.boardid,
+                timestamp: r.timestamp,
             }));
             const quests = questsRes.rows.map((r) => ({
                 ...r,
@@ -64,14 +107,17 @@ router.get('/', async (req, res) => {
                 if (userId && b.id === 'my-posts') {
                     b.items = posts
                         .filter(p => p.authorId === userId && p.systemGenerated !== true)
-                        .sort((a, b) => (b.timestamp || b.createdAt || '').localeCompare(a.timestamp || a.createdAt || ''))
+                        .sort((a, b) => toMs(b.timestamp || b.createdAt) - toMs(a.timestamp || a.createdAt))
                         .map(p => p.id);
                 }
                 else if (userId && b.id === 'my-quests') {
                     b.items = quests.filter(q => q.authorId === userId).map(q => q.id);
                 }
                 else if (b.id === 'quest-board') {
-                    b.items = getQuestBoardRequests(posts, userId);
+                    b.items = getQuestBoardRequests(posts);
+                }
+                else if (b.id === 'timeline-board') {
+                    b.items = getTimelineBoardItems(posts, quests, userId).items;
                 }
                 return b;
             });
@@ -89,8 +135,8 @@ router.get('/', async (req, res) => {
         }
         catch (err) {
             console.error(err);
-            res.status(500).json({ error: 'Database error' });
-            return;
+            (0, db_1.disablePg)();
+            // fall back to JSON store below
         }
     }
     let boards = stores_1.boardsStore.read();
@@ -105,7 +151,8 @@ router.get('/', async (req, res) => {
             const filtered = posts
                 .filter(p => p.authorId === userId &&
                 p.systemGenerated !== true)
-                .sort((a, b) => (b.timestamp || b.createdAt || '').localeCompare(a.timestamp || a.createdAt || ''))
+                .sort((a, b) => toMs(b.timestamp || b.createdAt) -
+                toMs(a.timestamp || a.createdAt))
                 .map(p => p.id);
             return { ...board, items: filtered };
         }
@@ -116,7 +163,11 @@ router.get('/', async (req, res) => {
             return { ...board, items: filtered };
         }
         if (board.id === 'quest-board') {
-            const items = getQuestBoardRequests(posts, userId);
+            const items = getQuestBoardRequests(posts);
+            return { ...board, items };
+        }
+        if (board.id === 'timeline-board') {
+            const { items } = getTimelineBoardItems(posts, quests, userId);
             return { ...board, items };
         }
         return board;
@@ -151,11 +202,7 @@ router.get('/thread/:postId', (req, res) => {
     const end = start + pageSize;
     const replies = posts
         .filter(p => p.replyTo === postId)
-        .sort((a, b) => {
-        const ta = a.timestamp || '';
-        const tb = b.timestamp || '';
-        return tb.localeCompare(ta);
-    })
+        .sort((a, b) => toMs(b.timestamp) - toMs(a.timestamp))
         .slice(start, end);
     const board = {
         id: `thread-${postId}`,
@@ -221,6 +268,8 @@ router.get('/:id', async (req, res) => {
                     ...r,
                     authorId: r.authorid,
                     createdAt: r.createdat,
+                    boardId: r.boardid,
+                    timestamp: r.timestamp,
                 }));
                 const quests = questsRes.rows.map((r) => ({
                     ...r,
@@ -256,48 +305,18 @@ router.get('/:id', async (req, res) => {
     let boardItems = board.items;
     let highlightMap = {};
     if (board.id === 'quest-board') {
-        boardItems = getQuestBoardRequests(posts, userId);
+        boardItems = getQuestBoardRequests(posts);
     }
     else if (board.id === 'timeline-board') {
-        const userQuestIds = userId
-            ? quests
-                .filter(q => q.authorId === userId ||
-                (q.collaborators || []).some(c => c.userId === userId) ||
-                posts.some(p => p.questId === q.id && p.authorId === userId))
-                .map(q => q.id)
-            : [];
-        const userTaskIds = userId
-            ? posts
-                .filter(p => p.authorId === userId && p.type === 'task')
-                .map(p => p.id)
-            : [];
-        const withMeta = posts
-            .filter(p => p.visibility !== 'private')
-            .map(p => {
-            let weight = 0;
-            let highlight = false;
-            if (userId) {
-                if (p.questId && userQuestIds.includes(p.questId)) {
-                    weight = p.type === 'task' ? 3 : 2;
-                    if (p.type === 'task')
-                        highlight = true;
-                }
-                else if (p.linkedItems?.some(li => (li.itemType === 'quest' && userQuestIds.includes(li.itemId)) ||
-                    (li.itemType === 'post' && userTaskIds.includes(li.itemId)))) {
-                    weight = 1;
-                    highlight = true;
-                }
-            }
-            return { id: p.id, timestamp: p.timestamp || '', weight, highlight };
-        })
-            .sort((a, b) => b.weight - a.weight || b.timestamp.localeCompare(a.timestamp));
-        highlightMap = Object.fromEntries(withMeta.map(it => [it.id, it.highlight]));
-        boardItems = withMeta.map(it => it.id);
+        const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
+        boardItems = items;
+        highlightMap = hm;
     }
     else if (userId && board.id === 'my-posts') {
         boardItems = posts
             .filter(p => p.authorId === userId && p.systemGenerated !== true)
-            .sort((a, b) => (b.timestamp || b.createdAt || '').localeCompare(a.timestamp || a.createdAt || ''))
+            .sort((a, b) => toMs(b.timestamp || b.createdAt) -
+            toMs(a.timestamp || a.createdAt))
             .map(p => p.id);
     }
     else if (userId && board.id === 'my-quests') {
@@ -341,6 +360,8 @@ router.get('/:id/items', async (req, res) => {
                 ...r,
                 authorId: r.authorid,
                 createdAt: r.createdat,
+                boardId: r.boardid,
+                timestamp: r.timestamp,
             }));
             const quests = questsRes.rows.map((r) => ({
                 ...r,
@@ -350,46 +371,18 @@ router.get('/:id/items', async (req, res) => {
             let boardItems = board.items;
             let highlightMap = {};
             if (board.id === 'quest-board') {
-                boardItems = getQuestBoardRequests(posts, userId);
+                boardItems = getQuestBoardRequests(posts);
             }
             else if (board.id === 'timeline-board') {
-                const userQuestIds = userId
-                    ? quests
-                        .filter(q => q.authorId === userId ||
-                        (q.collaborators || []).some(c => c.userId === userId) ||
-                        posts.some(p => p.questId === q.id && p.authorId === userId))
-                        .map(q => q.id)
-                    : [];
-                const userTaskIds = userId
-                    ? posts.filter(p => p.authorId === userId && p.type === 'task').map(p => p.id)
-                    : [];
-                const withMeta = posts
-                    .filter(p => p.visibility !== 'private')
-                    .map(p => {
-                    let weight = 0;
-                    let highlight = false;
-                    if (userId) {
-                        if (p.questId && userQuestIds.includes(p.questId)) {
-                            weight = p.type === 'task' ? 3 : 2;
-                            if (p.type === 'task')
-                                highlight = true;
-                        }
-                        else if (p.linkedItems?.some(li => (li.itemType === 'quest' && userQuestIds.includes(li.itemId)) ||
-                            (li.itemType === 'post' && userTaskIds.includes(li.itemId)))) {
-                            weight = 1;
-                            highlight = true;
-                        }
-                    }
-                    return { id: p.id, timestamp: p.timestamp || '', weight, highlight };
-                })
-                    .sort((a, b) => b.weight - a.weight || b.timestamp.localeCompare(a.timestamp));
-                highlightMap = Object.fromEntries(withMeta.map(it => [it.id, it.highlight]));
-                boardItems = withMeta.map(it => it.id);
+                const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
+                boardItems = items;
+                highlightMap = hm;
             }
             else if (userId && board.id === 'my-posts') {
                 boardItems = posts
                     .filter(p => p.authorId === userId && p.systemGenerated !== true)
-                    .sort((a, b) => (b.timestamp || b.createdAt || '').localeCompare(a.timestamp || a.createdAt || ''))
+                    .sort((a, b) => toMs(b.timestamp || b.createdAt) -
+                    toMs(a.timestamp || a.createdAt))
                     .map(p => p.id);
             }
             else if (userId && board.id === 'my-quests') {
@@ -417,11 +410,9 @@ router.get('/:id/items', async (req, res) => {
                     if (board.id === 'quest-board') {
                         if (p.type !== 'request')
                             return false;
-                        if (p.boardId !== 'quest-board')
+                        if (p.visibility === 'private')
                             return false;
-                        return (p.visibility === 'public' ||
-                            p.visibility === 'request_board' ||
-                            p.needsHelp === true);
+                        return true;
                     }
                     return true;
                 }
@@ -458,48 +449,18 @@ router.get('/:id/items', async (req, res) => {
     let boardItems = board.items;
     let highlightMap = {};
     if (board.id === 'quest-board') {
-        boardItems = getQuestBoardRequests(posts, userId);
+        boardItems = getQuestBoardRequests(posts);
     }
     else if (board.id === 'timeline-board') {
-        const userQuestIds = userId
-            ? quests
-                .filter(q => q.authorId === userId ||
-                (q.collaborators || []).some(c => c.userId === userId) ||
-                posts.some(p => p.questId === q.id && p.authorId === userId))
-                .map(q => q.id)
-            : [];
-        const userTaskIds = userId
-            ? posts
-                .filter(p => p.authorId === userId && p.type === 'task')
-                .map(p => p.id)
-            : [];
-        const withMeta = posts
-            .filter(p => p.visibility !== 'private')
-            .map(p => {
-            let weight = 0;
-            let highlight = false;
-            if (userId) {
-                if (p.questId && userQuestIds.includes(p.questId)) {
-                    weight = p.type === 'task' ? 3 : 2;
-                    if (p.type === 'task')
-                        highlight = true;
-                }
-                else if (p.linkedItems?.some(li => (li.itemType === 'quest' && userQuestIds.includes(li.itemId)) ||
-                    (li.itemType === 'post' && userTaskIds.includes(li.itemId)))) {
-                    weight = 1;
-                    highlight = true;
-                }
-            }
-            return { id: p.id, timestamp: p.timestamp || '', weight, highlight };
-        })
-            .sort((a, b) => b.weight - a.weight || b.timestamp.localeCompare(a.timestamp));
-        highlightMap = Object.fromEntries(withMeta.map(it => [it.id, it.highlight]));
-        boardItems = withMeta.map(it => it.id);
+        const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
+        boardItems = items;
+        highlightMap = hm;
     }
     else if (userId && board.id === 'my-posts') {
         boardItems = posts
             .filter(p => p.authorId === userId && p.systemGenerated !== true)
-            .sort((a, b) => (b.timestamp || b.createdAt || '').localeCompare(a.timestamp || a.createdAt || ''))
+            .sort((a, b) => toMs(b.timestamp || b.createdAt) -
+            toMs(a.timestamp || a.createdAt))
             .map(p => p.id);
     }
     else if (userId && board.id === 'my-quests') {
@@ -527,11 +488,9 @@ router.get('/:id/items', async (req, res) => {
             if (board.id === 'quest-board') {
                 if (p.type !== 'request')
                     return false;
-                if (p.boardId !== 'quest-board')
+                if (p.visibility === 'private')
                     return false;
-                return (p.visibility === 'public' ||
-                    p.visibility === 'request_board' ||
-                    p.needsHelp === true);
+                return true;
             }
             return true;
         }

--- a/ethos-backend/dist/tests/postgresPersistence.test.js
+++ b/ethos-backend/dist/tests/postgresPersistence.test.js
@@ -1,0 +1,94 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const supertest_1 = __importDefault(require("supertest"));
+const express_1 = __importDefault(require("express"));
+const postRoutes_1 = __importDefault(require("../src/routes/postRoutes"));
+const boardRoutes_1 = __importDefault(require("../src/routes/boardRoutes"));
+const db = __importStar(require("../src/db"));
+jest.mock('../src/middleware/authMiddleware', () => ({
+    authMiddleware: (_req, _res, next) => {
+        _req.user = { id: 'u1' };
+        next();
+    },
+}));
+db.usePg = true;
+const rows = {
+    posts: [],
+    boards: [
+        { id: 'quest-board', title: 'Quest Board', boardtype: 'post', layout: 'grid', items: [], featured: false },
+    ],
+    quests: [],
+};
+db.pool.query = jest.fn(async (text, params) => {
+    if (text.startsWith('INSERT INTO posts')) {
+        const [id, authorid, type, content, title, visibility, tags, boardid, timestamp] = params;
+        rows.posts.push({ id, authorid, type, content, title, visibility, tags, boardid, timestamp, createdat: timestamp });
+        return { rows: [] };
+    }
+    if (text.startsWith('UPDATE boards')) {
+        return { rows: [] };
+    }
+    if (text.startsWith('SELECT * FROM boards')) {
+        return { rows: rows.boards };
+    }
+    if (text.startsWith('SELECT * FROM posts')) {
+        return { rows: rows.posts };
+    }
+    if (text.startsWith('SELECT * FROM quests')) {
+        return { rows: rows.quests };
+    }
+    return { rows: [] };
+});
+const app = (0, express_1.default)();
+app.use(express_1.default.json());
+app.use('/posts', postRoutes_1.default);
+app.use('/boards', boardRoutes_1.default);
+describe('postgres persistence', () => {
+    it('shows request posts on quest board after refresh', async () => {
+        const postRes = await (0, supertest_1.default)(app)
+            .post('/posts')
+            .send({ type: 'request', content: 'Need help', visibility: 'public' });
+        expect(postRes.status).toBe(201);
+        const postId = postRes.body.id;
+        const boardRes = await (0, supertest_1.default)(app).get('/boards');
+        expect(boardRes.status).toBe(200);
+        const questBoard = boardRes.body.find((b) => b.id === 'quest-board');
+        expect(questBoard.items).toContain(postId);
+    });
+});

--- a/ethos-backend/src/routes/boardRoutes.ts
+++ b/ethos-backend/src/routes/boardRoutes.ts
@@ -32,22 +32,15 @@ const getQuestBoardQuests = (
     .map(q => q.id);
 };
 
-// Gather recent request posts for the quest board. Excludes the requesting user
-// and archived requests. Returns up to DEFAULT_PAGE_SIZE recent requests.
+// Gather recent request posts for the quest board. Returns up to DEFAULT_PAGE_SIZE
+// recent requests excluding archived or private ones.
 const getQuestBoardRequests = (
   posts: ReturnType<typeof postsStore.read>,
-  userId?: string
 ) => {
   return posts
-    .filter(p => p.type === 'request' && p.boardId === 'quest-board')
+    .filter(p => p.type === 'request')
+    .filter(p => p.visibility !== 'private')
     .filter(p => !p.tags?.includes('archived'))
-    .filter(
-      p =>
-        (p.visibility === 'public' ||
-          p.visibility === 'request_board' ||
-          p.needsHelp === true)
-    )
-    .filter(p => !userId || p.authorId !== userId)
     .sort((a, b) => toMs(b.timestamp) - toMs(a.timestamp))
     .slice(0, DEFAULT_PAGE_SIZE)
     .map(p => p.id);
@@ -132,6 +125,8 @@ router.get(
           ...r,
           authorId: r.authorid,
           createdAt: r.createdat,
+          boardId: r.boardid,
+          timestamp: r.timestamp,
         }));
         const quests: DBQuest[] = questsRes.rows.map((r: any) => ({
           ...r,
@@ -150,7 +145,7 @@ router.get(
           } else if (userId && b.id === 'my-quests') {
             b.items = quests.filter(q => q.authorId === userId).map(q => q.id);
           } else if (b.id === 'quest-board') {
-            b.items = getQuestBoardRequests(posts, userId);
+            b.items = getQuestBoardRequests(posts);
           } else if (b.id === 'timeline-board') {
             b.items = getTimelineBoardItems(posts, quests, userId).items;
           }
@@ -209,7 +204,7 @@ router.get(
       }
 
       if (board.id === 'quest-board') {
-        const items = getQuestBoardRequests(posts, userId);
+        const items = getQuestBoardRequests(posts);
         return { ...board, items };
       }
 
@@ -353,6 +348,8 @@ router.get(
             ...r,
             authorId: r.authorid,
             createdAt: r.createdat,
+            boardId: r.boardid,
+            timestamp: r.timestamp,
           }));
           const quests: DBQuest[] = questsRes.rows.map((r: any) => ({
             ...r,
@@ -388,7 +385,7 @@ router.get(
     let boardItems = board.items;
     let highlightMap: Record<string, boolean> = {};
     if (board.id === 'quest-board') {
-      boardItems = getQuestBoardRequests(posts, userId);
+      boardItems = getQuestBoardRequests(posts);
     } else if (board.id === 'timeline-board') {
       const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
       boardItems = items;
@@ -457,6 +454,8 @@ router.get(
           ...r,
           authorId: r.authorid,
           createdAt: r.createdat,
+          boardId: r.boardid,
+          timestamp: r.timestamp,
         }));
         const quests: DBQuest[] = questsRes.rows.map((r: any) => ({
           ...r,
@@ -468,7 +467,7 @@ router.get(
         let highlightMap: Record<string, boolean> = {};
 
         if (board.id === 'quest-board') {
-          boardItems = getQuestBoardRequests(posts, userId);
+          boardItems = getQuestBoardRequests(posts);
         } else if (board.id === 'timeline-board') {
           const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
           boardItems = items;
@@ -506,12 +505,8 @@ router.get(
               if (p.tags?.includes('archived')) return false;
               if (board.id === 'quest-board') {
                 if (p.type !== 'request') return false;
-                if (p.boardId !== 'quest-board') return false;
-                return (
-                  p.visibility === 'public' ||
-                  p.visibility === 'request_board' ||
-                  p.needsHelp === true
-                );
+                if (p.visibility === 'private') return false;
+                return true;
               }
               return true;
             }
@@ -551,7 +546,7 @@ router.get(
     let boardItems = board.items;
     let highlightMap: Record<string, boolean> = {};
     if (board.id === 'quest-board') {
-      boardItems = getQuestBoardRequests(posts, userId);
+      boardItems = getQuestBoardRequests(posts);
     } else if (board.id === 'timeline-board') {
       const { items, highlightMap: hm } = getTimelineBoardItems(posts, quests, userId);
       boardItems = items;
@@ -591,12 +586,8 @@ router.get(
           if (p.tags?.includes('archived')) return false;
           if (board.id === 'quest-board') {
             if (p.type !== 'request') return false;
-            if (p.boardId !== 'quest-board') return false;
-            return (
-              p.visibility === 'public' ||
-              p.visibility === 'request_board' ||
-              p.needsHelp === true
-            );
+            if (p.visibility === 'private') return false;
+            return true;
           }
           return true;
         }

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -248,8 +248,18 @@ router.post(
     if (usePg) {
       try {
         await pool.query(
-          'INSERT INTO posts (id, authorid, type, content, title) VALUES ($1, $2, $3, $4, $5)',
-          [newPost.id, newPost.authorId, newPost.type, newPost.content, newPost.title]
+          'INSERT INTO posts (id, authorid, type, content, title, visibility, tags, boardid, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+          [
+            newPost.id,
+            newPost.authorId,
+            newPost.type,
+            newPost.content,
+            newPost.title,
+            newPost.visibility,
+            newPost.tags,
+            effectiveBoardId,
+            newPost.timestamp,
+          ]
         );
         if (effectiveBoardId && effectiveBoardId !== 'quest-board') {
           await pool.query(

--- a/ethos-backend/tests/postgresPersistence.test.ts
+++ b/ethos-backend/tests/postgresPersistence.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import express from 'express';
+import postRoutes from '../src/routes/postRoutes';
+import boardRoutes from '../src/routes/boardRoutes';
+import * as db from '../src/db';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => {
+    _req.user = { id: 'u1' };
+    next();
+  },
+}));
+
+(db as any).usePg = true;
+const rows: any = {
+  posts: [] as any[],
+  boards: [
+    { id: 'quest-board', title: 'Quest Board', boardtype: 'post', layout: 'grid', items: [], featured: false },
+  ],
+  quests: [] as any[],
+};
+
+(db.pool as any).query = jest.fn(async (text: string, params?: any[]) => {
+  if (text.startsWith('INSERT INTO posts')) {
+    const [id, authorid, type, content, title, visibility, tags, boardid, timestamp] = params!;
+    rows.posts.push({ id, authorid, type, content, title, visibility, tags, boardid, timestamp, createdat: timestamp });
+    return { rows: [] };
+  }
+  if (text.startsWith('UPDATE boards')) {
+    return { rows: [] };
+  }
+  if (text.startsWith('SELECT * FROM boards')) {
+    return { rows: rows.boards };
+  }
+  if (text.startsWith('SELECT * FROM posts')) {
+    return { rows: rows.posts };
+  }
+  if (text.startsWith('SELECT * FROM quests')) {
+    return { rows: rows.quests };
+  }
+  return { rows: [] };
+});
+
+const app = express();
+app.use(express.json());
+app.use('/posts', postRoutes);
+app.use('/boards', boardRoutes);
+
+describe('postgres persistence', () => {
+  it('shows request posts on quest board after refresh', async () => {
+    const postRes = await request(app)
+      .post('/posts')
+      .send({ type: 'request', content: 'Need help', visibility: 'public' });
+    expect(postRes.status).toBe(201);
+    const postId = postRes.body.id;
+
+    const boardRes = await request(app).get('/boards');
+    expect(boardRes.status).toBe(200);
+    const questBoard = boardRes.body.find((b: any) => b.id === 'quest-board');
+    expect(questBoard.items).toContain(postId);
+  });
+});

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -451,7 +451,7 @@ describe('route handlers', () => {
     postsStoreMock.read.mockReturnValue([
       {
         id: 'r1', authorId: 'u2', type: 'request', content: '', visibility: 'public',
-        timestamp: '2024-01-02', boardId: 'quest-board', tags: [], collaborators: [], linkedItems: []
+        timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
       },
       {
         id: 't1', authorId: 'u2', type: 'task', content: '', visibility: 'public',


### PR DESCRIPTION
## Summary
- show request posts on the quest board regardless of boardId or author
- allow non-private requests to appear on quest board and timeline board
- persist request posts in PostgreSQL so they remain visible after refresh
- add test ensuring quest board returns request posts

## Testing
- `npm test --prefix ethos-backend`
- `npm test --prefix ethos-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68995284d0d0832f8589173172b159ed