### PR TITLE
Hide main post from thread board

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestHelp.test.tsx
@@ -38,9 +38,6 @@ jest.mock('../../api/auth', () => ({
   __esModule: true,
   fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
 }));
-
-const appendMock = jest.fn();
-const removeMock = jest.fn();
   
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -39,8 +39,6 @@ jest.mock('../../api/auth', () => ({
   fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
 }));
 
-const appendMock = jest.fn();
-
 jest.mock('../../contexts/BoardContext', () => ({
   __esModule: true,
   useBoardContext: () => ({ appendToBoard: jest.fn(), selectedBoard: null }),

--- a/ethos-frontend/src/pages/__tests__/PostPageThreadBoard.test.tsx
+++ b/ethos-frontend/src/pages/__tests__/PostPageThreadBoard.test.tsx
@@ -1,0 +1,85 @@
+import { render, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostPage from '../post/[id]';
+import type { BoardData } from '../../types/boardTypes';
+import type { Post } from '../../types/postTypes';
+
+const fetchPostById = jest.fn(() =>
+  Promise.resolve({
+    id: 'p1',
+    authorId: 'u1',
+    type: 'free_speech',
+    content: 'hi',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+  })
+);
+
+const replyBoard: BoardData = {
+  id: 'thread-p1',
+  items: ['r1'],
+  enrichedItems: [{ id: 'r1' } as unknown as Post],
+};
+const fetchReplyBoard = jest.fn(() => Promise.resolve(replyBoard));
+
+const boardMock = jest.fn();
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchPostById: (...args: Parameters<typeof fetchPostById>) => fetchPostById(...args),
+  fetchReplyBoard: (...args: Parameters<typeof fetchReplyBoard>) => fetchReplyBoard(...args),
+}));
+
+jest.mock('../../components/board/Board', () => ({
+  __esModule: true,
+  default: (props: unknown) => {
+    boardMock(props);
+    return <div>Board</div>;
+  },
+}));
+
+jest.mock('../../components/post/PostCard', () => ({
+  __esModule: true,
+  default: () => <div>PostCard</div>,
+}));
+
+jest.mock('../../components/post/CreatePost', () => ({
+  __esModule: true,
+  default: () => <div>CreatePost</div>,
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+jest.mock('../../hooks/useSocket', () => ({
+  useSocket: () => ({ socket: null }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useParams: () => ({ id: 'p1' }),
+    useSearchParams: () => [new URLSearchParams('')],
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('PostPage thread board', () => {
+  it('does not include main post in thread board items', async () => {
+    render(
+      <BrowserRouter>
+        <PostPage />
+      </BrowserRouter>
+    );
+    await waitFor(() => expect(boardMock).toHaveBeenCalled());
+    const props = boardMock.mock.calls[0][0];
+    expect(props.board.items).not.toContain('p1');
+    expect(props.board.title).toBe('Thread');
+  });
+});

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -37,15 +37,13 @@ const PostPage: React.FC = () => {
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [parentPost, setParentPost] = useState<Post | null>(null);
 
-  const boardWithPost = useMemo<BoardData | null>(() => {
-    if (!replyBoard || !post) return null;
+  const threadBoard = useMemo<BoardData | null>(() => {
+    if (!replyBoard) return null;
     return {
       ...replyBoard,
       title: replyBoard.title || 'Thread',
-      items: [post.id, ...(replyBoard.items || [])],
-      enrichedItems: [post, ...(replyBoard.enrichedItems ?? [])],
     };
-  }, [replyBoard, post]);
+  }, [replyBoard]);
 
   const taskRepliesBoard = useMemo<BoardData | null>(() => {
     if (!replyBoard) return null;
@@ -234,10 +232,10 @@ const PostPage: React.FC = () => {
       </section>
 
       <section>
-        {boardWithPost ? (
+        {threadBoard ? (
           <Board
             boardId={`thread-${id}`}
-            board={boardWithPost}
+            board={threadBoard}
             layout="grid"
             onScrollEnd={loadMoreReplies}
             loading={loadingMore}


### PR DESCRIPTION
## Summary
- Stop prepending the main post to the reply board
- Display only replies in the thread board on the post detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2e3ea5d8832fbb2f81194a6268e5