### PR TITLE
refactor scroll handling across layouts

### DIFF
--- a/ethos-frontend/src/components/layout/GraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/GraphLayout.tsx
@@ -5,6 +5,7 @@ import React, {
   useLayoutEffect,
   useCallback,
 } from "react";
+import { useScrollEnd } from "../../hooks/useScrollEnd";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import { useGitDiff } from "../../hooks/useGit";
 import { Spinner } from "../ui";
@@ -73,7 +74,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   loadingMore = false,
   boardId,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useScrollEnd<HTMLDivElement>(onScrollEnd, 100);
   const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [paths, setPaths] = useState<{ key: string; d: string; type?: string }[]>([]);
 
@@ -131,7 +132,7 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
       }
     });
     setPaths(newPaths);
-  }, [edgeList]);
+  }, [edgeList, containerRef]);
 
   const debouncedComputePaths = useRef<() => void>(() => {});
 
@@ -193,18 +194,12 @@ const GraphLayout: React.FC<GraphLayoutProps> = ({
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-
     const handleScroll = () => {
       debouncedComputePaths.current();
-      if (!onScrollEnd) return;
-      const { scrollTop, scrollHeight, clientHeight } = el;
-      if (scrollTop + clientHeight >= scrollHeight - 100) {
-        onScrollEnd();
-      }
     };
     el.addEventListener("scroll", handleScroll);
     return () => el.removeEventListener("scroll", handleScroll);
-  }, [onScrollEnd]);
+  }, [containerRef, debouncedComputePaths]);
 
   const handleNodeClick = (n: Post) => {
     setSelectedNode(n);

--- a/ethos-frontend/src/components/layout/ListLayout.tsx
+++ b/ethos-frontend/src/components/layout/ListLayout.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
+import { useScrollEnd } from '../../hooks/useScrollEnd';
 import ContributionCard from '../contribution/ContributionCard';
 import { Spinner } from '../ui';
 import type { Post } from '../../types/postTypes';
@@ -38,19 +39,7 @@ const ListLayout: React.FC<ListLayoutProps> = ({
   expandedId,
   onExpand,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !onScrollEnd) return;
-    const handle = () => {
-      if (el.scrollHeight - el.scrollTop <= el.clientHeight + 150) {
-        onScrollEnd();
-      }
-    };
-    el.addEventListener('scroll', handle);
-    return () => el.removeEventListener('scroll', handle);
-  }, [onScrollEnd]);
+  const containerRef = useScrollEnd<HTMLDivElement>(onScrollEnd);
 
   if (!items || items.length === 0) {
     return (

--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -10,6 +10,7 @@ import type { User } from '../../types/userTypes';
 import type { TaskEdge } from '../../types/questTypes';
 import { getDisplayTitle } from '../../utils/displayUtils';
 import { getNodeStyle } from '../ui/NodeTypeBadge';
+import { Spinner } from '../ui';
 
 interface MapGraphLayoutProps {
   items: Post[];
@@ -27,6 +28,8 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
   items,
   edges = [],
   onNodeClick,
+  onScrollEnd,
+  loadingMore = false,
 }) => {
   const fgRef =
     useRef<
@@ -117,6 +120,11 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
         onNodeClick={handleNodeClick}
         onNodeDragEnd={handleNodeDragEnd}
       />
+      {loadingMore && (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      )}
     </div>
   );
 };

--- a/ethos-frontend/src/components/layout/MapGraphLayout.tsx
+++ b/ethos-frontend/src/components/layout/MapGraphLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useEffect, useRef, useState } from 'react';
+import { useScrollEnd } from '../../hooks/useScrollEnd';
 import ForceGraph2D, {
   type ForceGraphMethods,
   type NodeObject,
@@ -35,7 +36,7 @@ const MapGraphLayout: React.FC<MapGraphLayoutProps> = ({
         >
       | undefined
     >(undefined);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useScrollEnd<HTMLDivElement>(onScrollEnd);
   const [edgeList, setEdgeList] = useState<TaskEdge[]>(edges);
 
   useEffect(() => {

--- a/ethos-frontend/src/hooks/useScrollEnd.ts
+++ b/ethos-frontend/src/hooks/useScrollEnd.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook to trigger a callback when a scrollable element reaches the end.
+ *
+ * @param callback Function invoked when the element is scrolled near the bottom.
+ * @param offset   Distance from the bottom before triggering the callback.
+ * @returns        A ref to attach to the scrollable element.
+ */
+export const useScrollEnd = <T extends HTMLElement>(
+  callback?: () => void,
+  offset = 150
+) => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !callback) return;
+    const handle = () => {
+      if (el.scrollHeight - el.scrollTop <= el.clientHeight + offset) {
+        callback();
+      }
+    };
+    el.addEventListener('scroll', handle);
+    return () => el.removeEventListener('scroll', handle);
+  }, [callback, offset]);
+
+  return ref;
+};
+
+export default useScrollEnd;


### PR DESCRIPTION
## Summary
- add `useScrollEnd` hook for reusable infinite scroll logic
- refactor ListLayout, GraphLayout, and MapGraphLayout to use the hook
- remove duplicated scroll event code

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbbb99a60832fa456be631844b101