### PR TITLE
Ensure change PostCard renders three summary tags

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -111,5 +111,7 @@ describe('PostCard summary tags', () => {
     expect(taskLink).toHaveAttribute('href', '/post/t1');
     const changeLink = await screen.findByRole('link', { name: 'Q::Task:T01:C00' });
     expect(changeLink).toHaveAttribute('href', '/post/c1');
+    const tags = await screen.findAllByTestId('summary-tag');
+    expect(tags).toHaveLength(3);
   });
 });

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -80,7 +80,7 @@ const SummaryTag: React.FC<SummaryTagProps> = ({
 
   if (username && usernameLink && detailLink) {
     return (
-      <span className={clsx(baseClass, colorClass, className)}>
+      <span data-testid="summary-tag" className={clsx(baseClass, colorClass, className)}>
         <Icon className="w-3 h-3 flex-shrink-0" />
         <Link to={detailLink} className="underline text-inherit">
           {label}
@@ -100,7 +100,11 @@ const SummaryTag: React.FC<SummaryTagProps> = ({
 
   if (link) {
     return (
-      <Link to={link} className={clsx(baseClass, colorClass, className)}>
+      <Link
+        to={link}
+        data-testid="summary-tag"
+        className={clsx(baseClass, colorClass, className)}
+      >
         {content}
       </Link>
     );
@@ -108,13 +112,21 @@ const SummaryTag: React.FC<SummaryTagProps> = ({
 
   if (detailLink) {
     return (
-      <Link to={detailLink} className={clsx(baseClass, colorClass, className)}>
+      <Link
+        to={detailLink}
+        data-testid="summary-tag"
+        className={clsx(baseClass, colorClass, className)}
+      >
         {content}
       </Link>
     );
   }
 
-  return <span className={clsx(baseClass, colorClass, className)}>{content}</span>;
+  return (
+    <span data-testid="summary-tag" className={clsx(baseClass, colorClass, className)}>
+      {content}
+    </span>
+  );
 };
 
 export default SummaryTag;


### PR DESCRIPTION
## Summary
- add test IDs to SummaryTag component for easy counting
- verify change post cards display Task, Change, and username tags

## Testing
- `npx jest --testMatch "<rootDir>/src/components/post/PostCard.summary.test.tsx"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb0f24b1c832f905e6990e0a9f475