### PR TITLE
filter internal tags from board search

### DIFF
--- a/ethos-frontend/src/pages/board/[id].tsx
+++ b/ethos-frontend/src/pages/board/[id].tsx
@@ -77,8 +77,12 @@ const BoardPage: React.FC = () => {
         setQuest(null);
       }
       const tagSet = new Set<string>();
+      const internalPrefixes = ['summary:', 'pending:', 'system', 'archived'];
       (boardData.enrichedItems || []).forEach((it: unknown) => {
-        ((it as { tags?: string[] }).tags || []).forEach((t: string) => tagSet.add(t));
+        ((it as { tags?: string[] }).tags || []).forEach((t: string) => {
+          if (internalPrefixes.some((p) => t.startsWith(p))) return;
+          tagSet.add(t);
+        });
       });
       setAvailableTags(Array.from(tagSet));
     }


### PR DESCRIPTION
## Summary
- skip internal tag prefixes when deriving available board tags

## Testing
- `npm test` *(fails: Unable to find element 'Review')*
- `npm run lint` *(fails: 'onToggleExpand' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689b71232e7c832fa2cc0f4c448d33e2