### PR TITLE
Fix help request fallback endpoint

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -262,8 +262,11 @@ export const requestHelp = async (
     return res.data;
   } catch (err) {
     if (axios.isAxiosError(err) && err.response?.status === 404 && type === 'task') {
+      // Fallback for older backends that expose the legacy
+      // `/tasks/:id/request-help` endpoint instead of the
+      // generic `/posts/:id/request-help` route.
       const res = await axiosWithAuth.post(
-        `/posts/tasks/${postId}/request-help`,
+        `/tasks/${postId}/request-help`,
         payload
       );
       return res.data;
@@ -284,7 +287,9 @@ export const removeHelpRequest = async (
     return res.data;
   } catch (err) {
     if (axios.isAxiosError(err) && err.response?.status === 404 && type === 'task') {
-      const res = await axiosWithAuth.delete(`/posts/tasks/${postId}/request-help`);
+      // Fallback for legacy backends which expect the request-help
+      // routes to live under `/tasks/:id`.
+      const res = await axiosWithAuth.delete(`/tasks/${postId}/request-help`);
       return res.data;
     }
     throw err;


### PR DESCRIPTION
## Summary
- fix legacy request-help endpoint path to `/tasks/:id/request-help`
- preserve compatibility with older backends when requesting or removing help

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c037f69a4832f8cf03a59ccf3ca0a