### PR TITLE
Fix disappearing request posts after refresh

### DIFF
--- a/ethos-backend/src/utils/enrich.ts
+++ b/ethos-backend/src/utils/enrich.ts
@@ -284,10 +284,13 @@ export const enrichBoard = (
     .filter((item) => {
       if ('type' in item) {
         const p = item as DBPost;
-        return p.type !== 'request' ||
-          p.visibility === 'public' ||
-          p.visibility === 'request_board' ||
-          p.needsHelp === true;
+        const visibility = (p.visibility || '').toLowerCase();
+        return (
+          p.type !== 'request' ||
+          visibility === 'public' ||
+          visibility === 'request_board' ||
+          p.needsHelp === true
+        );
       }
       const q = item as DBQuest;
       if (q.displayOnBoard === false) return false;
@@ -318,10 +321,13 @@ export const enrichBoard = (
     .filter((item) => {
       if ('type' in item) {
         const p = item as EnrichedPost;
-        return p.type !== 'request' ||
-          p.visibility === 'public' ||
-          p.visibility === 'request_board' ||
-          p.needsHelp === true;
+        const visibility = (p.visibility || '').toLowerCase();
+        return (
+          p.type !== 'request' ||
+          visibility === 'public' ||
+          visibility === 'request_board' ||
+          p.needsHelp === true
+        );
       }
       const q = item as EnrichedQuest;
       if (q.displayOnBoard === false) return false;

--- a/ethos-backend/tests/enrichBoardRequestVisibility.test.ts
+++ b/ethos-backend/tests/enrichBoardRequestVisibility.test.ts
@@ -1,0 +1,30 @@
+import { enrichBoard } from '../src/utils/enrich';
+import type { DBBoard, DBPost } from '../src/types/db';
+
+describe('enrichBoard request visibility', () => {
+  it('keeps request posts with uppercase visibility', () => {
+    const board: DBBoard = {
+      id: 'quest-board',
+      title: 'Quest',
+      boardType: 'post',
+      layout: 'grid',
+      items: ['p1'],
+      createdAt: '',
+    } as DBBoard;
+
+    const posts: DBPost[] = [
+      {
+        id: 'p1',
+        authorId: 'u1',
+        type: 'request',
+        content: '',
+        visibility: 'PUBLIC' as any,
+        timestamp: '',
+      },
+    ];
+
+    const enriched = enrichBoard(board, { posts, quests: [] });
+    expect(enriched.enrichedItems).toHaveLength(1);
+    expect(enriched.enrichedItems[0].id).toBe('p1');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize request post visibility in board enrichment
- add regression test for uppercase visibility

## Testing
- `cd ethos-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689adc15887c832f8a77491d65faa7db