### PR TITLE
feat: mark review requests in quest board

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -376,7 +376,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
             >
               {post.type === 'task' ? <FaHandsHelping /> : <FaClipboardCheck />}
               {post.type === 'change'
-                ? (helpRequested ? 'Requested' : 'Review')
+                ? (helpRequested ? 'In Review' : 'Review')
                 : (helpRequested ? 'Requested' : 'Request')}
             </button>
           ) : helpRequested ? (

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -77,11 +77,20 @@ describe('PostCard request review', () => {
     await waitFor(() =>
       expect(requestHelp).toHaveBeenCalledWith('c1', 'change')
     );
-    expect(appendMock).toHaveBeenCalled();
-    expect(screen.getByText(/Requested/i)).toBeInTheDocument();
+    expect(appendMock).toHaveBeenNthCalledWith(
+      1,
+      'quest-board',
+      expect.objectContaining({ id: 'r1' })
+    );
+    expect(appendMock).toHaveBeenNthCalledWith(
+      2,
+      'timeline-board',
+      expect.objectContaining({ id: 'r1' })
+    );
+    expect(screen.getByText(/In Review/i)).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.click(screen.getByText(/Requested/i));
+      fireEvent.click(screen.getByText(/In Review/i));
     });
     await waitFor(() =>
       expect(removeHelpRequest).toHaveBeenCalledWith('c1')


### PR DESCRIPTION
## Summary
- show review button as **In Review** after clicking
- verify review requests append to quest and timeline boards

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689bedb7a600832fa214346e5fcf27a2