### PR TITLE
fix: stabilize request and repost controls

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -108,8 +108,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [accepted, setAccepted] = useState<boolean>(initialAccepted);
   const [accepting, setAccepting] = useState(false);
 
-  useEffect(() => setHelpRequested(post.helpRequest === true), [post.helpRequest]);
-  useEffect(() => setUserRepostId(post.userRepostId ?? null), [post.userRepostId]);
+  // Sync initial help/repost state only when switching posts
+  useEffect(() => setHelpRequested(post.helpRequest === true), [post.id]);
+  useEffect(() => setUserRepostId(post.userRepostId ?? null), [post.id]);
   useEffect(() => setAccepted(initialAccepted), [initialAccepted]);
 
   const navigate = useNavigate();
@@ -171,7 +172,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [post.id, post.userRepostId, user?.id]);
+  }, [post.id, user?.id]);
 
   // ---------- Helpers ----------
   const safeBump = (n: number, delta: number) => Math.max(0, n + delta);


### PR DESCRIPTION
## Summary
- prevent request/repost buttons from reverting when parent post updates
- avoid extra reaction fetches that reset local state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0ee0fb88832f9357a4a2c39cfb6f