### PR TITLE
Filter root tasks for active quest board

### DIFF
--- a/ethos-backend/dist/src/routes/questRoutes.js
+++ b/ethos-backend/dist/src/routes/questRoutes.js
@@ -62,21 +62,9 @@ router.get('/active', authOptional_1.default, (req, res) => {
     }));
     if (includeTasks) {
         const taskPosts = posts.filter((p) => p.type === 'task');
-        const rootTasks = active.flatMap((q) => {
-            const edges = q.taskGraph || [];
-            return taskPosts
-                .filter((p) => p.questId === q.id)
-                .filter((p) => {
-                const hasChild = edges.some((e) => e.from === p.id);
-                const hasParent = edges.some((e) => e.to === p.id);
-                if (!hasChild || hasParent)
-                    return false;
-                if (userId) {
-                    return p.authorId !== userId;
-                }
-                return true;
-            });
-        });
+        const rootTasks = active.flatMap((q) => taskPosts
+            .filter((p) => p.questId === q.id && p.nodeId?.endsWith('T00'))
+            .filter((p) => (userId ? p.authorId !== userId : true)));
         res.json({ quests: active, tasks: rootTasks });
         return;
     }

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -86,20 +86,11 @@ router.get('/active', authOptional, (req: AuthRequest, res: Response) => {
 
   if (includeTasks) {
     const taskPosts = posts.filter((p) => p.type === 'task');
-    const rootTasks = active.flatMap((q) => {
-      const edges = q.taskGraph || [];
-      return taskPosts
-        .filter((p) => p.questId === q.id)
-        .filter((p) => {
-          const hasChild = edges.some((e) => e.from === p.id);
-          const hasParent = edges.some((e) => e.to === p.id);
-          if (!hasChild || hasParent) return false;
-          if (userId) {
-            return p.authorId !== userId;
-          }
-          return true;
-        });
-    });
+    const rootTasks = active.flatMap((q) =>
+      taskPosts
+        .filter((p) => p.questId === q.id && p.nodeId?.endsWith('T00'))
+        .filter((p) => (userId ? p.authorId !== userId : true))
+    );
 
     res.json({ quests: active, tasks: rootTasks });
     return;

--- a/ethos-backend/tests/questActiveTasks.test.ts
+++ b/ethos-backend/tests/questActiveTasks.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import express from 'express';
+
+import questRoutes from '../src/routes/questRoutes';
+
+jest.mock('../src/middleware/authOptional', () => ({
+  __esModule: true,
+  default: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../src/models/stores', () => ({
+  postsStore: { read: jest.fn(() => []), write: jest.fn() },
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
+}));
+
+import { postsStore, questsStore } from '../src/models/stores';
+
+const postsStoreMock = postsStore as jest.Mocked<any>;
+const questsStoreMock = questsStore as jest.Mocked<any>;
+
+const app = express();
+app.use(express.json());
+app.use('/quests', questRoutes);
+
+describe('questRoutes /active includeTasks', () => {
+  it('returns only root tasks with nodeId T00', async () => {
+    const quest = {
+      id: 'q1',
+      authorId: 'u2',
+      title: 'Quest',
+      visibility: 'public',
+      approvalStatus: 'approved',
+      status: 'active',
+      headPostId: '',
+      linkedPosts: [],
+      collaborators: [],
+      taskGraph: [],
+    };
+    questsStoreMock.read.mockReturnValue([quest]);
+
+    const posts = [
+      {
+        id: 't1',
+        authorId: 'u2',
+        type: 'task',
+        content: 'Root',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+        questId: 'q1',
+        nodeId: 'Q:quest:T00',
+      },
+      {
+        id: 't2',
+        authorId: 'u2',
+        type: 'task',
+        content: 'Child',
+        visibility: 'public',
+        timestamp: '',
+        tags: [],
+        collaborators: [],
+        linkedItems: [],
+        questId: 'q1',
+        nodeId: 'Q:quest:T00:T01',
+      },
+    ];
+    postsStoreMock.read.mockReturnValue(posts);
+
+    const res = await request(app).get('/quests/active?includeTasks=1');
+    expect(res.status).toBe(200);
+    expect(res.body.tasks).toHaveLength(1);
+    expect(res.body.tasks[0].id).toBe('t1');
+  });
+});
+

--- a/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestBoard.tsx
@@ -72,11 +72,12 @@ const ActiveQuestBoard: React.FC<ActiveQuestBoardProps> = ({ onlyMine }) => {
         );
 
         let enriched = Object.values(questMap);
+        const rootTasks = boardData.tasks.filter(t => t.nodeId?.endsWith('T00'));
         if (onlyMine) {
           enriched = enriched.filter(q => q.authorId === user?.id);
-          setTasks(boardData.tasks.filter(t => t.authorId === user?.id));
+          setTasks(rootTasks.filter(t => t.authorId === user?.id));
         } else {
-          setTasks(boardData.tasks);
+          setTasks(rootTasks);
         }
         setQuests(enriched);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Show only root `T00` tasks on active quest board
- Filter active quest board tasks to head nodes on frontend
- Add backend test for fetching root tasks

## Testing
- `npm --prefix ethos-backend test`
- `npm --prefix ethos-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689befe7e400832f9551e1c60eee69f4