### PR TITLE
Assign T00 nodeId to standalone tasks

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -273,7 +273,12 @@ router.post(
       status: finalStatus,
       helpRequest: type === 'request' || helpRequest,
       needsHelp: type === 'request' ? needsHelp ?? true : undefined,
-      nodeId: quest ? generateNodeId({ quest, posts, postType: type, parentPost: parent }) : undefined,
+      nodeId:
+        quest
+          ? generateNodeId({ quest, posts, postType: type, parentPost: parent })
+          : type === 'task' && !replyTo
+            ? 'T00'
+            : undefined,
       boardId: effectiveBoardId,
     };
 
@@ -436,7 +441,9 @@ router.patch(
             postType: post.type,
             parentPost: parent,
           })
-        : undefined;
+        : post.type === 'task' && !post.replyTo
+          ? 'T00'
+          : undefined;
     }
 
     postsStore.write(posts);

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -39,6 +39,15 @@ describe('post routes', () => {
     expect(res.body.content).toBe('hello');
   });
 
+  it('assigns nodeId T00 to tasks without quest or parent', async () => {
+    postsStoreMock.read.mockReturnValue([]);
+    const res = await request(app)
+      .post('/posts')
+      .send({ type: 'task', content: 'root task' });
+    expect(res.status).toBe(201);
+    expect(res.body.nodeId).toBe('T00');
+  });
+
   it('rejects linking free speech posts', async () => {
     postsStoreMock.read.mockReturnValue([
       { id: 't1', authorId: 'u1', type: 'task', content: '', visibility: 'public', timestamp: '' },


### PR DESCRIPTION
## Summary
- Set nodeId to `T00` when creating a task without a quest or parent, marking it as a new quest root.
- Preserve `T00` nodeId on updates unless the task is linked to a quest or parent.
- Add test covering questless task creation.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b52d0e110832fb32713d796d8c642