### PR TITLE
feat: show username in summary tag

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
@@ -8,6 +8,11 @@ jest.mock('../git/GitFileBrowserInline', () => () => <div>File Browser</div>);
 jest.mock('../quest/TeamPanel', () => () => <div>Team Panel</div>);
 jest.mock('../../hooks/useGraph', () => ({ useGraph: () => ({ nodes: [], edges: [], loadGraph: jest.fn() }) }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 const task: Post = {
   id: 't1',
   authorId: 'u1',
@@ -22,9 +27,9 @@ const task: Post = {
   questId: 'q1',
 };
 
-test('shows map and file browser in expanded view', () => {
+test('shows map and file browser in expanded view', async () => {
   render(<PostCard post={task} expanded />);
-  expect(screen.getByTestId('map')).toBeInTheDocument();
-  expect(screen.getByText('File Browser')).toBeInTheDocument();
-  expect(screen.getByText('Options')).toBeInTheDocument();
+  expect(await screen.findByTestId('map')).toBeInTheDocument();
+  expect(await screen.findByText('File Browser')).toBeInTheDocument();
+  expect(await screen.findByText('Options')).toBeInTheDocument();
 });

--- a/ethos-frontend/src/components/post/PostCard.initialShowReplies.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.initialShowReplies.test.tsx
@@ -9,6 +9,11 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({})

--- a/ethos-frontend/src/components/post/PostCard.link.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.link.test.tsx
@@ -17,6 +17,11 @@ jest.mock('../../api/post', () => ({
   )
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 jest.mock('../../api/quest', () => ({
   __esModule: true,
   linkPostToQuest: jest.fn(() => Promise.resolve({}))

--- a/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.questBoardRequest.test.tsx
@@ -10,6 +10,11 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({ selectedBoard: 'quest-board' }),
@@ -45,16 +50,15 @@ const post: Post = {
   linkedItems: [],
 } as unknown as Post;
 
-it('hides status controls and shows only request tag', () => {
+it('hides status controls and shows only request tag', async () => {
   render(
     <BrowserRouter>
       <PostCard post={post} user={{ id: 'u1' } as User} />
     </BrowserRouter>
   );
-
-  expect(screen.getByText('Request')).toBeInTheDocument();
-  expect(screen.getByRole('link', { name: '@u1' })).toBeInTheDocument();
+  expect(await screen.findByText('Request')).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: '@alice' })).toBeInTheDocument();
   expect(screen.queryByText('In Progress')).toBeNull();
   expect(screen.queryByRole('combobox')).toBeNull();
-  expect(screen.getByText('1 day ago')).toBeInTheDocument();
+  expect(await screen.findByText('1 day ago')).toBeInTheDocument();
 });

--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 const appendMock = jest.fn();
 const removeMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../api/post', () => ({
   fetchUserRepost: jest.fn(() => Promise.resolve(null)),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 const appendMock = jest.fn();
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,

--- a/ethos-frontend/src/components/post/PostCard.review.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.review.test.tsx
@@ -8,6 +8,11 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({}),
@@ -23,7 +28,7 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('PostCard review rating', () => {
-  it('renders rating stars for review posts', () => {
+  it('renders rating stars for review posts', async () => {
     const post: Post = {
       id: 'r1',
       authorId: 'u1',
@@ -43,6 +48,6 @@ describe('PostCard review rating', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByLabelText('Rating: 4.5')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Rating: 4.5')).toBeInTheDocument();
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -8,6 +8,11 @@ jest.mock('../../api/post', () => ({
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
 }));
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({})
@@ -37,22 +42,22 @@ const post: Post = {
 } as unknown as Post;
 
 describe('PostCard summary tags', () => {
-  it('renders node id, status, and username tags', () => {
+  it('renders node id, status, and username tags', async () => {
     const enriched = { ...post, author: { id: 'u1', username: 'alice' } } as Post;
     render(
       <BrowserRouter>
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(screen.getByText('Q::Task:T1')).toBeInTheDocument();
-    expect(screen.getByText('In Progress')).toBeInTheDocument();
-    const userLink = screen.getByRole('link', { name: '@alice' });
+    expect(await screen.findByText('Q::Task:T1')).toBeInTheDocument();
+    expect(await screen.findByText('In Progress')).toBeInTheDocument();
+    const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const nodeLink = screen.getByRole('link', { name: 'Q::Task:T1' });
+    const nodeLink = await screen.findByRole('link', { name: 'Q::Task:T1' });
     expect(nodeLink).toHaveAttribute('href', '/post/p1');
   });
 
-  it('renders node id and username for change requests', () => {
+  it('renders node id and username for change requests', async () => {
     const changeReq: Post = {
       id: 'p2',
       authorId: 'u1',
@@ -71,10 +76,10 @@ describe('PostCard summary tags', () => {
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(screen.getByText('Q::Task:T01:C00')).toBeInTheDocument();
-    const userLink = screen.getByRole('link', { name: '@alice' });
+    expect(await screen.findByText('Q::Task:T01:C00')).toBeInTheDocument();
+    const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const nodeLink = screen.getByRole('link', { name: 'Q::Task:T01:C00' });
+    const nodeLink = await screen.findByRole('link', { name: 'Q::Task:T01:C00' });
     expect(nodeLink).toHaveAttribute('href', '/post/p2');
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -21,7 +21,7 @@ import ActionMenu from '../ui/ActionMenu';
 import GitFileBrowserInline from '../git/GitFileBrowserInline';
 import MapGraphLayout from '../layout/MapGraphLayout';
 import TeamPanel from '../quest/TeamPanel';
-import { buildSummaryTags } from '../../utils/displayUtils';
+import { buildSummaryTags, type SummaryTagData } from '../../utils/displayUtils';
 import { TAG_BASE } from '../../constants/styles';
 
 const PREVIEW_LIMIT = 240;
@@ -162,7 +162,16 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const content = post.renderedContent || post.content;
   const titleText = post.title || makeHeader(post.content);
-  const summaryTags = buildSummaryTags(post, questTitle, questId);
+  const [summaryTags, setSummaryTags] = useState<SummaryTagData[]>([]);
+  useEffect(() => {
+    let active = true;
+    buildSummaryTags(post, questTitle, questId).then(tags => {
+      if (active) setSummaryTags(tags);
+    });
+    return () => {
+      active = false;
+    };
+  }, [post, questTitle, questId]);
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
 

--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -15,6 +15,11 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
 const basePost: PostWithQuestTitle = {
   id: 'p1',
   authorId: 'u1',
@@ -28,18 +33,19 @@ const basePost: PostWithQuestTitle = {
 } as unknown as PostWithQuestTitle;
 
 describe('PostListItem', () => {
-  it('navigates to post page on click', () => {
+  it('navigates to post page on click', async () => {
     render(
       <BrowserRouter>
         <PostListItem post={basePost} />
       </BrowserRouter>
     );
 
+    await screen.findByText(/hello world/i);
     fireEvent.click(screen.getByText(/hello world/i));
     expect(navMock).toHaveBeenCalledWith(ROUTES.POST('p1'));
   });
 
-  it('renders quest path tag for task posts', () => {
+  it('renders quest path tag for task posts', async () => {
     const taskPost: PostWithQuestTitle = {
       ...basePost,
       id: 't1',
@@ -53,7 +59,6 @@ describe('PostListItem', () => {
         <PostListItem post={taskPost} />
       </BrowserRouter>
     );
-
-    expect(screen.getAllByText('Q::Task:T00').length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Q::Task:T00')).length).toBeGreaterThan(0);
   });
 });

--- a/ethos-frontend/src/components/post/PostListItem.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { FaStar, FaStarHalfAlt, FaRegStar } from 'react-icons/fa';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import type { PostWithQuestTitle } from '../../utils/displayUtils';
-import { getDisplayTitle, buildSummaryTags } from '../../utils/displayUtils';
+import { getDisplayTitle, buildSummaryTags, type SummaryTagData } from '../../utils/displayUtils';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import SummaryTag from '../ui/SummaryTag';
@@ -32,7 +32,16 @@ const PostListItem: React.FC<PostListItemProps> = ({ post }) => {
     ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
     : '';
   const header = getDisplayTitle(post, post.questTitle);
-  const summaryTags = buildSummaryTags(post);
+  const [summaryTags, setSummaryTags] = useState<SummaryTagData[]>([]);
+  useEffect(() => {
+    let active = true;
+    buildSummaryTags(post).then(tags => {
+      if (active) setSummaryTags(tags);
+    });
+    return () => {
+      active = false;
+    };
+  }, [post]);
 
   return (
     <div

--- a/ethos-frontend/src/components/post/TaskPreviewCard.tsx
+++ b/ethos-frontend/src/components/post/TaskPreviewCard.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Select, StatusBadge, SummaryTag } from '../ui';
 import { STATUS_OPTIONS, TASK_TYPE_OPTIONS } from '../../constants/options';
 import type { Post, QuestTaskStatus } from '../../types/postTypes';
-import { buildSummaryTags } from '../../utils/displayUtils';
+import { buildSummaryTags, type SummaryTagData } from '../../utils/displayUtils';
 import type { SummaryTagData } from '../ui/SummaryTag';
 import { ROUTES } from '../../constants/routes';
 import { updatePost } from '../../api/post';
@@ -120,7 +120,16 @@ const TaskPreviewCard: React.FC<TaskPreviewCardProps> = ({
     }
   };
 
-  const summaryTags = buildSummaryTags(post);
+  const [summaryTags, setSummaryTags] = useState<SummaryTagData[]>([]);
+  useEffect(() => {
+    let active = true;
+    buildSummaryTags(post).then(tags => {
+      if (active) setSummaryTags(tags);
+    });
+    return () => {
+      active = false;
+    };
+  }, [post]);
   let taskTag: SummaryTagData | undefined = summaryTags.find(
     t => t.type === 'task',
   );

--- a/ethos-frontend/src/components/quest/TaskCard.tsx
+++ b/ethos-frontend/src/components/quest/TaskCard.tsx
@@ -6,7 +6,7 @@ import { useGraph } from '../../hooks/useGraph';
 import QuestNodeInspector from './QuestNodeInspector';
 import TaskPreviewCard from '../post/TaskPreviewCard';
 import SummaryTag from '../ui/SummaryTag';
-import { buildSummaryTags } from '../../utils/displayUtils';
+import { buildSummaryTags, type SummaryTagData } from '../../utils/displayUtils';
 import StatusBoardPanel from './StatusBoardPanel';
 import QuickTaskForm from '../post/QuickTaskForm';
 import SubtaskChecklist from './SubtaskChecklist';
@@ -122,9 +122,20 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, questId, user, onUpdate }) =>
 
   const parentEdge = edges.find((e) => e.to === selected.id);
   const parentNode = parentEdge ? nodes.find((n) => n.id === parentEdge.from) : undefined;
-  const parentTag = !isRootSelected && parentNode
-    ? buildSummaryTags(parentNode).find((t) => t.type === 'task')
-    : undefined;
+  const [parentTag, setParentTag] = useState<SummaryTagData | undefined>(undefined);
+  useEffect(() => {
+    if (!isRootSelected && parentNode) {
+      let active = true;
+      buildSummaryTags(parentNode).then(tags => {
+        if (active) setParentTag(tags.find(t => t.type === 'task'));
+      });
+      return () => {
+        active = false;
+      };
+    }
+    setParentTag(undefined);
+    return undefined;
+  }, [isRootSelected, parentNode]);
 
   const taskType = selected.taskType || 'abstract';
   const status = selected.status;

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -2,6 +2,22 @@ import type { Post, PostType } from "../types/postTypes";
 import type { Quest } from "../types/questTypes";
 import { ROUTES } from "../constants/routes";
 import type { SummaryTagType } from "../components/ui/SummaryTag";
+import { fetchUserById } from "../api/auth";
+
+const usernameCache = new Map<string, string>();
+
+const getUsernameFromId = async (userId: string): Promise<string> => {
+  if (usernameCache.has(userId)) return usernameCache.get(userId)!;
+  try {
+    const user = await fetchUserById(userId);
+    const name = user.username || user.id;
+    usernameCache.set(userId, name);
+    return name;
+  } catch {
+    usernameCache.set(userId, userId);
+    return userId;
+  }
+};
 
 export const toTitleCase = (str: string): string =>
   str.replace(/\b([a-z])/g, (c) => c.toUpperCase());
@@ -114,11 +130,11 @@ const formatNodeId = (nodeId: string): string => {
   return typeLabel ? `Q::${typeLabel}:${segments.join(':')}` : `Q:${segments.join(':')}`;
 };
 
-export const buildSummaryTags = (
+export const buildSummaryTags = async (
   post: PostWithQuestTitle,
   questTitle?: string,
   questId?: string,
-): SummaryTagData[] => {
+): Promise<SummaryTagData[]> => {
   void questTitle;
   void questId;
   const tags: SummaryTagData[] = [];
@@ -151,10 +167,10 @@ export const buildSummaryTags = (
   tags.push(primaryTag);
 
   if (post.authorId) {
-    const user = post.author?.username || post.authorId;
+    const username = await getUsernameFromId(post.authorId);
     tags.push({
       type: 'type',
-      label: `@${user}`,
+      label: `@${username}`,
       link: ROUTES.PUBLIC_PROFILE(post.authorId),
     });
   }


### PR DESCRIPTION
## Summary
- fetch username by authorId for summary tags
- update components/tests for async summary tag building

## Testing
- `npm --prefix ethos-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689c22301538832f821814089de1a09a