### PR TITLE
feat: show username in summary tag

### DIFF
--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -150,11 +150,10 @@ export const buildSummaryTags = (
 
   tags.push(primaryTag);
 
-  if (post.authorId) {
-    const user = post.author?.username || post.authorId;
+  if (post.authorId && post.author?.username) {
     tags.push({
       type: 'type',
-      label: `@${user}`,
+      label: `@${post.author.username}`,
       link: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
   }


### PR DESCRIPTION
## Summary
- show usernames instead of user IDs in summary tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c22301538832f821814089de1a09a