### PR TITLE
feat: add quest board component

### DIFF
--- a/ethos-frontend/src/components/quest/QuestBoard.tsx
+++ b/ethos-frontend/src/components/quest/QuestBoard.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { useBoardContext } from '../../contexts/BoardContext';
+import Board from '../board/Board';
+import PostTypeFilter from '../board/PostTypeFilter';
+import { ROUTES } from '../../constants/routes';
+import { BOARD_PREVIEW_LIMIT } from '../../constants/pagination';
+import { getRenderableBoardItems } from '../../utils/boardUtils';
+
+const QuestBoard: React.FC = () => {
+  const { user } = useAuth();
+  const { boards } = useBoardContext();
+  const [postType, setPostType] = useState('');
+
+  const questBoard = boards['quest-board'];
+
+  const questItems = useMemo(
+    () => getRenderableBoardItems(questBoard?.enrichedItems || []),
+    [questBoard?.enrichedItems]
+  );
+
+  const showSeeAll = questItems.length >= BOARD_PREVIEW_LIMIT;
+
+  const hasMultipleTypes = useMemo(() => {
+    if (!questBoard?.enrichedItems?.length) return false;
+    const types = new Set<string>();
+    getRenderableBoardItems(questBoard.enrichedItems).forEach(item => {
+      if ('type' in item) types.add(item.type as string);
+    });
+    return types.size > 1;
+  }, [questBoard?.enrichedItems]);
+
+  return (
+    <section className="space-y-4">
+      {hasMultipleTypes && (
+        <PostTypeFilter value={postType} onChange={setPostType} />
+      )}
+      <Board
+        boardId="quest-board"
+        title="🗺️ Quest Board"
+        layout="grid"
+        gridLayout="horizontal"
+        compact
+        user={user}
+        hideControls
+        filter={postType ? { postType } : {}}
+      />
+      {showSeeAll && (
+        <div className="text-right">
+          <Link
+            to={ROUTES.BOARD('quest-board')}
+            className="text-blue-600 underline text-sm"
+          >
+            → See all
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default QuestBoard;
+

--- a/ethos-frontend/src/pages/index.tsx
+++ b/ethos-frontend/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '../constants/routes';
 import { BOARD_PREVIEW_LIMIT } from '../constants/pagination';
 import { Spinner } from '../components/ui';
 import { getRenderableBoardItems } from '../utils/boardUtils';
+import QuestBoard from '../components/quest/QuestBoard';
 
 
 const HomePage: React.FC = () => {
@@ -42,9 +43,7 @@ const HomePage: React.FC = () => {
         </p>
       </header>
 
-      {/* <section className="space-y-4">
-    quest board
-      </section> */}
+      <QuestBoard />
 
       <section>
         <h2 className="text-xl font-semibold mb-2">⏳ Recent Activity</h2>

--- a/ethos-frontend/tests/QuestBoardComponent.test.tsx
+++ b/ethos-frontend/tests/QuestBoardComponent.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import QuestBoard from '../src/components/quest/QuestBoard';
+
+const mockBoard = {
+  id: 'quest-board',
+  enrichedItems: [
+    { id: 'p1', type: 'task', content: 'Task', tags: ['request'] },
+    { id: 'c1', type: 'change', content: 'Change', tags: ['review'] },
+  ],
+};
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ boards: { 'quest-board': mockBoard } }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => ({ user: null }),
+}));
+
+jest.mock('../src/components/board/Board', () => ({
+  __esModule: true,
+  default: (props: { filter: unknown }) => (
+    <div data-testid="board-filter">{JSON.stringify(props.filter)}</div>
+  ),
+}));
+
+jest.mock('../src/components/board/PostTypeFilter', () => ({
+  __esModule: true,
+  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <select data-testid="post-type-filter" value={value} onChange={e => onChange(e.target.value)}>
+      <option value="">All Posts</option>
+      <option value="request">Requests</option>
+      <option value="review">Reviews</option>
+    </select>
+  ),
+}));
+
+test('passes selected post type to Board filter', () => {
+  render(
+    <BrowserRouter>
+      <QuestBoard />
+    </BrowserRouter>
+  );
+  const filter = screen.getByTestId('post-type-filter');
+  fireEvent.change(filter, { target: { value: 'review' } });
+  expect(screen.getByTestId('board-filter').textContent).toBe(
+    JSON.stringify({ postType: 'review' })
+  );
+});
+


### PR DESCRIPTION
## Summary
- add QuestBoard component to surface requests and reviews
- wire QuestBoard into home page
- test QuestBoard filter behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c1b0e1244832f9132913754946154