### PR TITLE
Use authorId as fallback username for missing users

### DIFF
--- a/ethos-backend/src/utils/enrich.ts
+++ b/ethos-backend/src/utils/enrich.ts
@@ -138,8 +138,8 @@ export const enrichPosts = (
     const u = userById.get(post.authorId);
 
     // Prefer DBUser.username; fall back to the stored authorId string
-    // (guest IDs often carry the guest's username).
-    const username = u?.username || 'guest';
+    // so that guests retain their unique identifier.
+    const username = u?.username || post.authorId;
 
     // If you want the full enriched user when available:
     const enrichedAuthor = u


### PR DESCRIPTION
## Summary
- Preserve guest identifiers by falling back to `authorId` when a user record is absent.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b671e8d10832fadfb995bfcb23387