### PR TITLE
Fix guest username summary tags

### DIFF
--- a/ethos-backend/src/utils/enrich.ts
+++ b/ethos-backend/src/utils/enrich.ts
@@ -133,8 +133,14 @@ export const enrichPosts = (
     const enrichedAuthor = author
       ? enrichUser(author, { currentUserId })
       : {
-          id: 'anon',
-          username: 'Anonymous',
+          // When a post's author cannot be found in the user store, we still
+          // want to surface whatever identifier the post carries. Many posts
+          // are created by guests with a randomly generated username stored in
+          // `authorId`. Previously these posts were enriched with a static
+          // "Anonymous" user which caused summary tags to display "Anonymous"
+          // instead of the guest's assigned name.
+          id: post.authorId,
+          username: post.authorId,
           bio: '',
           tags: [],
           links: {},

--- a/ethos-backend/tests/enrichPosts.test.ts
+++ b/ethos-backend/tests/enrichPosts.test.ts
@@ -1,0 +1,18 @@
+import { enrichPosts } from '../src/utils/enrich';
+import type { DBPost } from '../src/types/db';
+
+describe('enrichPosts author fallback', () => {
+  it('uses authorId as username when user record is missing', () => {
+    const posts: DBPost[] = [{
+      id: 'p1',
+      authorId: 'guest-123',
+      type: 'free_speech',
+      content: 'Hello',
+      visibility: 'public',
+      timestamp: '',
+    }];
+    const result = enrichPosts(posts, [], []);
+    expect(result[0].author).toBeDefined();
+    expect(result[0].author?.username).toBe('guest-123');
+  });
+});


### PR DESCRIPTION
## Summary
- keep guest usernames when enriching posts so summary tags show the right author
- cover enrichPosts author fallback with a unit test

## Testing
- `npx jest -c ethos-backend/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_689b14400508832fabdf1c6205172451