### PR TITLE
Parse Postgres post route and test tags array

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -1171,7 +1171,39 @@ router.get('/:id', authOptional, async (req: Request<{ id: string }>, res: Respo
         res.status(404).json({ error: 'Post not found' });
         return;
       }
-      res.json(row);
+      const post: DBPost = {
+        id: row.id,
+        authorId: row.authorid,
+        type: row.type,
+        content: row.content,
+        title: row.title,
+        visibility: row.visibility,
+        tags: Array.isArray(row.tags)
+          ? row.tags
+          : typeof row.tags === 'string'
+          ? row.tags
+              .replace(/[{}]/g, '')
+              .split(',')
+              .map((t: string) => t.replace(/"/g, '').trim())
+              .filter(Boolean)
+          : [],
+        boardId: row.boardid ?? undefined,
+        timestamp:
+          row.timestamp instanceof Date
+            ? row.timestamp.toISOString()
+            : row.timestamp,
+        createdAt:
+          row.createdat instanceof Date
+            ? row.createdat.toISOString()
+            : row.createdat,
+      };
+      const users = usersStore.read();
+      res.json(
+        enrichPost(post, {
+          users,
+          currentUserId: ((req as any).user?.id as string) || null,
+        })
+      );
       return;
     } catch (err) {
       console.error(err);

--- a/ethos-backend/tests/routes.test.ts
+++ b/ethos-backend/tests/routes.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../src/db', () => ({
+  pool: { query: jest.fn() },
+  usePg: true,
+}));
+
+jest.mock('../src/models/stores', () => ({
+  postsStore: { read: jest.fn(() => []), write: jest.fn() },
+  usersStore: { read: jest.fn(() => [{ id: 'u1', username: 'user1' }]), write: jest.fn() },
+  reactionsStore: { read: jest.fn(() => []), write: jest.fn() },
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
+  notificationsStore: { read: jest.fn(() => []), write: jest.fn() },
+}));
+
+import postRoutes from '../src/routes/postRoutes';
+import { pool } from '../src/db';
+
+const app = express();
+app.use(express.json());
+app.use('/posts', postRoutes);
+
+describe('Postgres routes', () => {
+  it('GET /posts/:id returns enriched post with tags array', async () => {
+    const now = new Date();
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 'p1',
+          authorid: 'u1',
+          type: 'free_speech',
+          content: 'hello',
+          title: '',
+          visibility: 'public',
+          tags: '{"alpha","beta"}',
+          boardid: null,
+          timestamp: now,
+          createdat: now,
+        },
+      ],
+    });
+
+    const res = await request(app).get('/posts/p1');
+    expect(res.status).toBe(200);
+    expect(res.body.enriched).toBe(true);
+    expect(res.body.tags).toEqual(['alpha', 'beta']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Parse Postgres post query results, ensuring tags array and timestamps are typed, and enrich response with user context
- Add test confirming Postgres path returns enriched post with tags array

## Testing
- `cd ethos-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7120b410832fa9f61d4cad9297f8