### PR TITLE
fix: toggle help request

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -94,7 +94,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   );
   const [followerCount, setFollowerCount] = useState(post.followers?.length || 0);
   const navigate = useNavigate();
-  const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
+  const { selectedBoard, appendToBoard, boards, removeItemFromBoard } =
+    useBoardContext() || {};
   const ctxBoardId = boardId || selectedBoard;
   const ctxBoardType = ctxBoardId ? boards?.[ctxBoardId]?.boardType : undefined;
   const isTimelineBoard = isTimeline ?? ctxBoardId === 'timeline-board';
@@ -105,6 +106,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     post.tags?.includes('request') && ctxBoardId === 'quest-board';
   const roleTag = post.tags?.find(t => t.toLowerCase().startsWith('role:'));
   const [helpRequested, setHelpRequested] = useState(post.helpRequest === true);
+  const [requestPostId, setRequestPostId] = useState<string | null>(null);
   const expanded = expandedProp !== undefined ? expandedProp : post.type === 'task';
 
   useEffect(() => {
@@ -195,17 +197,22 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         subRequests.forEach(sr => {
           appendToBoard?.('quest-board', sr as unknown as BoardItem);
           appendToBoard?.('timeline-board', sr as unknown as BoardItem);
-          onUpdate?.(sr);
         });
         setHelpRequested(true);
-        onUpdate?.(reqPost);
+        setRequestPostId(reqPost.id);
+        onUpdate?.({ ...post, helpRequest: true, needsHelp: true } as Post);
       } catch (err) {
         console.error('[ReactionControls] Failed to request help:', err);
       }
     } else {
       try {
         await removeHelpRequest(post.id);
+        if (requestPostId) {
+          removeItemFromBoard?.('quest-board', requestPostId);
+          removeItemFromBoard?.('timeline-board', requestPostId);
+        }
         setHelpRequested(false);
+        setRequestPostId(null);
         onUpdate?.({ ...post, helpRequest: false, needsHelp: false } as Post);
       } catch (err) {
         console.error('[ReactionControls] Failed to cancel help request:', err);

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -34,9 +34,14 @@ jest.mock('../../api/post', () => ({
 }));
 
 const appendMock = jest.fn();
+const removeMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ appendToBoard: appendMock, selectedBoard: null }),
+  useBoardContext: () => ({
+    appendToBoard: appendMock,
+    removeItemFromBoard: removeMock,
+    selectedBoard: null,
+  }),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -78,7 +83,16 @@ describe('PostCard request help', () => {
     await waitFor(() =>
       expect(requestHelp).toHaveBeenCalledWith('t1', 'task')
     );
-    expect(appendMock).toHaveBeenCalled();
+    expect(appendMock).toHaveBeenNthCalledWith(
+      1,
+      'quest-board',
+      expect.objectContaining({ id: 'r1' })
+    );
+    expect(appendMock).toHaveBeenNthCalledWith(
+      2,
+      'timeline-board',
+      expect.objectContaining({ id: 'r1' })
+    );
 
     await act(async () => {
       fireEvent.click(screen.getByText(/Cancel Help/i));
@@ -86,6 +100,8 @@ describe('PostCard request help', () => {
     await waitFor(() =>
       expect(removeHelpRequest).toHaveBeenCalledWith('t1')
     );
+    expect(removeMock).toHaveBeenNthCalledWith(1, 'quest-board', 'r1');
+    expect(removeMock).toHaveBeenNthCalledWith(2, 'timeline-board', 'r1');
   });
 
   it('does not show checkbox for free speech posts', () => {


### PR DESCRIPTION
## Summary
- track request cards when requesting help so they can be removed on cancel
- avoid replacing original post when requesting help
- test request card addition/removal

## Testing
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b78c914a4832f98278dca935f6345