### PR TITLE
Refactor summary tags to include node ID and author

### DIFF
--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -108,6 +108,7 @@ const SummaryTag: React.FC<SummaryTagData & { className?: string }> = ({
         <Link to={detailLink} className="underline text-inherit">
           {label}
         </Link>{' '}
+        <FaUser className="w-3 h-3 flex-shrink-0" />{' '}
         <Link to={usernameLink} className="text-inherit">@{username}</Link>
       </span>
     );


### PR DESCRIPTION
## Summary
- Display node path instead of generic type in summary tags and combine with author handle
- Render user icon alongside post type icon for detailed tag

## Testing
- `npm test` *(fails: 2 failed, 9 passed)*
- `npm run lint` *(fails: 1 error, 43 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689bbfac3cb4832faa540bec1ad9ff64