### PR TITLE
feat: support secondary post type tags

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -455,8 +455,8 @@ const Board: React.FC<BoardProps> = ({
               onCancel={() => setShowCreateForm(false)}
               boardId={board.id}
               initialType={
-                (localFilter.postType ||
-                  (board.id === 'quest-board' ? 'request' : 'free_speech')) as PostType
+                localFilter.postType ||
+                (board.id === 'quest-board' ? 'request' : 'free_speech')
               }
             />
           )}

--- a/ethos-frontend/src/components/contribution/ContributionCard.tsx
+++ b/ethos-frontend/src/components/contribution/ContributionCard.tsx
@@ -73,7 +73,7 @@ const ContributionCard: React.FC<ContributionCardProps> = ({
   // ✅ Render Post types
   if ('type' in contribution) {
     const post = contribution as Post;
-    if (post.type === 'request' && boardId === 'quest-board') {
+    if (post.tags?.includes('request') && boardId === 'quest-board') {
       return <RequestCard post={post as EnrichedPost} onUpdate={onEdit ? (p) => onEdit(p.id) : undefined} />;
     }
     return (

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -32,7 +32,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
   const [newTitle, setNewTitle] = useState('');
   const [search, setSearch] = useState('');
   const [postTypeFilter, setPostTypeFilter] =
-    useState<'all' | PostType>('all');
+    useState<'all' | PostType | 'request' | 'review'>('all');
   const [sortBy, setSortBy] = useState<'label' | 'node'>('label');
 
   const linkTypes = [
@@ -142,7 +142,11 @@ const LinkControls: React.FC<LinkControlsProps> = ({
   };
 
   const filteredPosts = posts.filter(
-    (p) => postTypeFilter === 'all' || p.type === postTypeFilter
+    (p) =>
+      postTypeFilter === 'all' ||
+      p.type === postTypeFilter ||
+      (postTypeFilter === 'request' && p.tags?.includes('request')) ||
+      (postTypeFilter === 'review' && p.tags?.includes('review'))
   );
   type Option = { value: string; label: string; nodeId?: string; type?: string };
   const allOptions: Option[] = [
@@ -184,12 +188,12 @@ const LinkControls: React.FC<LinkControlsProps> = ({
         <> 
           {itemTypes.includes('post') && (
             <div className="flex gap-1 mb-1 flex-wrap">
-              {['all', 'free_speech', 'request', 'task', 'change', 'review'].map((t) => (
+              {['all', 'free_speech', 'task', 'change', 'request', 'review'].map((t) => (
                 <button
                   key={t}
                   type="button"
                   onClick={() =>
-                    setPostTypeFilter(t as 'all' | PostType)
+                    setPostTypeFilter(t as 'all' | PostType | 'request' | 'review')
                   }
                   className={`text-xs px-2 py-0.5 rounded ${
                     postTypeFilter === t

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -103,9 +103,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const isTimelineBoard = isTimeline ?? ctxBoardId === 'timeline-board';
   const isPostHistory = ctxBoardId === 'my-posts';
   const isPostBoard = isPostHistory || ctxBoardType === 'post';
-  const isQuestRequest = ctxBoardId === 'quest-board' && post.type === 'request';
+  const isQuestRequest = ctxBoardId === 'quest-board' && post.tags?.includes('request');
   const isRequestCard =
-    post.type === 'request' && ctxBoardId === 'quest-board';
+    post.tags?.includes('request') && ctxBoardId === 'quest-board';
   const roleTag = post.tags?.find(t => t.toLowerCase().startsWith('role:'));
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
   const expanded = expandedProp !== undefined ? expandedProp : internalExpanded;
@@ -234,10 +234,10 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const handleJoin = async () => {
     if (!user) return;
     const joinAndNavigate =
-      ctxBoardId === 'my-posts' && post.type === 'request' && post.questId && roleTag;
+      ctxBoardId === 'my-posts' && post.tags?.includes('request') && post.questId && roleTag;
     if (joinAndNavigate) {
       const isPrivate = post.visibility === 'private';
-      const type: PostType = isPrivate ? 'request' : 'free_speech';
+      const type = isPrivate ? 'request' : 'free_speech';
       navigate(
         ROUTES.POST(post.id) + `?reply=1&initialType=${type}&intro=1`
       );
@@ -347,7 +347,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           )
         )}
 
-        {['task', 'request'].includes(post.type) && !isRequestCard && !joined && (
+        {(post.type === 'task' || post.tags?.includes('request')) && !isRequestCard && !joined && (
           <button className="flex items-center gap-1" onClick={handleFollow} disabled={!user}>
             <FaBell /> {following ? 'Following' : 'Follow'} {followerCount}
           </button>
@@ -377,7 +377,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
               if (replyOverride) {
                 replyOverride.onClick();
               } else if (
-                post.type === 'request' ||
+                post.tags?.includes('request') ||
                 isTimelineBoard ||
                 isPostBoard
               ) {

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
-import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
+import { POST_TYPES, STATUS_OPTIONS, SECONDARY_POST_TYPES } from '../../constants/options';
 import { addPost } from '../../api/post';
 import { Button, Select, Label, FormSection, Input, MarkdownEditor } from '../ui';
 import CollaberatorControls from '../controls/CollaberatorControls';
@@ -16,7 +16,7 @@ type CreatePostProps = {
   replyTo?: Post | null;
   repostSource?: Post | null;
   /** Set an initial post type value */
-  initialType?: PostType;
+  initialType?: PostType | 'request' | 'review';
   /**
    * Optional quest ID to automatically link the post to.
    * Useful when creating quest tasks or logs from a quest board.
@@ -47,11 +47,20 @@ const CreatePost: React.FC<CreatePostProps> = ({
 }) => {
   const restrictedReply = !!replyTo;
 
+  const [secondaryType, setSecondaryType] = useState<'' | 'request' | 'review'>(
+    initialType === 'request' ? 'request' : initialType === 'review' ? 'review' : ''
+  );
   const [type, setType] = useState<PostType>(
-    restrictedReply ? 'free_speech' : initialType
+    restrictedReply
+      ? 'free_speech'
+      : initialType === 'request'
+      ? 'task'
+      : initialType === 'review'
+      ? 'change'
+      : initialType
   );
   const [status, setStatus] = useState<string>(
-    initialType === 'request' ? 'In Progress' : 'To Do'
+    secondaryType === 'request' ? 'In Progress' : 'To Do'
   );
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>(initialContent || '');
@@ -59,7 +68,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [helpRequest, setHelpRequest] = useState(boardId === 'quest-board');
+  const [helpRequest, setHelpRequest] = useState(boardId === 'quest-board' || secondaryType === 'request');
   const [rating, setRating] = useState(0);
 
 const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
@@ -67,15 +76,19 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   const boardType: BoardType | undefined =
     boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
 
-  const allowedPostTypes: PostType[] = restrictedReply
+  let allowedPostTypes: PostType[] = restrictedReply
     ? ['free_speech']
     : boardId === 'quest-board'
-    ? ['request']
+    ? ['task', 'change']
     : boardType === 'quest'
     ? ['task', 'free_speech']
     : boardType === 'post'
-    ? ['free_speech', 'request', 'review', 'change']
+    ? ['free_speech', 'task', 'change']
     : POST_TYPES.map((p) => p.value as PostType);
+
+  if (secondaryType) {
+    allowedPostTypes = ['task', 'change'];
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -88,7 +101,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       ? boardQuestMatch[1]
       : questId || replyTo?.questId || null;
 
-    if (type === 'review' && rating === 0) {
+    if (secondaryType === 'review' && rating === 0) {
       alert('Please provide a rating.');
       setIsSubmitting(false);
       return;
@@ -99,7 +112,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       autoLinkItems.push({ itemId: questIdFromBoard, itemType: 'quest' });
     }
 
-    const validation = validateLinks(type, autoLinkItems, !!replyTo);
+    const validation = validateLinks(type, autoLinkItems, !!replyTo, secondaryType);
     if (!validation.valid) {
       alert(validation.message);
       setIsSubmitting(false);
@@ -108,13 +121,14 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
       const payload: Partial<Post> = {
         type,
+        secondaryType: secondaryType || undefined,
         title: type === 'task' ? content : title || undefined,
         content,
         ...(type === 'task' && details ? { details } : {}),
         visibility: 'public',
         linkedItems: autoLinkItems,
-        helpRequest: type === 'request' || helpRequest || undefined,
-        ...(type === 'task' || type === 'request'
+        helpRequest: secondaryType === 'request' || helpRequest || undefined,
+        ...(type === 'task' || secondaryType === 'request'
           ? { status }
           : {}),
         ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
@@ -133,7 +147,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
             }
           : {}),
         ...(requiresQuestRoles(type) && { collaborators }),
-        ...(type === 'review' && rating ? { rating } : {}),
+        ...(secondaryType === 'review' && rating ? { rating } : {}),
       };
 
     try {
@@ -183,14 +197,35 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           onChange={(e) => {
             const val = e.target.value as PostType;
             setType(val);
-            if (val === 'task') setStatus('To Do');
-            else if (val === 'request') setStatus('In Progress');
+            if (val === 'task') setStatus(secondaryType === 'request' ? 'In Progress' : 'To Do');
+            if (val === 'free_speech') setSecondaryType('');
           }}
           options={allowedPostTypes.map((t) => {
             const opt = POST_TYPES.find((o) => o.value === t)!;
             return { value: opt.value, label: opt.label };
           })}
         />
+
+        {type !== 'free_speech' && (
+          <>
+            <Label htmlFor="secondary-type">Tag</Label>
+            <Select
+              id="secondary-type"
+              value={secondaryType}
+              onChange={(e) => {
+                const val = e.target.value as '' | 'request' | 'review';
+                setSecondaryType(val);
+                if (val === 'request') {
+                  setStatus('In Progress');
+                  setHelpRequest(true);
+                } else if (secondaryType === 'request') {
+                  setHelpRequest(boardId === 'quest-board');
+                }
+              }}
+              options={[{ value: '', label: 'None' }, ...SECONDARY_POST_TYPES]}
+            />
+          </>
+        )}
 
         {type === 'task' && (
           <>
@@ -213,7 +248,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
               onChange={(e) => setTitle(e.target.value)}
               required={type !== 'free_speech'}
             />
-            {type === 'review' && (
+            {secondaryType === 'review' && (
               <div className="mt-2">
                 <Label>Rating</Label>
                 <div className="flex space-x-1">
@@ -342,13 +377,14 @@ function requiresQuestRoles(type: PostType): boolean {
 }
 
 function showLinkControls(type: PostType): boolean {
-  return ['request', 'task', 'change', 'review'].includes(type);
+  return ['task', 'change'].includes(type);
 }
 
 function validateLinks(
   type: PostType,
   items: LinkedItem[],
-  hasParent: boolean = false
+  hasParent: boolean = false,
+  _secondaryType?: string,
 ): {
   valid: boolean;
   message?: string;
@@ -358,17 +394,10 @@ function validateLinks(
       return items.some(i => i.itemType === 'post')
         ? { valid: false, message: 'Free speech posts cannot have links.' }
         : { valid: true };
-    case 'request':
-      // Requests no longer require a linked task
-      return { valid: true };
-    case 'task':
-      return { valid: true };
     case 'change':
       return hasParent || items.some(i => i.itemType === 'post')
         ? { valid: true }
         : { valid: false, message: 'Please link a task or request before submitting.' };
-    case 'review':
-      return { valid: true };
     default:
       return { valid: true };
   }

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -200,5 +200,5 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
 export default EditPost;
 
 function showLinkControls(type: PostType): boolean {
-  return ['request', 'task', 'change', 'review'].includes(type);
+  return ['task', 'change'].includes(type);
 }

--- a/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
@@ -35,12 +35,12 @@ afterAll(() => {
 const post: Post = {
   id: 'p1',
   authorId: 'u1',
-  type: 'request',
+  type: 'task',
   content: 'Help me',
   status: 'In Progress',
   visibility: 'public',
   timestamp: '2023-01-01T00:00:00Z',
-  tags: [],
+  tags: ['request'],
   collaborators: [],
   linkedItems: [],
 } as unknown as Post;

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -13,11 +13,11 @@ jest.mock('../../api/post', () => ({
       request: {
         id: 'r1',
         authorId: 'u1',
-        type: 'request',
+        type: 'task',
         content: 'Task',
         visibility: 'public',
         timestamp: '',
-        tags: [],
+        tags: ['request'],
         collaborators: [],
         linkedItems: [],
       },

--- a/ethos-frontend/src/components/post/PostCard.review.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.review.test.tsx
@@ -27,12 +27,12 @@ describe('PostCard review rating', () => {
     const post: Post = {
       id: 'r1',
       authorId: 'u1',
-      type: 'review',
+      type: 'change',
       content: 'Great quest',
       rating: 4.5,
       visibility: 'public',
       timestamp: '',
-      tags: [],
+      tags: ['review'],
       collaborators: [],
       linkedItems: [],
     } as unknown as Post;

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -148,7 +148,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const ctxBoardId = boardId || selectedBoard;
 
   const isQuestBoardRequest =
-    post.type === 'request' && ctxBoardId === 'quest-board';
+    post.tags?.includes('request') && ctxBoardId === 'quest-board';
 
   const widthClass =
     ctxBoardId === 'timeline-board' || ctxBoardId === 'my-posts'
@@ -313,7 +313,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const renderLinkSummary = () => {
     if (
-      post.type === 'request' ||
+      post.tags?.includes('request') ||
       (!showDetails && (!post.linkedItems || post.linkedItems.length === 0))
     ) {
       return null;
@@ -423,7 +423,7 @@ const PostCard: React.FC<PostCardProps> = ({
                 />
               </React.Fragment>
             ))}
-            {post.type === 'review' && post.rating && renderStars(post.rating)}
+            {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
           </div>
           <div className="flex items-center gap-2">
             {post.type === 'task' && (
@@ -500,10 +500,10 @@ const PostCard: React.FC<PostCardProps> = ({
               />
             </React.Fragment>
           ))}
-          {post.type === 'review' && post.rating && renderStars(post.rating)}
+          {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
           {!isQuestBoardRequest &&
             canEdit &&
-            ['task', 'request'].includes(post.type) &&
+            (post.type === 'task' || post.tags?.includes('request')) &&
             showStatusControl && (
             <div className="ml-1 w-28">
               <Select
@@ -515,7 +515,7 @@ const PostCard: React.FC<PostCardProps> = ({
           )}
         </div>
         <div className="flex items-center gap-2">
-          {post.type === 'task' && (
+        {post.type === 'task' && (
             <button
               className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400"
               onClick={() =>
@@ -663,7 +663,7 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {['request','task','free_speech','change','review'].includes(post.type) && (
+      {( ['task','free_speech','change'].includes(post.type) || post.tags?.some(t => ['request','review'].includes(t)) ) && (
         <div className="text-xs text-secondary space-y-1">
           {showLinkEditor && (
             <div className="mt-2">

--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -59,7 +59,8 @@ describe('PostListItem', () => {
     const reviewPost: PostWithQuestTitle = {
       ...basePost,
       id: 'r1',
-      type: 'review',
+      type: 'change',
+      tags: ['review'],
       questId: 'q2',
       questTitle: 'Quest B',
     } as unknown as PostWithQuestTitle;
@@ -78,7 +79,8 @@ describe('PostListItem', () => {
     const reviewPost: PostWithQuestTitle = {
       ...basePost,
       id: 'r2',
-      type: 'review',
+      type: 'change',
+      tags: ['review'],
     } as unknown as PostWithQuestTitle;
 
     render(

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -49,7 +49,7 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
             {summaryTags.map((tag, idx) => (
               <SummaryTag key={idx} {...tag} />
             ))}
-            {post.type === 'review' && post.rating && renderStars(post.rating)}
+            {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
           </div>
         </div>
         {timestamp && (

--- a/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
@@ -34,7 +34,7 @@ const ActiveQuestsBoard: React.FC = () => {
           if (!involved) continue;
 
           questPosts.forEach(p => {
-            if ((p.type === 'free_speech' && p.replyTo) || p.type === 'change' || p.type === 'review' || p.authorId === user.id) {
+            if ((p.type === 'free_speech' && p.replyTo) || p.type === 'change' || p.tags?.includes('review') || p.authorId === user.id) {
               postsMap.set(p.id, p);
             }
           });

--- a/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
+++ b/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
@@ -48,7 +48,7 @@ const NODE_STYLES: Record<NodeVisualType, NodeStyle> = {
 };
 
 export function getNodeVisualType(post: Post): NodeVisualType {
-  if (post.type === 'request') {
+  if (post.tags?.includes('request')) {
     return post.needsHelp === false ? 'request-accepted' : 'request-open';
   }
   if (post.type === 'task') return 'task';

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -26,9 +26,12 @@ export const BOARD_TYPE_OPTIONS: { value: BoardType; label: string }[] = [
 
 export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },
-  { value: 'request', label: 'Request' },
   { value: 'task', label: 'Task' },
   { value: 'change', label: 'Change' },
+];
+
+export const SECONDARY_POST_TYPES = [
+  { value: 'request', label: 'Request' },
   { value: 'review', label: 'Review' },
 ];
 

--- a/ethos-frontend/src/pages/board/[boardType].tsx
+++ b/ethos-frontend/src/pages/board/[boardType].tsx
@@ -34,7 +34,7 @@ const BoardTypePage: React.FC = () => {
           }
         } else if (boardType === 'requests') {
           const posts = await fetchAllPosts();
-          setItems(posts.filter(p => p.type === 'request' || p.helpRequest));
+          setItems(posts.filter(p => p.tags?.includes('request') || p.helpRequest));
         } else {
           setItems([]);
         }

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -68,7 +68,7 @@ const PostPage: React.FC = () => {
   }, [searchParams]);
 
   useEffect(() => {
-    if (post?.type === 'review' && post.replyTo) {
+    if (post?.tags?.includes('review') && post.replyTo) {
       fetchPostById(post.replyTo)
         .then(setParentPost)
         .catch(() => setParentPost(null));
@@ -181,7 +181,7 @@ const PostPage: React.FC = () => {
       </section>
 
       <section>
-        {post.type === 'request' && taskBoard && (
+        {post.tags?.includes('request') && taskBoard && (
           <Board
             boardId={`tasks-${id}`}
             board={taskBoard}
@@ -203,7 +203,7 @@ const PostPage: React.FC = () => {
         {post.type === 'change' && post.questId && (
           <GitFileBrowserInline questId={post.questId} />
         )}
-        {post.type === 'review' && parentPost && (
+        {post.tags?.includes('review') && parentPost && (
           <PostCard post={parentPost} />
         )}
       </section>

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -13,6 +13,8 @@ export interface Post {
   };
 
   type: PostType;
+  /** Optional secondary classification such as request or review */
+  secondaryType?: 'request' | 'review';
   subtype?: string;
   /** Short header for the post */
   title?: string;
@@ -186,10 +188,8 @@ export type QuestTaskStatus = 'To Do' | 'In Progress' | 'Blocked' | 'Done' | str
  */
 export type PostType =
   | 'free_speech'
-  | 'request'
   | 'task'
-  | 'change'
-  | 'review';
+  | 'change';
   
 /**
  * Supported tags for labeling and filtering posts.
@@ -207,6 +207,7 @@ export type PostTag =
   | 'quest'
   | 'task'
   | 'issue'
+  | 'request'
   | 'review'
   | string;
 

--- a/ethos-frontend/src/utils/boardUtils.ts
+++ b/ethos-frontend/src/utils/boardUtils.ts
@@ -71,7 +71,7 @@ export const getRenderableBoardItems = (
     if (!('headPostId' in item)) {
       const post = item as Post;
       // Allow request posts to always render even if a linked quest is present
-      if (post.type !== 'request') {
+      if (!post.tags?.includes('request')) {
         const questId = post.questId;
         const linkedQuest = post.linkedItems?.find(
           (l: LinkedItem) => l.itemType === 'quest' && questIds.has(l.itemId)

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -6,11 +6,11 @@ import type { SummaryTagType } from "../components/ui/SummaryTag";
 export const toTitleCase = (str: string): string =>
   str.replace(/\b([a-z])/g, (c) => c.toUpperCase());
 
-export const POST_TYPE_LABELS: Record<PostType, string> = {
+export const POST_TYPE_LABELS: Record<PostType | 'request' | 'review', string> = {
   free_speech: "Free Speech",
-  request: "Request",
   task: "Task",
   change: "Change",
+  request: "Request",
   review: "Review",
 };
 
@@ -115,10 +115,16 @@ export const buildSummaryTags = (
   if (post.type === 'free_speech') {
     primaryType = post.replyTo ? 'log' : 'free_speech';
     primaryLabel = post.replyTo ? 'Log' : 'Free Speech';
-  } else if (post.type === 'request') {
-    primaryLabel = post.subtype ? `${toTitleCase(post.subtype)} Request` : 'Request';
   }
   tags.push({ type: primaryType as SummaryTagType, label: primaryLabel, detailLink: ROUTES.POST(post.id) });
+
+  if (post.tags?.includes('request')) {
+    tags.push({ type: 'request', label: 'Request' });
+  }
+
+  if (post.tags?.includes('review')) {
+    tags.push({ type: 'review', label: 'Review' });
+  }
 
   // Quest association tag
   if (!multipleSources && title) {

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -54,11 +54,11 @@ describe.skip('accept request button', () => {
   const post = {
     id: 'p1',
     authorId: 'u2',
-    type: 'request',
+    type: 'task',
     content: 'help me',
     visibility: 'public',
     timestamp: '',
-    tags: [],
+    tags: ['request'],
     collaborators: [],
     linkedItems: [],
   } as Post;

--- a/ethos-frontend/tests/BoardUtilsRequestPosts.test.ts
+++ b/ethos-frontend/tests/BoardUtilsRequestPosts.test.ts
@@ -7,11 +7,11 @@ const quest = { id: 'q1', headPostId: 'hp1' } as unknown as Quest;
 const requestPost = {
   id: 'p1',
   authorId: 'u1',
-  type: 'request',
+  type: 'task',
   content: 'need help',
   visibility: 'public',
   timestamp: '',
-  tags: [],
+  tags: ['request'],
   collaborators: [],
   linkedItems: [],
   questId: 'q1',

--- a/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
+++ b/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
@@ -41,8 +41,7 @@ describe('CreatePost request without task', () => {
         <CreatePost onCancel={() => {}} initialType="request" />
       </BrowserRouter>
     );
-    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Need help' } });
-    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Assist me' } });
+    fireEvent.change(screen.getByLabelText('Task Title'), { target: { value: 'Need help' } });
     fireEvent.click(screen.getByText('Create Post'));
     await waitFor(() => expect(addPost).toHaveBeenCalled());
     expect(window.alert).not.toHaveBeenCalled();

--- a/ethos-frontend/tests/RequestPostRendering.test.tsx
+++ b/ethos-frontend/tests/RequestPostRendering.test.tsx
@@ -22,11 +22,11 @@ jest.mock('../src/api/post', () => ({
 const requestPost: EnrichedPost = {
   id: 'r1',
   authorId: 'u1',
-  type: 'request',
+  type: 'task',
   content: 'Need help',
   visibility: 'public',
   timestamp: '',
-  tags: [],
+  tags: ['request'],
   collaborators: [],
   linkedItems: [],
   author: { id: 'u1', username: 'u1' },

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -38,6 +38,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Request', 'Review', 'Change']);
+    expect(options).toEqual(['Free Speech', 'Task', 'Change']);
   });
 });


### PR DESCRIPTION
## Summary
- restrict primary post types to task, change, and free speech
- add optional secondary post type tags for request and review
- allow tagging posts on creation and update UI to display these tags

## Testing
- `npm test` (frontend)
- `cd ethos-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b5549ce94832f81683becca1628b3