### PR TITLE
Add legacy task request-help endpoint fallback

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -23,6 +23,7 @@ export default {
     '<rootDir>/src/components/controls/ReactionControls.repost.test.tsx',
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
+    '<rootDir>/src/api/post.requestHelpLegacy.test.ts',
     '<rootDir>/tests/CreatePostReply.test.tsx',
     '<rootDir>/tests/CreatePostRequestNoTask.test.tsx',
     '<rootDir>/tests/BoardUtilsRequestPosts.test.ts',

--- a/ethos-frontend/src/api/post.requestHelpLegacy.test.ts
+++ b/ethos-frontend/src/api/post.requestHelpLegacy.test.ts
@@ -1,0 +1,42 @@
+import { requestHelp, removeHelpRequest } from './post';
+import { axiosWithAuth } from '../utils/authUtils';
+
+jest.mock('../utils/authUtils', () => ({
+  axiosWithAuth: { post: jest.fn(), delete: jest.fn() },
+}));
+
+describe('requestHelp legacy fallbacks', () => {
+  beforeEach(() => {
+    (axiosWithAuth.post as unknown as jest.Mock).mockReset();
+    (axiosWithAuth.delete as unknown as jest.Mock).mockReset();
+  });
+
+  it('falls back to legacy tasks endpoint when post routes are missing', async () => {
+    const mockPost = axiosWithAuth.post as unknown as jest.Mock;
+    mockPost
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } })
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } })
+      .mockResolvedValueOnce({ data: { request: { id: 'r1' }, subRequests: [] } });
+
+    const res = await requestHelp('p1', 'task');
+    expect(res.request.id).toBe('r1');
+    const payload = { subtype: 'task' };
+    expect(mockPost).toHaveBeenNthCalledWith(1, '/posts/p1/request-help', payload);
+    expect(mockPost).toHaveBeenNthCalledWith(2, '/posts/tasks/p1/request-help', payload);
+    expect(mockPost).toHaveBeenNthCalledWith(3, '/tasks/p1/request-help', payload);
+  });
+
+  it('falls back to legacy tasks delete route', async () => {
+    const mockDelete = axiosWithAuth.delete as unknown as jest.Mock;
+    mockDelete
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } })
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } })
+      .mockResolvedValueOnce({ data: { success: true } });
+
+    const res = await removeHelpRequest('p1', 'task');
+    expect(res.success).toBe(true);
+    expect(mockDelete).toHaveBeenNthCalledWith(1, '/posts/p1/request-help');
+    expect(mockDelete).toHaveBeenNthCalledWith(2, '/posts/tasks/p1/request-help');
+    expect(mockDelete).toHaveBeenNthCalledWith(3, '/tasks/p1/request-help');
+  });
+});


### PR DESCRIPTION
## Summary
- Add deeper fallbacks for legacy `/tasks/:id/request-help` API routes
- Cover legacy request-help behavior with dedicated tests

## Testing
- `npx jest src/api/post.requestHelpLegacy.test.ts --runInBand`
- `npm test -- --runInBand` *(fails: test suite hangs with open handles and console warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c176d1a84832fbf19622afe2f44e9