### PR TITLE
Restrict replies to free speech for non-participants

### DIFF
--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import type { Post } from '../src/types/postTypes';
 
 jest.mock('../src/api/post', () => ({
   __esModule: true,
@@ -21,13 +22,20 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
+const mockUseAuth = jest.fn();
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
 import CreatePost from '../src/components/post/CreatePost';
 
 import { addPost } from '../src/api/post';
 
 describe('CreatePost replying', () => {
-  it('offers free speech, task, and change when replying to a task', () => {
-    const reply = { id: 't1', type: 'task' } as Post;
+  it('offers free speech, task, and change when replying to a task as a participant', () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' } });
+    const reply = { id: 't1', type: 'task', authorId: 'u1' } as Post;
     render(
       <BrowserRouter>
         <CreatePost onCancel={() => {}} replyTo={reply} />
@@ -37,6 +45,20 @@ describe('CreatePost replying', () => {
       screen.getByLabelText('Item Type').querySelectorAll('option')
     ).map((o) => o.textContent);
     expect(options).toEqual(['Free Speech', 'Task', 'Change']);
+  });
+
+  it('offers only free speech when replying to a task as an outsider', () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u2' } });
+    const reply = { id: 't1', type: 'task', authorId: 'u1', collaborators: [] } as Post;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={reply} />
+      </BrowserRouter>
+    );
+    const options = Array.from(
+      screen.getByLabelText('Item Type').querySelectorAll('option')
+    ).map((o) => o.textContent);
+    expect(options).toEqual(['Free Speech']);
   });
 
   it('includes reply questId in payload', async () => {

--- a/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
+++ b/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
@@ -21,6 +21,12 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
+const mockUseAuth = jest.fn(() => ({ user: { id: 'u1' } }));
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
 // Avoid LinkControls side effects
 jest.mock('../src/components/controls/LinkControls', () => ({
   __esModule: true,

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -24,6 +24,12 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
+const mockUseAuth = jest.fn(() => ({ user: { id: 'u1' } }));
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
 import CreatePost from '../src/components/post/CreatePost';
 
 describe('Timeline board post types', () => {


### PR DESCRIPTION
## Summary
- limit reply options to free speech when current user is not the author or collaborator of a task or change
- enforce same restriction on backend route for creating posts
- update tests to cover participant vs non-participant replies

## Testing
- `cd ethos-frontend && npm test`
- `cd ethos-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb10aae94832fae6009b17e44a69e