### PR TITLE
Ensure change request summary tags stack in order

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -52,4 +52,30 @@ describe('PostCard summary tags', () => {
     const typeLink = screen.getByRole('link', { name: 'Task' });
     expect(typeLink).toHaveAttribute('href', '/post/p1');
   });
+
+  it('orders stacked summary tags for change requests', () => {
+    const changeReq: Post = {
+      id: 'p2',
+      authorId: 'u1',
+      type: 'request' as any,
+      nodeId: 'Q:slug:T01:C00',
+      content: 'Change request',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as unknown as Post;
+    const enriched = { ...changeReq, author: { id: 'u1', username: 'alice' } } as Post;
+    render(
+      <BrowserRouter>
+        <PostCard post={enriched} questTitle="Quest A" />
+      </BrowserRouter>
+    );
+    const requestTag = screen.getByText('Request');
+    const taskTag = screen.getByText('Q::Task:T01');
+    const changeTag = screen.getByText('Change:C00');
+    expect(requestTag.compareDocumentPosition(taskTag) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(taskTag.compareDocumentPosition(changeTag) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -119,12 +119,25 @@ export const buildSummaryTags = (
   }
   tags.push({ type: primaryType as SummaryTagType, label: primaryLabel, detailLink: ROUTES.POST(post.id) });
 
-  // Quest path tag for task posts
-  if (post.type === 'task' && post.nodeId && !multipleSources) {
-    tags.push({
-      type: 'quest',
-      label: getQuestLinkLabel(post),
-    });
+  // Quest path / change tags for request and task posts
+  if (post.nodeId && !multipleSources) {
+    if (post.type === 'request') {
+      const stripped = post.nodeId.replace(/^Q:[^:]+:/, '');
+      const segments = stripped.split(':');
+      const taskId = segments[0];
+      const changeId = segments[1];
+      if (taskId) {
+        tags.push({ type: 'quest', label: `Q::Task:${taskId}` });
+      }
+      if (changeId) {
+        tags.push({ type: 'change', label: `Change:${changeId}` });
+      }
+    } else if (post.type === 'task') {
+      tags.push({
+        type: 'quest',
+        label: getQuestLinkLabel(post),
+      });
+    }
   }
 
   // Status tag for task posts


### PR DESCRIPTION
## Summary
- order quest and change tags when building request summary tags
- test stacked summary tag ordering on change requests

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba206fa58832fa609453fc09ed110