### PR TITLE
Reuse original post for help requests

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -720,80 +720,19 @@ router.post(
   authMiddleware,
   (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
     const posts = postsStore.read();
-    const task = posts.find((p) => p.id === req.params.id && p.type === 'task');
+    const task = posts.find(p => p.id === req.params.id && p.type === 'task');
     if (!task) {
       res.status(404).json({ error: 'Task not found' });
       return;
     }
 
-    const requestPost: DBPost = {
-      id: uuidv4(),
-      authorId: req.user!.id,
-      type: 'request',
-      content: task.content,
-      visibility: task.visibility,
-      timestamp: new Date().toISOString(),
-      subtype: 'task',
-      nodeId: task.nodeId,
-      tags: [
-        'request',
-        'summary:request',
-        'summary:task',
-        `summary:user:${req.user?.username || req.user?.id}`,
-      ],
-      collaborators: [],
-      replyTo: task.id,
-      repostedFrom: null,
-      linkedItems: [],
-      questId: task.questId || null,
-      helpRequest: true,
-      needsHelp: true,
-      boardId: 'quest-board',
-    };
-
     task.helpRequest = true;
     task.needsHelp = true;
-    task.requestId = requestPost.id;
-
-    const quests = questsStore.read();
-    const quest = task.questId ? quests.find(q => q.id === task.questId) : null;
-    const openRoles = [
-      ...(task.collaborators || []),
-      ...(quest?.collaborators || [])
-    ].filter(c => !c.userId);
-
-    const subRequests: DBPost[] = openRoles.map(role => ({
-      id: uuidv4(),
-      authorId: req.user!.id,
-      type: 'request',
-      content: `Role needed: ${(role.roles || []).join(', ')}`,
-      visibility: task.visibility,
-      timestamp: new Date().toISOString(),
-      subtype: 'task',
-      nodeId: task.nodeId,
-      tags: [
-        'request',
-        'summary:request',
-        'summary:task',
-        `summary:user:${req.user?.username || req.user?.id}`,
-      ],
-      collaborators: [role],
-      replyTo: requestPost.id,
-      repostedFrom: null,
-      linkedItems: [],
-      questId: task.questId || null,
-      helpRequest: true,
-      needsHelp: true,
-      boardId: 'quest-board',
-    }));
-
-    posts.push(requestPost, ...subRequests);
+    task.tags = Array.from(new Set([...(task.tags || []), 'request']));
     postsStore.write(posts);
+
     const users = usersStore.read();
-    res.status(201).json({
-      request: enrichPost(requestPost, { users }),
-      subRequests: subRequests.map(p => enrichPost(p, { users })),
-    });
+    res.status(200).json({ post: enrichPost(task, { users }) });
   }
 );
 
@@ -805,52 +744,25 @@ router.post(
   authMiddleware,
   (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
     const posts = postsStore.read();
-    const original = posts.find((p) => p.id === req.params.id);
-    if (!original) {
+    const post = posts.find(p => p.id === req.params.id);
+    if (!post) {
       res.status(404).json({ error: 'Post not found' });
       return;
     }
-    const subtype = req.body?.subtype || (original.type === 'task' ? 'task' : 'change');
-    if (subtype === 'change' && original.type !== 'task') {
+    const subtype = req.body?.subtype || (post.type === 'task' ? 'task' : 'change');
+    if (subtype === 'change' && post.type !== 'task') {
       res.status(400).json({ error: 'Change requests must originate from a task' });
       return;
     }
 
-    const requestPost: DBPost = {
-      id: uuidv4(),
-      authorId: req.user!.id,
-      type: 'request',
-      content: original.content,
-      visibility: original.visibility,
-      timestamp: new Date().toISOString(),
-      subtype,
-      nodeId: original.type === 'task' ? original.nodeId : undefined,
-      tags: [
-        subtype === 'change' ? 'review' : 'request',
-        'summary:request',
-        `summary:${subtype}`,
-        `summary:user:${req.user?.username || req.user?.id}`,
-      ],
-      collaborators: [],
-      replyTo: original.id,
-      repostedFrom: null,
-      linkedItems: [],
-      questId: original.questId || null,
-      helpRequest: true,
-      needsHelp: true,
-      boardId: 'quest-board',
-    };
-    original.helpRequest = true;
-    original.needsHelp = true;
-    original.requestId = requestPost.id;
-
-    posts.push(requestPost);
+    const tag = subtype === 'change' ? 'review' : 'request';
+    post.helpRequest = true;
+    post.needsHelp = true;
+    post.tags = Array.from(new Set([...(post.tags || []), tag]));
     postsStore.write(posts);
+
     const users = usersStore.read();
-    res.status(201).json({
-      request: enrichPost(requestPost, { users }),
-      subRequests: [],
-    });
+    res.status(200).json({ post: enrichPost(post, { users }) });
   }
 );
 
@@ -868,26 +780,14 @@ router.delete(
       return;
     }
 
-    const removedIds: string[] = [];
-    for (let i = posts.length - 1; i >= 0; i--) {
-      const p = posts[i];
-      if (
-        p.type === 'request' &&
-        p.authorId === req.user!.id &&
-        p.helpRequest === true &&
-        p.replyTo === post.id
-      ) {
-        removedIds.push(p.id);
-        posts.splice(i, 1);
-      }
-    }
-
+    const tag = post.type === 'change' ? 'review' : 'request';
     post.helpRequest = false;
     post.needsHelp = false;
-    post.requestId = undefined;
+    post.tags = (post.tags || []).filter(t => t !== tag);
     postsStore.write(posts);
 
-    res.json({ success: true, removedIds });
+    const users = usersStore.read();
+    res.json({ post: enrichPost(post, { users }) });
   }
 );
 

--- a/ethos-frontend/src/api/post.requestHelp.test.ts
+++ b/ethos-frontend/src/api/post.requestHelp.test.ts
@@ -13,19 +13,19 @@ describe('requestHelp API', () => {
 
   it('calls the posts request-help route with subtype', async () => {
     const mockPost = axiosWithAuth.post as unknown as jest.Mock;
-    mockPost.mockResolvedValueOnce({ data: { request: { id: 'r1' }, subRequests: [] } });
+    mockPost.mockResolvedValueOnce({ data: { post: { id: 'p1' } } });
 
     const res = await requestHelp('p1', 'task');
-    expect(res.request.id).toBe('r1');
+    expect(res.post.id).toBe('p1');
     expect(mockPost).toHaveBeenCalledWith('/posts/p1/request-help', { subtype: 'task' });
   });
 
   it('calls posts route when removing help request', async () => {
     const mockDelete = axiosWithAuth.delete as unknown as jest.Mock;
-    mockDelete.mockResolvedValueOnce({ data: { success: true } });
+    mockDelete.mockResolvedValueOnce({ data: { post: { id: 'p1' } } });
 
     const res = await removeHelpRequest('p1');
-    expect(res.success).toBe(true);
+    expect(res.post.id).toBe('p1');
     expect(mockDelete).toHaveBeenCalledWith('/posts/p1/request-help');
   });
 });

--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -241,8 +241,7 @@ export const solvePost = async (postId: string): Promise<{ success: boolean }> =
  * 🤝 Request help for any post
  */
 export interface RequestHelpResult {
-  request: Post;
-  subRequests: Post[];
+  post: Post;
 }
 
 export const requestHelp = async (
@@ -262,7 +261,7 @@ export const requestHelp = async (
  */
 export const removeHelpRequest = async (
   postId: string
-): Promise<{ success: boolean }> => {
+): Promise<{ post: Post }> => {
   // Cancel help requests using the unified posts route.
   const res = await axiosWithAuth.delete(`${BASE_URL}/${postId}/request-help`);
   return res.data;

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -10,8 +10,8 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   requestHelp: jest.fn(() =>
     Promise.resolve({
-      request: {
-        id: 'r1',
+      post: {
+        id: 't1',
         authorId: 'u1',
         type: 'task',
         content: 'Task',
@@ -20,11 +20,12 @@ jest.mock('../../api/post', () => ({
         tags: ['request'],
         collaborators: [],
         linkedItems: [],
+        helpRequest: true,
+        needsHelp: true,
       },
-      subRequests: [],
     })
   ),
-  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ post: { id: 't1' } })),
   updateReaction: jest.fn(() => Promise.resolve()),
   addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
   removeRepost: jest.fn(() => Promise.resolve()),
@@ -33,13 +34,11 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
-const appendMock = jest.fn();
-const removeMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({
-    appendToBoard: appendMock,
-    removeItemFromBoard: removeMock,
+    appendToBoard: jest.fn(),
+    removeItemFromBoard: jest.fn(),
     selectedBoard: null,
   }),
 }));
@@ -72,7 +71,7 @@ describe('PostCard request help', () => {
   } as unknown as Post;
 
 
-  it('calls endpoint and appends to board', async () => {
+  it('calls endpoint to request help', async () => {
     render(
       <BrowserRouter>
         <PostCard post={post} user={{ id: 'u1' } as User} />
@@ -88,23 +87,10 @@ describe('PostCard request help', () => {
     await waitFor(() =>
       expect(requestHelp).toHaveBeenCalledWith('t1', 'task')
     );
-    expect(appendMock).toHaveBeenNthCalledWith(
-      1,
-      'quest-board',
-      expect.objectContaining({ id: 'r1' })
-    );
-    expect(appendMock).toHaveBeenNthCalledWith(
-      2,
-      'timeline-board',
-      expect.objectContaining({ id: 'r1' })
-    );
-
     await act(async () => {
       fireEvent.click(screen.getByText(/Requested/i));
     });
     await waitFor(() => expect(removeHelpRequest).toHaveBeenCalledWith('t1'));
-    expect(removeMock).toHaveBeenNthCalledWith(1, 'quest-board', 'r1');
-    expect(removeMock).toHaveBeenNthCalledWith(2, 'timeline-board', 'r1');
   });
 
   it('does not show checkbox for free speech posts', () => {

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -10,8 +10,8 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
   requestHelp: jest.fn(() =>
     Promise.resolve({
-      request: {
-        id: 'r1',
+      post: {
+        id: 'c1',
         authorId: 'u1',
         type: 'change',
         content: 'Change',
@@ -20,11 +20,12 @@ jest.mock('../../api/post', () => ({
         tags: ['review'],
         collaborators: [],
         linkedItems: [],
+        helpRequest: true,
+        needsHelp: true,
       },
-      subRequests: [],
     })
   ),
-  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ post: { id: 'c1' } })),
   updateReaction: jest.fn(() => Promise.resolve()),
   addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
   removeRepost: jest.fn(() => Promise.resolve()),
@@ -33,10 +34,9 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
-const appendMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
-  useBoardContext: () => ({ appendToBoard: appendMock, selectedBoard: null }),
+  useBoardContext: () => ({ appendToBoard: jest.fn(), selectedBoard: null }),
 }));
 
 jest.mock('react-router-dom', () => {
@@ -76,16 +76,6 @@ describe('PostCard request review', () => {
 
     await waitFor(() =>
       expect(requestHelp).toHaveBeenCalledWith('c1', 'change')
-    );
-    expect(appendMock).toHaveBeenNthCalledWith(
-      1,
-      'quest-board',
-      expect.objectContaining({ id: 'r1' })
-    );
-    expect(appendMock).toHaveBeenNthCalledWith(
-      2,
-      'timeline-board',
-      expect.objectContaining({ id: 'r1' })
     );
     expect(screen.getByText(/In Review/i)).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- mark tasks and posts as help requests instead of creating separate request posts
- adjust frontend API to return updated post when requesting or removing help
- simplify ReactionControls to toggle help request state without board fan-out

## Testing
- `npm --prefix ethos-frontend test`
- `npm --prefix ethos-backend test`


------
https://chatgpt.com/codex/tasks/task_e_689c21abdc04832f9e6da84e6c89a66a