### PR TITLE
Allow linking change posts to repository tasks

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -396,7 +396,10 @@ function validateLinks(
     case 'change':
       return hasParent || items.some(i => i.itemType === 'post')
         ? { valid: true }
-        : { valid: false, message: 'Please link a task or request before submitting.' };
+        : {
+            valid: false,
+            message: 'Please link a task before submitting.',
+          };
     default:
       return { valid: true };
   }


### PR DESCRIPTION
## Summary
- Permit change posts to link directly to tasks instead of requiring a reply
- Validate change posts for task links on the client
- Display repository tasks in a nested, quest-grouped dropdown when linking

## Testing
- `npm test` (frontend) *(fails: PostListItem renders review summary tag)*
- `npm test` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_689b73723a40832f8bdac5185cbca42d