### PR TITLE
feat: separate node and user summary tags

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -37,23 +37,22 @@ const post: Post = {
 } as unknown as Post;
 
 describe('PostCard summary tags', () => {
-  it('renders type, quest, status, and username tags', () => {
+  it('renders node id, status, and username tags', () => {
     const enriched = { ...post, author: { id: 'u1', username: 'alice' } } as Post;
     render(
       <BrowserRouter>
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(screen.getByText('Task')).toBeInTheDocument();
-    expect(screen.getByText('Q:T1')).toBeInTheDocument();
+    expect(screen.getByText('Q::Task:T1')).toBeInTheDocument();
     expect(screen.getByText('In Progress')).toBeInTheDocument();
     const userLink = screen.getByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const typeLink = screen.getByRole('link', { name: 'Task' });
-    expect(typeLink).toHaveAttribute('href', '/post/p1');
+    const nodeLink = screen.getByRole('link', { name: 'Q::Task:T1' });
+    expect(nodeLink).toHaveAttribute('href', '/post/p1');
   });
 
-  it('orders stacked summary tags for change requests', () => {
+  it('renders node id and username for change requests', () => {
     const changeReq: Post = {
       id: 'p2',
       authorId: 'u1',
@@ -72,10 +71,10 @@ describe('PostCard summary tags', () => {
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    const requestTag = screen.getByText('Request');
-    const taskTag = screen.getByText('Q::Task:T01');
-    const changeTag = screen.getByText('Change:C00');
-    expect(requestTag.compareDocumentPosition(taskTag) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(taskTag.compareDocumentPosition(changeTag) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Q::Task:T01:C00')).toBeInTheDocument();
+    const userLink = screen.getByRole('link', { name: '@alice' });
+    expect(userLink).toHaveAttribute('href', '/user/u1');
+    const nodeLink = screen.getByRole('link', { name: 'Q::Task:T01:C00' });
+    expect(nodeLink).toHaveAttribute('href', '/post/p2');
   });
 });

--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -54,6 +54,6 @@ describe('PostListItem', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getAllByText('Q:T00').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Q::Task:T00').length).toBeGreaterThan(0);
   });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -106,11 +106,11 @@ const formatNodeId = (nodeId: string): string => {
     path = path.split(':').slice(2).join(':');
   }
   const segments = path.split(':');
-  const last = segments[segments.length - 1] || '';
+  const typeSeg = segments.find((s) => s.startsWith('T') || s.startsWith('F') || s.startsWith('L')) || '';
   let typeLabel = '';
-  if (last.startsWith('T')) typeLabel = 'Task';
-  else if (last.startsWith('F')) typeLabel = 'File';
-  else if (last.startsWith('L')) typeLabel = 'Log';
+  if (typeSeg.startsWith('T')) typeLabel = 'Task';
+  else if (typeSeg.startsWith('F')) typeLabel = 'File';
+  else if (typeSeg.startsWith('L')) typeLabel = 'Log';
   return typeLabel ? `Q::${typeLabel}:${segments.join(':')}` : `Q:${segments.join(':')}`;
 };
 
@@ -148,13 +148,16 @@ export const buildSummaryTags = (
     detailLink: ROUTES.POST(post.id),
   };
 
+  tags.push(primaryTag);
+
   if (post.authorId) {
     const user = post.author?.username || post.authorId;
-    primaryTag.username = user;
-    primaryTag.usernameLink = ROUTES.PUBLIC_PROFILE(post.authorId);
+    tags.push({
+      type: 'type',
+      label: `@${user}`,
+      link: ROUTES.PUBLIC_PROFILE(post.authorId),
+    });
   }
-
-  tags.push(primaryTag);
 
   // Status tag for task posts
   if (post.status && post.type === 'task') {


### PR DESCRIPTION
## Summary
- show node IDs using first task segment and add dedicated user summary tag
- adjust post card and list item tests for new tag structure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bee2538f4832fa9e38b8369f5c0af