### PR TITLE
Refactor contribution and post components

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -7,6 +7,11 @@ import type { Quest } from '../types/questTypes';
 
 const BASE_URL = '/posts';
 
+const buildQuery = (params: URLSearchParams): string => {
+  const query = params.toString();
+  return query ? `?${query}` : '';
+};
+
 /**
  * 🔍 Fetch a single post by ID
  * @param id - Post ID
@@ -31,7 +36,7 @@ export const fetchRecentPosts = async (
   const params = new URLSearchParams();
   if (userId) params.set('userId', userId);
   params.set('hops', hops.toString());
-  const url = `${BASE_URL}/recent${params.toString() ? `?${params.toString()}` : ''}`;
+  const url = `${BASE_URL}/recent${buildQuery(params)}`;
   const res = await axiosWithAuth.get(url);
   return res.data;
 };
@@ -70,7 +75,7 @@ export const fetchReplyBoard = async (
   if (options.page) params.set('page', options.page.toString());
   if (options.limit) params.set('limit', options.limit.toString());
 
-  const url = `/boards/thread/${postId}${params.toString() ? `?${params.toString()}` : ''}`;
+  const url = `/boards/thread/${postId}${buildQuery(params)}`;
   const res = await axiosWithAuth.get(url);
   return res.data;
 };
@@ -105,7 +110,7 @@ export const fetchPostsByBoardId = async (
   params.set('enrich', 'true');
   if (userId) params.set('userId', userId);
   const res = await axiosWithAuth.get(
-    `/boards/${boardId}/items?${params.toString()}`
+    `/boards/${boardId}/items${buildQuery(params)}`
   );
   return (res.data || []).filter((item: Post | Record<string, unknown>) => 'content' in item) as Post[];
 };

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -118,6 +118,13 @@ const PostCard: React.FC<PostCardProps> = ({
         : 'max-w-prose';
 
   const expandedView = expanded ?? internalExpandedView;
+  const cardClasses = clsx(
+    'relative border border-secondary rounded bg-surface shadow-sm p-4 space-y-3 text-primary',
+    widthClass,
+    depth === 0 ? 'mx-auto' : '',
+    post.highlight && 'border-accent bg-infoBackground',
+    className,
+  );
 
   const qid = questId || post.questId;
 
@@ -147,6 +154,34 @@ const PostCard: React.FC<PostCardProps> = ({
   }, [post, questTitle, questId]);
   const isLong = content.length > PREVIEW_LIMIT;
   const allowDelete = !headPostId || post.id !== headPostId;
+
+  const renderHeader = () => (
+    <div className="flex justify-between text-sm text-secondary">
+      <div className="flex flex-wrap items-center gap-2">
+        {summaryTags.map((tag, idx) => (
+          <React.Fragment key={idx}>
+            <SummaryTag
+              {...tag}
+              className={tag.type === 'quest' ? 'truncate max-w-[8rem]' : undefined}
+            />
+          </React.Fragment>
+        ))}
+        {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
+      </div>
+      <div className="flex items-center gap-2">
+        <ActionMenu
+          id={post.id}
+          type="post"
+          canEdit={canEdit}
+          onEdit={() => setEditMode(true)}
+          onDelete={() => onDelete?.(post.id)}
+          allowDelete={allowDelete}
+          content={post.content}
+          permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
+        />
+      </div>
+    </div>
+  );
 
 
   useEffect(() => {
@@ -207,46 +242,13 @@ const PostCard: React.FC<PostCardProps> = ({
 
   if (headerOnly) {
     return (
-      <div
-        id={post.id}
-        className={clsx(
-          'relative border border-secondary rounded bg-surface shadow-sm p-4 space-y-3 text-primary',
-          widthClass,
-          depth === 0 ? 'mx-auto' : '',
-          post.highlight && 'border-accent bg-infoBackground',
-          className
+      <div id={post.id} className={cardClasses}>
+        {renderHeader()}
+        {isQuestBoardRequest && timestamp && (
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {timestamp}
+          </div>
         )}
-      >
-        <div className="flex justify-between text-sm text-secondary">
-          <div className="flex flex-wrap items-center gap-2">
-            {summaryTags.map((tag, idx) => (
-              <React.Fragment key={idx}>
-                <SummaryTag
-                  {...tag}
-                  className={tag.type === 'quest' ? 'truncate max-w-[8rem]' : undefined}
-                />
-              </React.Fragment>
-            ))}
-            {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
-          </div>
-          <div className="flex items-center gap-2">
-            <ActionMenu
-              id={post.id}
-              type="post"
-              canEdit={canEdit}
-              onEdit={() => setEditMode(true)}
-              onDelete={() => onDelete?.(post.id)}
-              allowDelete={allowDelete}
-              content={post.content}
-              permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
-            />
-          </div>
-        </div>
-          {isQuestBoardRequest && timestamp && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {timestamp}
-            </div>
-          )}
         {titleText && (
           <h3
             className="font-semibold text-lg mt-1 cursor-pointer truncate"
@@ -269,41 +271,8 @@ const PostCard: React.FC<PostCardProps> = ({
   }
 
   return (
-    <div
-      id={post.id}
-      className={clsx(
-        'relative border border-secondary rounded bg-surface shadow-sm p-4 space-y-3 text-primary',
-        widthClass,
-        depth === 0 ? 'mx-auto' : '',
-        post.highlight && 'border-accent bg-infoBackground',
-        className
-      )}
-    >
-      <div className="flex justify-between text-sm text-secondary">
-        <div className="flex flex-wrap items-center gap-2">
-          {summaryTags.map((tag, idx) => (
-            <React.Fragment key={idx}>
-              <SummaryTag
-                {...tag}
-                className={tag.type === 'quest' ? 'truncate max-w-[8rem]' : undefined}
-              />
-            </React.Fragment>
-          ))}
-          {post.tags?.includes('review') && post.rating && renderStars(post.rating)}
-        </div>
-        <div className="flex items-center gap-2">
-          <ActionMenu
-            id={post.id}
-            type="post"
-            canEdit={canEdit}
-            onEdit={() => setEditMode(true)}
-            onDelete={() => onDelete?.(post.id)}
-            allowDelete={allowDelete}
-            content={post.content}
-            permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
-          />
-        </div>
-      </div>
+    <div id={post.id} className={cardClasses}>
+      {renderHeader()}
       {isQuestBoardRequest && timestamp && (
         <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
           {timestamp}


### PR DESCRIPTION
## Summary
- factor out quest-to-post conversion for ContributionCard
- extract reusable header rendering in PostCard and simplify card classes
- streamline ReactionControls role logic and memoization
- add helper for query string building in post API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc99b9eb0832f97e95304c8eb3cff