### PR TITLE
feat: allow task or change requests

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -135,6 +135,9 @@ export interface Post {
   /** Whether this request still needs help */
   needsHelp?: boolean;
 
+  /** Pointer to a generated request post */
+  requestId?: string;
+
   /** UI hint used when a post is part of a highlighted task path */
   highlight?: boolean;
 }

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -58,6 +58,9 @@ export interface DBPost {
   /** Whether this request still needs help */
   needsHelp?: boolean;
 
+  /** Pointer to a generated request post */
+  requestId?: string;
+
   questId?: string | null;
   questNodeTitle?: string;
   nodeId?: string;

--- a/ethos-backend/tests/enrichBoardRequestVisibility.test.ts
+++ b/ethos-backend/tests/enrichBoardRequestVisibility.test.ts
@@ -17,6 +17,7 @@ describe('enrichBoard request visibility', () => {
         id: 'p1',
         authorId: 'u1',
         type: 'request',
+        subtype: 'task',
         content: '',
         visibility: 'PUBLIC' as any,
         timestamp: '',

--- a/ethos-backend/tests/postgresPersistence.test.ts
+++ b/ethos-backend/tests/postgresPersistence.test.ts
@@ -50,7 +50,7 @@ describe('postgres persistence', () => {
   it('shows request posts on quest board after refresh', async () => {
     const postRes = await request(app)
       .post('/posts')
-      .send({ type: 'request', content: 'Need help', visibility: 'public' });
+      .send({ type: 'request', subtype: 'task', content: 'Need help', visibility: 'public' });
     expect(postRes.status).toBe(201);
     const postId = postRes.body.id;
 

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -450,7 +450,7 @@ describe('route handlers', () => {
     ]);
     postsStoreMock.read.mockReturnValue([
       {
-        id: 'r1', authorId: 'u2', type: 'request', content: '', visibility: 'public',
+        id: 'r1', authorId: 'u2', type: 'request', subtype: 'task', content: '', visibility: 'public',
         timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
       },
       {
@@ -473,7 +473,7 @@ describe('route handlers', () => {
     ]);
     postsStoreMock.read.mockReturnValue([
       {
-        id: 'r1', authorId: 'u1', type: 'request', content: '', visibility: 'public',
+        id: 'r1', authorId: 'u1', type: 'request', subtype: 'task', content: '', visibility: 'public',
         timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
       },
       {
@@ -497,7 +497,7 @@ describe('route handlers', () => {
     ]);
     postsStoreMock.read.mockReturnValue([
       {
-        id: 'r1', authorId: 'u1', type: 'request', content: '', visibility: 'public',
+        id: 'r1', authorId: 'u1', type: 'request', subtype: 'task', content: '', visibility: 'public',
         timestamp: '2024-01-02', boardId: '', tags: [], collaborators: [], linkedItems: []
       }
     ]);


### PR DESCRIPTION
## Summary
- require request posts to declare subtype `task` or `change`
- tag requests with post type and author summary labels
- link source posts to generated request via `requestId`

## Testing
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_689b1892d2f0832fb925b751fed55c83