### PR TITLE
Allow change posts to reply to prior changes

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -183,8 +183,24 @@ router.post(
         return;
       }
     } else if (type === 'change') {
+      const parentIsValid =
+        parent && ['task', 'request', 'change'].includes(parent.type);
+
       if (
-        linkedPosts.length === 0 ||
+        linkedPosts.length === 0 &&
+        !parentIsValid
+      ) {
+        res
+          .status(400)
+          .json({
+            error:
+              'Changes must link to a task or request, or reply to an existing change',
+          });
+        return;
+      }
+
+      if (
+        linkedPosts.length > 0 &&
         !linkedPosts.every((p: DBPost) => p.type === 'task' || p.type === 'request')
       ) {
         res

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -58,21 +58,46 @@ describe('post routes', () => {
     expect(res.status).toBe(400);
   });
 
-  it('allows change post linked to task', async () => {
-    const task = {
-      id: 't1',
-      authorId: 'u1',
-      type: 'task',
-      content: '',
-      visibility: 'public',
-      timestamp: '',
-    };
-    postsStoreMock.read.mockReturnValue([task]);
-    const res = await request(app)
-      .post('/posts')
-      .send({ type: 'change', linkedItems: [{ itemId: 't1', itemType: 'post' }] });
-    expect(res.status).toBe(201);
-  });
+    it('allows change post linked to task', async () => {
+      const task = {
+        id: 't1',
+        authorId: 'u1',
+        type: 'task',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+      };
+      postsStoreMock.read.mockReturnValue([task]);
+      const res = await request(app)
+        .post('/posts')
+        .send({ type: 'change', linkedItems: [{ itemId: 't1', itemType: 'post' }] });
+      expect(res.status).toBe(201);
+    });
+
+    it('allows change post replying to a change', async () => {
+      const task = {
+        id: 't1',
+        authorId: 'u1',
+        type: 'task',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+      };
+      const parentChange = {
+        id: 'c1',
+        authorId: 'u1',
+        type: 'change',
+        content: '',
+        visibility: 'public',
+        timestamp: '',
+        linkedItems: [{ itemId: 't1', itemType: 'post' }],
+      };
+      postsStoreMock.read.mockReturnValue([task, parentChange]);
+      const res = await request(app)
+        .post('/posts')
+        .send({ type: 'change', replyTo: 'c1' });
+      expect(res.status).toBe(201);
+    });
 
   it('rejects task linked to change', async () => {
     const change = {

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -99,7 +99,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       autoLinkItems.push({ itemId: questIdFromBoard, itemType: 'quest' });
     }
 
-    const validation = validateLinks(type, autoLinkItems);
+    const validation = validateLinks(type, autoLinkItems, !!replyTo);
     if (!validation.valid) {
       alert(validation.message);
       setIsSubmitting(false);
@@ -345,7 +345,11 @@ function showLinkControls(type: PostType): boolean {
   return ['request', 'task', 'change', 'review'].includes(type);
 }
 
-function validateLinks(type: PostType, items: LinkedItem[]): {
+function validateLinks(
+  type: PostType,
+  items: LinkedItem[],
+  hasParent: boolean = false
+): {
   valid: boolean;
   message?: string;
 } {
@@ -360,7 +364,7 @@ function validateLinks(type: PostType, items: LinkedItem[]): {
     case 'task':
       return { valid: true };
     case 'change':
-      return items.some(i => i.itemType === 'post')
+      return hasParent || items.some(i => i.itemType === 'post')
         ? { valid: true }
         : { valid: false, message: 'Please link a task or request before submitting.' };
     case 'review':


### PR DESCRIPTION
## Summary
- permit change posts without explicit links when replying to an existing change/task/request
- relax frontend validation so replies to changes can be submitted
- add backend test for change replies

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ef5bd85c832fb17f5706f36fda14