### PR TITLE
feat: expose legacy task request help route

### DIFF
--- a/ethos-backend/dist/src/server.js
+++ b/ethos-backend/dist/src/server.js
@@ -88,6 +88,17 @@ app.use(logger_1.requestLogger);
 app.use('/api/auth', authRoutes_1.default); // 🔐 Authentication (login, register, session)
 app.use('/api/git', gitRoutes_1.default); // 🔁 Git sync, commits, diffs
 app.use('/api/posts', postRoutes_1.default); // 📝 Posts, reactions, replies
+// Legacy task request-help routes for backward compatibility
+app.post('/api/tasks/:id/request-help', (req, res, next) => {
+    // Delegate to the existing postRoutes handler
+    req.url = `/tasks/${req.params.id}/request-help`;
+    (0, postRoutes_1.default)(req, res, next);
+});
+app.delete('/api/tasks/:id/request-help', (req, res, next) => {
+    // Delegate to the generic cancel handler in postRoutes
+    req.url = `/${req.params.id}/request-help`;
+    (0, postRoutes_1.default)(req, res, next);
+});
 app.use('/api/quests', questRoutes_1.default); // 📦 Quests, task maps
 app.use('/api/projects', projectRoutes_1.default); // 🗂 Projects
 app.use('/api/boards', boardRoutes_1.default); // 🧭 Boards and view layouts

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -102,6 +102,18 @@ app.use(requestLogger);
 app.use('/api/auth', authRoutes);     // 🔐 Authentication (login, register, session)
 app.use('/api/git', gitRoutes);       // 🔁 Git sync, commits, diffs
 app.use('/api/posts', postRoutes);    // 📝 Posts, reactions, replies
+// Legacy task request-help routes for backward compatibility
+app.post('/api/tasks/:id/request-help', (req: Request, res: Response, next: NextFunction) => {
+  // Delegate to the existing postRoutes handler
+  req.url = `/tasks/${req.params.id}/request-help`;
+  postRoutes(req, res, next);
+});
+
+app.delete('/api/tasks/:id/request-help', (req: Request, res: Response, next: NextFunction) => {
+  // Delegate to the generic cancel handler in postRoutes
+  req.url = `/${req.params.id}/request-help`;
+  postRoutes(req, res, next);
+});
 app.use('/api/quests', questRoutes);  // 📦 Quests, task maps
 app.use('/api/projects', projectRoutes); // 🗂 Projects
 app.use('/api/boards', boardRoutes);  // 🧭 Boards and view layouts


### PR DESCRIPTION
## Summary
- add legacy `/api/tasks/:id/request-help` endpoints that delegate to existing post request-handlers
- ensure old clients can request and cancel help for tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1b2d7948832f9dd6efae283d9603