### PR TITLE
feat: link git accounts via API

### DIFF
--- a/docs/git-account-integration.md
+++ b/docs/git-account-integration.md
@@ -1,0 +1,30 @@
+# Git Account Integration
+
+This guide outlines how Ethos connects a user's GitHub or GitLab account and maps tasks to a repository.
+
+## Sign In and API Key
+
+1. Generate a personal access token from your Git provider (GitHub or GitLab).
+2. Send a `POST /api/git/account` request with the provider name, your git username and the token.
+3. The backend stores a hashed version of the token so it is never returned in plain text.
+4. Linked accounts are available from the response and can be used for repository operations.
+
+## Mapping Tasks to a Repository
+
+* After linking an account, connect a quest or project to a repository using `POST /api/git/connect`.
+* The top task `T00` corresponds to the repository root directory.
+* Files and tracked changes appear as `C00`, `C01`, etc., representing replies to the original task.
+* Each change post shows additions and insertions similar to a commit diff.
+
+## Task Posts and Subtasks
+
+* Users can open a task and create reply posts to discuss or propose changes.
+* A reply of type `change` is treated as a subtask in the graph and can be tied to deliverables.
+* Clicking on a task opens its post page where further replies and discussions can occur.
+
+## Nested Folders and READMEs
+
+* Repository folders may contain `README` files that act as planners, listing the files within that folder.
+* Subfolders can contain their own `README` to describe nested structures.
+
+This workflow allows Ethos to mirror repository structure within the task graph, enabling a seamless link between code changes and project deliverables.

--- a/ethos-backend/tests/gitAccountRoutes.test.ts
+++ b/ethos-backend/tests/gitAccountRoutes.test.ts
@@ -1,0 +1,36 @@
+import request from 'supertest';
+import express from 'express';
+
+import gitRoutes from '../src/routes/gitRoutes';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => {
+    _req.user = { id: 'u1' };
+    next();
+  },
+}));
+
+jest.mock('../src/models/stores', () => ({
+  usersStore: { read: jest.fn(() => [{ id: 'u1', gitAccounts: [] }]), write: jest.fn() },
+  gitStore: { read: jest.fn(() => []), write: jest.fn() },
+}));
+
+import { usersStore } from '../src/models/stores';
+
+const app = express();
+app.use(express.json());
+app.use('/git', gitRoutes);
+
+describe('git account routes', () => {
+  it('saves hashed token', async () => {
+    const res = await request(app)
+      .post('/git/account')
+      .send({ provider: 'github', username: 'alice', token: 'abc123' });
+    expect(res.status).toBe(200);
+    const written = (usersStore.write as jest.Mock).mock.calls[0][0];
+    expect(written[0].gitAccounts[0].provider).toBe('github');
+    expect(written[0].gitAccounts[0].username).toBe('alice');
+    expect(written[0].gitAccounts[0].tokenHash).toBeDefined();
+    expect(written[0].gitAccounts[0].tokenHash).not.toBe('abc123');
+  });
+});


### PR DESCRIPTION
## Summary
- allow users to register a GitHub or GitLab account and hashed API token via `POST /api/git/account`
- document how tasks map to repositories and how to link git accounts
- add tests for saving hashed git tokens

## Testing
- `cd ethos-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b70ff9394832fa14680dacb631c8c