### PR TITLE
Use backend quest enrichment

### DIFF
--- a/ethos-frontend/src/hooks/useQuest.ts
+++ b/ethos-frontend/src/hooks/useQuest.ts
@@ -6,7 +6,6 @@ import type { GitCommit, GitFile } from '../types/gitTypes';
 import {
   fetchQuestById,
   fetchAllQuests as fetchQuests,
-  enrichQuestWithData,
   fetchQuestsByBoardId,
 } from '../api/quest';
 
@@ -79,7 +78,7 @@ export const useQuest = (questId?: string) => {
         const enriched = await Promise.all(
           items
             .filter(isQuest)
-            .map((q) => enrichQuestWithData(q))
+            .map((q) => fetchQuestById(q.id))
         );
         return enriched;
       } catch (err) {


### PR DESCRIPTION
## Summary
- switch `useQuest.enrichQuests` to fetch enriched quests via `fetchQuestById`
- replace client-side `enrichQuestWithData` with backend proxy

## Testing
- `npx jest src/api/quest.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689b711f3cf8832f8227765e77e0e87e