### PR TITLE
Surface non-system tags in summary tags

### DIFF
--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -138,6 +138,58 @@ export const buildSummaryTags = (
     tags.push({ type: 'type', label: `@${user}`, link: ROUTES.PUBLIC_PROFILE(post.authorId) });
   }
 
+  // Include non-system tags
+  if (post.tags && post.tags.length > 0) {
+    const blockedPrefixes = ['summary:', 'pending:'];
+    const blockedTags = ['system'];
+    post.tags.forEach((rawTag) => {
+      const lower = rawTag.toLowerCase();
+      if (
+        blockedTags.includes(lower) ||
+        blockedPrefixes.some((prefix) => lower.startsWith(prefix))
+      ) {
+        return;
+      }
+
+      let tagType: SummaryTagType = 'category';
+      let label = rawTag;
+
+      switch (lower) {
+        case 'request':
+        case 'review':
+        case 'change':
+        case 'quest':
+        case 'task':
+        case 'log':
+        case 'free_speech':
+        case 'party_request':
+        case 'quest_task':
+        case 'solved':
+          tagType = lower as SummaryTagType;
+          label = toTitleCase(rawTag);
+          break;
+        default: {
+          if (lower.startsWith('meta:')) {
+            const meta = lower.split(':')[1];
+            if (meta === 'system') {
+              tagType = 'meta_system';
+              label = 'System';
+            } else if (meta === 'announcement') {
+              tagType = 'meta_announcement';
+              label = 'Announcement';
+            } else {
+              label = `#${rawTag}`;
+            }
+          } else {
+            label = `#${rawTag}`;
+          }
+        }
+      }
+
+      tags.push({ type: tagType, label });
+    });
+  }
+
   // Remove duplicate entries by label in case of redundant inputs
   return tags.filter((t, idx) => tags.findIndex(o => o.label === t.label && o.type === t.type) === idx);
 };


### PR DESCRIPTION
## Summary
- include post tag strings in SummaryTag generation
- ignore internal tags like `summary:*` and `pending:*`

## Testing
- `npm test --prefix ethos-frontend`
- `npm run lint --prefix ethos-frontend` *(fails: 1 error, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b74ab1724832fb1e79d0a52038427