### PR TITLE
Add request help endpoint fallback

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -279,7 +279,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     // Cancel help request
     setHelpRequested(false); // optimistic
     try {
-      await removeHelpRequest(post.id);
+      await removeHelpRequest(post.id, post.type);
       if (requestPostId) {
         removeItemFromBoard?.('quest-board', requestPostId);
         removeItemFromBoard?.('timeline-board', requestPostId);

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -103,7 +103,7 @@ describe('PostCard request help', () => {
       fireEvent.click(screen.getByText(/Requested/i));
     });
     await waitFor(() =>
-      expect(removeHelpRequest).toHaveBeenCalledWith('t1')
+      expect(removeHelpRequest).toHaveBeenCalledWith('t1', 'task')
     );
     expect(removeMock).toHaveBeenNthCalledWith(1, 'quest-board', 'r1');
     expect(removeMock).toHaveBeenNthCalledWith(2, 'timeline-board', 'r1');

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -93,7 +93,7 @@ describe('PostCard request review', () => {
       fireEvent.click(screen.getByText(/In Review/i));
     });
     await waitFor(() =>
-      expect(removeHelpRequest).toHaveBeenCalledWith('c1')
+      expect(removeHelpRequest).toHaveBeenCalledWith('c1', 'change')
     );
   });
 });


### PR DESCRIPTION
## Summary
- handle 404s when requesting help by retrying older task endpoint
- include post type when cancelling help requests
- update tests for new requestHelp API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfcb826b4832f9f346ab966eaadb5