### PR TITLE
Add tags for request/review posts and unify repost reaction logic

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -677,6 +677,7 @@ router.post(
       subtype: 'task',
       nodeId: task.nodeId,
       tags: [
+        'request',
         'summary:request',
         'summary:task',
         `summary:user:${req.user?.username || req.user?.id}`,
@@ -712,6 +713,7 @@ router.post(
       subtype: 'task',
       nodeId: task.nodeId,
       tags: [
+        'request',
         'summary:request',
         'summary:task',
         `summary:user:${req.user?.username || req.user?.id}`,
@@ -765,6 +767,7 @@ router.post(
       subtype,
       nodeId: original.type === 'task' ? original.nodeId : undefined,
       tags: [
+        subtype === 'change' ? 'review' : 'request',
         'summary:request',
         `summary:${subtype}`,
         `summary:user:${req.user?.username || req.user?.id}`,


### PR DESCRIPTION
## Summary
- tag request and review posts so they show on the quest board
- track repost state alongside other reactions and tag posts when requesting help

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf249a090832f9ed4e7711cbc3089