### PR TITLE
Rename change posts to file posts

### DIFF
--- a/docs/git-account-integration.md
+++ b/docs/git-account-integration.md
@@ -13,13 +13,13 @@ This guide outlines how Ethos connects a user's GitHub or GitLab account and map
 
 * After linking an account, connect a quest or project to a repository using `POST /api/git/connect`.
 * The top task `T00` corresponds to the repository root directory.
-* Files and tracked changes appear as `C00`, `C01`, etc., representing replies to the original task.
-* Each change post shows additions and insertions similar to a commit diff.
+* File posts appear as `F00`, `F01`, etc., representing files stored under the original task.
+* Each file post shows additions and insertions similar to a commit diff.
 
 ## Task Posts and Subtasks
 
-* Users can open a task and create reply posts to discuss or propose changes.
-* A reply of type `change` is treated as a subtask in the graph and can be tied to deliverables.
+* Users can open a task and create reply posts to discuss or propose file updates.
+* A reply of type `file` is treated as a subtask in the graph and can be tied to deliverables.
 * Clicking on a task opens its post page where further replies and discussions can occur.
 
 ## Nested Folders and READMEs

--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -13,7 +13,7 @@ Q:<quest-slug>:<segment><number>
 - `<segment>` – one letter describing the post type:
   - `T` – task or quest node
   - `L` – log entry
-  - `C` – commit
+  - `F` – file
   - `I` – issue
 - `<number>` – a zero‑padded counter starting at `00` for each segment within a quest.
 

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -67,7 +67,7 @@ export type PostType =
   | 'free_speech'
   | 'request'
   | 'task'
-  | 'change'
+  | 'file'
   | 'review';
 
 export type LinkStatus = 'active' | 'solved' | 'private' | 'pending';

--- a/ethos-backend/src/utils/nodeIdUtils.ts
+++ b/ethos-backend/src/utils/nodeIdUtils.ts
@@ -17,7 +17,7 @@ const zeroPad = (num: number): string => num.toString().padStart(2, '0');
 const typeMap: Record<string, string> = {
   quest: 'T',
   task: 'T',
-  change: 'C',
+  file: 'F',
   free_speech: 'L',
 };
 

--- a/ethos-backend/tests/posts.test.ts
+++ b/ethos-backend/tests/posts.test.ts
@@ -49,31 +49,31 @@ describe('post routes', () => {
     expect(res.body.nodeId).toBe('T00');
   });
 
-  it('rejects change post without parent', async () => {
+  it('rejects file post without parent', async () => {
     postsStoreMock.read.mockReturnValue([]);
-    const res = await request(app).post('/posts').send({ type: 'change' });
+    const res = await request(app).post('/posts').send({ type: 'file' });
     expect(res.status).toBe(400);
   });
 
-  it('allows change post replying to task', async () => {
+  it('allows file post replying to task', async () => {
     const task = { id: 't1', authorId: 'u1', type: 'task', content: '', visibility: 'public', timestamp: '' };
     postsStoreMock.read.mockReturnValue([task]);
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'change', replyTo: 't1' });
+      .send({ type: 'file', replyTo: 't1' });
     expect(res.status).toBe(201);
   });
 
-  it('disallows change requests replying to tasks', async () => {
+  it('disallows file requests replying to tasks', async () => {
     const task = { id: 't1', authorId: 'u1', type: 'task', content: '', visibility: 'public', timestamp: '' };
     postsStoreMock.read.mockReturnValue([task]);
     let res = await request(app)
       .post('/posts')
-      .send({ type: 'request', subtype: 'change', content: 'req' });
+      .send({ type: 'request', subtype: 'file', content: 'req' });
     expect(res.status).toBe(400);
     res = await request(app)
       .post('/posts')
-      .send({ type: 'request', subtype: 'change', content: 'req', replyTo: 't1' });
+      .send({ type: 'request', subtype: 'file', content: 'req', replyTo: 't1' });
     expect(res.status).toBe(400);
   });
 
@@ -86,12 +86,12 @@ describe('post routes', () => {
     expect(res.status).toBe(201);
   });
 
-  it('rejects task replying to change', async () => {
-    const change = { id: 'c1', authorId: 'u1', type: 'change', content: '', visibility: 'public', timestamp: '' };
-    postsStoreMock.read.mockReturnValue([change]);
+  it('rejects task replying to file', async () => {
+    const file = { id: 'f1', authorId: 'u1', type: 'file', content: '', visibility: 'public', timestamp: '' };
+    postsStoreMock.read.mockReturnValue([file]);
     const res = await request(app)
       .post('/posts')
-      .send({ type: 'task', replyTo: 'c1' });
+      .send({ type: 'task', replyTo: 'f1' });
     expect(res.status).toBe(400);
   });
 
@@ -108,16 +108,16 @@ describe('post routes', () => {
     expect(res.status).toBe(400);
   });
 
-  it('restricts replies to change posts', async () => {
-    const change = { id: 'c1', authorId: 'u1', type: 'change', content: '', visibility: 'public', timestamp: '' };
-    postsStoreMock.read.mockReturnValue([change]);
+  it('restricts replies to file posts', async () => {
+    const file = { id: 'f1', authorId: 'u1', type: 'file', content: '', visibility: 'public', timestamp: '' };
+    postsStoreMock.read.mockReturnValue([file]);
     let res = await request(app)
       .post('/posts')
-      .send({ type: 'free_speech', replyTo: 'c1' });
+      .send({ type: 'free_speech', replyTo: 'f1' });
     expect(res.status).toBe(201);
     res = await request(app)
       .post('/posts')
-      .send({ type: 'change', replyTo: 'c1' });
+      .send({ type: 'file', replyTo: 'f1' });
     expect(res.status).toBe(201);
   });
 
@@ -126,7 +126,7 @@ describe('post routes', () => {
     postsStoreMock.read.mockReturnValue([task]);
     let res = await request(app)
       .post('/posts')
-      .send({ type: 'change', replyTo: 't1' });
+      .send({ type: 'file', replyTo: 't1' });
     expect(res.status).toBe(400);
     res = await request(app)
       .post('/posts')

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -230,7 +230,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
         <> 
           {itemTypes.includes('post') && (
             <div className="flex gap-1 mb-1 flex-wrap">
-              {['all', 'free_speech', 'task', 'change', 'request', 'review'].map((t) => (
+              {['all', 'free_speech', 'task', 'file', 'request', 'review'].map((t) => (
                 <button
                   key={t}
                   type="button"

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -27,7 +27,7 @@ import type {
 } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
 
-type ReplyType = 'free_speech' | 'task' | 'change';
+type ReplyType = 'free_speech' | 'task' | 'file';
 
 type ReviewState = 'review' | 'pending' | 'reviewed';
 type RequestState = 'request' | 'pending' | 'complete';
@@ -247,7 +247,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </button>
 
         {/* Repost */}
-        {['free_speech', 'task', 'change'].includes(post.type) && (
+        {['free_speech', 'task', 'file'].includes(post.type) && (
           <button
             aria-label="Repost"
             className={clsx('flex items-center gap-1', reactions.repost && 'text-indigo-600')}
@@ -258,8 +258,8 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           </button>
         )}
 
-        {/* Review status for changes */}
-        {post.type === 'change' && (
+        {/* Review status for files */}
+        {post.type === 'file' && (
           <button
             className={clsx('flex items-center gap-1', reviewState !== 'review' && 'text-indigo-600')}
             onClick={cycleReview}
@@ -293,10 +293,10 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         )}
 
         {/* Reply / Update */}
-        {post.type === 'change' ? (
+        {post.type === 'file' ? (
           <button
             className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-            onClick={() => goToReplyPageOrToggle('change')}
+            onClick={() => goToReplyPageOrToggle('file')}
             aria-label="Update"
           >
             <FaReply /> {showReplyPanel ? 'Cancel' : 'Update'}

--- a/ethos-frontend/src/components/git/GitFileBrowser.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowser.tsx
@@ -15,7 +15,7 @@ const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => 
   const [currentPath, setCurrentPath] = useState<string>('');
   const [editingFile, setEditingFile] = useState<GitFile | null>(null);
   const [content, setContent] = useState('');
-  const [message, setMessage] = useState('Commit change');
+  const [message, setMessage] = useState('Commit file');
   const [issueId, setIssueId] = useState('');
   const [saving, setSaving] = useState(false);
 
@@ -33,7 +33,7 @@ const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => 
     } else {
       setEditingFile(f);
       setContent('');
-      setMessage('Commit change');
+      setMessage('Commit file');
       }
   };
 
@@ -50,7 +50,7 @@ const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => 
       const diff = await fetchGitDiff(questId, editingFile.path);
       const commitMsg = message || `Update ${editingFile.path}`;
       await addPost({
-        type: 'change',
+        type: 'file',
         questId,
         content: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
         commitSummary: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
@@ -89,7 +89,7 @@ const GitFileBrowser: React.FC<GitFileBrowserProps> = ({ questId, onClose }) => 
             <TextArea rows={10} value={content} onChange={(e) => setContent(e.target.value)} />
             <div className="flex gap-2">
               <Button onClick={handleSave} disabled={saving}>
-                {saving ? 'Saving...' : 'Commit Change'}
+                {saving ? 'Saving...' : 'Commit File'}
               </Button>
               <Button variant="ghost" onClick={() => setEditingFile(null)}>
                 Cancel

--- a/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
+++ b/ethos-frontend/src/components/git/GitFileBrowserInline.tsx
@@ -15,7 +15,7 @@ const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, on
   const [currentPath, setCurrentPath] = useState<string>('');
   const [editingFile, setEditingFile] = useState<GitFile | null>(null);
   const [content, setContent] = useState('');
-  const [message, setMessage] = useState('Commit change');
+  const [message, setMessage] = useState('Commit file');
   const [issueId, setIssueId] = useState('');
   const [saving, setSaving] = useState(false);
   const [creatingFolder, setCreatingFolder] = useState(false);
@@ -35,7 +35,7 @@ const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, on
     } else {
       setEditingFile(f);
       setContent('');
-      setMessage('Commit change');
+      setMessage('Commit file');
     }
   };
 
@@ -52,7 +52,7 @@ const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, on
       const diff = await fetchGitDiff(questId, editingFile.path);
       const commitMsg = message || `Update ${editingFile.path}`;
       await addPost({
-        type: 'change',
+        type: 'file',
         questId,
         content: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
         commitSummary: issueId ? `${commitMsg} (Issue #${issueId})` : commitMsg,
@@ -93,7 +93,7 @@ const GitFileBrowserInline: React.FC<GitFileBrowserInlineProps> = ({ questId, on
           <TextArea rows={10} value={content} onChange={(e) => setContent(e.target.value)} />
           <div className="flex gap-2">
             <Button onClick={handleSave} disabled={saving}>
-              {saving ? 'Saving...' : 'Commit Change'}
+              {saving ? 'Saving...' : 'Commit File'}
             </Button>
             <Button variant="ghost" onClick={() => setEditingFile(null)}>
               Cancel

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -56,13 +56,13 @@ const CreatePost: React.FC<CreatePostProps> = ({
 
   const [type, setType] = useState<PostType>(
     restrictedReply
-      ? replyToType === 'change' && isParticipant
-        ? 'change'
+      ? replyToType === 'file' && isParticipant
+        ? 'file'
         : 'free_speech'
       : initialType === 'request'
       ? 'task'
       : initialType === 'review'
-      ? 'change'
+      ? 'file'
       : initialType
   );
   const [status, setStatus] = useState<string>('To Do');
@@ -83,19 +83,19 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   const allowedPostTypes: PostType[] = restrictedReply
     ? replyToType === 'task'
       ? isParticipant
-        ? ['free_speech', 'task', 'change']
+        ? ['free_speech', 'task', 'file']
         : ['free_speech']
-      : replyToType === 'change'
+      : replyToType === 'file'
       ? isParticipant
-        ? ['free_speech', 'change']
+        ? ['free_speech', 'file']
         : ['free_speech']
       : ['free_speech']
     : boardId === 'quest-board'
-    ? ['task', 'change']
+    ? ['task', 'file']
     : boardType === 'quest'
     ? ['task', 'free_speech']
     : boardType === 'post'
-    ? ['free_speech', 'task', 'change']
+    ? ['free_speech', 'task', 'file']
     : POST_TYPES.map((p) => p.value as PostType);
 
 
@@ -317,7 +317,7 @@ function requiresQuestRoles(type: PostType): boolean {
 }
 
 function showLinkControls(type: PostType): boolean {
-  return ['task', 'change'].includes(type);
+  return ['task', 'file'].includes(type);
 }
 
 function validateLinks(
@@ -333,7 +333,7 @@ function validateLinks(
       return items.some(i => i.itemType === 'post')
         ? { valid: false, message: 'Free speech posts cannot have links.' }
         : { valid: true };
-    case 'change':
+    case 'file':
       return hasParent || items.some(i => i.itemType === 'post')
         ? { valid: true }
         : {

--- a/ethos-frontend/src/components/post/EditPost.tsx
+++ b/ethos-frontend/src/components/post/EditPost.tsx
@@ -200,5 +200,5 @@ const EditPost: React.FC<EditPostProps> = ({ post, onCancel, onUpdated }) => {
 export default EditPost;
 
 function showLinkControls(type: PostType): boolean {
-  return ['task', 'change'].includes(type);
+  return ['task', 'file'].includes(type);
 }

--- a/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.requestReview.test.tsx
@@ -11,10 +11,10 @@ jest.mock('../../api/post', () => ({
   requestHelp: jest.fn(() =>
     Promise.resolve({
       post: {
-        id: 'c1',
+        id: 'f1',
         authorId: 'u1',
-        type: 'change',
-        content: 'Change',
+        type: 'file',
+        content: 'File',
         visibility: 'public',
         timestamp: '',
         tags: ['review'],
@@ -55,10 +55,10 @@ jest.mock('react-router-dom', () => {
 
 describe.skip('PostCard request review', () => {
   const post: Post = {
-    id: 'c1',
+    id: 'f1',
     authorId: 'u1',
-    type: 'change',
-    content: 'Change',
+    type: 'file',
+    content: 'File',
     visibility: 'public',
     timestamp: '',
     tags: [],
@@ -80,13 +80,13 @@ describe.skip('PostCard request review', () => {
     });
 
     await waitFor(() =>
-      expect(requestHelp).toHaveBeenCalledWith('c1', 'change')
+      expect(requestHelp).toHaveBeenCalledWith('f1', 'file')
     );
     expect(screen.getByText(/In Review/i)).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText(/In Review/i));
     });
-    await waitFor(() => expect(removeHelpRequest).toHaveBeenCalledWith('c1', 'change'));
+    await waitFor(() => expect(removeHelpRequest).toHaveBeenCalledWith('f1', 'file'));
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.review.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.review.test.tsx
@@ -32,7 +32,7 @@ describe('PostCard review rating', () => {
     const post: Post = {
       id: 'r1',
       authorId: 'u1',
-      type: 'change',
+      type: 'file',
       content: 'Great quest',
       rating: 4.5,
       visibility: 'public',

--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -57,39 +57,39 @@ describe('PostCard summary tags', () => {
     expect(nodeLink).toHaveAttribute('href', '/post/p1');
   });
 
-  it('renders node id and username for change requests', async () => {
-    const changeReq: Post = {
+  it('renders node id and username for file requests', async () => {
+    const fileReq: Post = {
       id: 'p2',
       authorId: 'u1',
       type: 'request' as unknown as Post['type'],
-      nodeId: 'Q:slug:T01:C00',
-      content: 'Change request',
+      nodeId: 'Q:slug:T01:F00',
+      content: 'File request',
       visibility: 'public',
       timestamp: '',
       tags: [],
       collaborators: [],
       linkedItems: [],
     } as unknown as Post;
-    const enriched = { ...changeReq, author: { id: 'u1', username: 'alice' } } as Post;
+    const enriched = { ...fileReq, author: { id: 'u1', username: 'alice' } } as Post;
     render(
       <BrowserRouter>
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(await screen.findByText('Q::Task:T01:C00')).toBeInTheDocument();
+    expect(await screen.findByText('Q::File:T01:F00')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const nodeLink = await screen.findByRole('link', { name: 'Q::Task:T01:C00' });
+    const nodeLink = await screen.findByRole('link', { name: 'Q::File:T01:F00' });
     expect(nodeLink).toHaveAttribute('href', '/post/p2');
   });
 
-  it('renders task, change, and username tags for change posts', async () => {
-    const changePost: Post = {
-      id: 'c1',
+  it('renders file, task, and username tags for file posts', async () => {
+    const filePost: Post = {
+      id: 'f1',
       authorId: 'u1',
-      type: 'change',
-      nodeId: 'Q:slug:T01:C00',
-      content: 'A change',
+      type: 'file',
+      nodeId: 'Q:slug:T01:F00',
+      content: 'A file',
       visibility: 'public',
       timestamp: '',
       tags: [],
@@ -97,21 +97,22 @@ describe('PostCard summary tags', () => {
       linkedItems: [],
       replyTo: 't1',
     } as unknown as Post;
-    const enriched = { ...changePost, author: { id: 'u1', username: 'alice' } } as Post;
+    const enriched = { ...filePost, author: { id: 'u1', username: 'alice' } } as Post;
     render(
       <BrowserRouter>
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
     expect(await screen.findByText('Q::Task:T01')).toBeInTheDocument();
-    expect(await screen.findByText('Q::Task:T01:C00')).toBeInTheDocument();
+    expect(await screen.findByText('Q::File:T01:F00')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
     const taskLink = await screen.findByRole('link', { name: 'Q::Task:T01' });
     expect(taskLink).toHaveAttribute('href', '/post/t1');
-    const changeLink = await screen.findByRole('link', { name: 'Q::Task:T01:C00' });
-    expect(changeLink).toHaveAttribute('href', '/post/c1');
+    const fileLink = await screen.findByRole('link', { name: 'Q::File:T01:F00' });
+    expect(fileLink).toHaveAttribute('href', '/post/f1');
     const tags = await screen.findAllByTestId('summary-tag');
     expect(tags).toHaveLength(3);
+    expect(tags[0].textContent).toContain('Q::File:T01:F00');
   });
 });

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -162,7 +162,7 @@ const PostCard: React.FC<PostCardProps> = ({
         ...post,
         userRepostId: null,
         helpRequest: false,
-        tags: (post.tags || []).filter(t => t !== (post.type === 'change' ? 'review' : 'request')),
+        tags: (post.tags || []).filter(t => t !== (post.type === 'file' ? 'review' : 'request')),
       } as Post);
     } catch (err) {
       console.error('[PostCard] Failed to cancel help request:', err);

--- a/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
+++ b/ethos-frontend/src/components/quest/ActiveQuestsBoard.tsx
@@ -34,7 +34,7 @@ const ActiveQuestsBoard: React.FC = () => {
           if (!involved) continue;
 
           questPosts.forEach(p => {
-            if ((p.type === 'free_speech' && p.replyTo) || p.type === 'change' || p.tags?.includes('review') || p.authorId === user.id) {
+            if ((p.type === 'free_speech' && p.replyTo) || p.type === 'file' || p.tags?.includes('review') || p.authorId === user.id) {
               postsMap.set(p.id, p);
             }
           });

--- a/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
+++ b/ethos-frontend/src/components/ui/NodeTypeBadge.tsx
@@ -53,7 +53,7 @@ export function getNodeVisualType(post: Post): NodeVisualType {
     return post.needsHelp === false ? 'request-accepted' : 'request-open';
   }
   if (post.type === 'task') return 'task';
-  if (post.type === 'change' || post.type === 'free_speech') return 'subtask';
+  if (post.type === 'file' || post.type === 'free_speech') return 'subtask';
   return 'task';
 }
 

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -9,7 +9,7 @@ import {
   FaUser,
   FaHandsHelping,
   FaCheckCircle,
-  FaExchangeAlt
+  FaFile
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import { TAG_BASE, TAG_TRUNCATED } from '../../constants/styles';
@@ -22,7 +22,7 @@ export type SummaryTagType =
   | 'type'
   | 'free_speech'
   | 'request'
-  | 'change'
+  | 'file'
   | 'solved'
   | 'log'
   | 'category'
@@ -41,7 +41,7 @@ const icons: Partial<Record<SummaryTagType, React.ComponentType<{className?: str
   free_speech: FaCommentAlt,
   type: FaUser,
   request: FaHandsHelping,
-  change: FaExchangeAlt,
+  file: FaFile,
   solved: FaCheckCircle,
 };
 
@@ -55,7 +55,7 @@ const colors: Record<SummaryTagType, string> = {
   free_speech: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200',
   type: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
   request: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200',
-  change: 'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-200',
+  file: 'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-200',
   party_request: 'bg-pink-100 text-pink-800 dark:bg-pink-800 dark:text-pink-200',
   quest_task: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-800 dark:text-cyan-200',
   meta_system: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -27,7 +27,7 @@ export const BOARD_TYPE_OPTIONS: { value: BoardType; label: string }[] = [
 export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },
   { value: 'task', label: 'Task' },
-  { value: 'change', label: 'Change' },
+  { value: 'file', label: 'File' },
 ];
 
 export const SECONDARY_POST_TYPES = [

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -59,17 +59,17 @@ const PostPage: React.FC = () => {
     };
   }, [replyBoard]);
 
-  const changeRepliesBoard = useMemo<BoardData | null>(() => {
+  const fileRepliesBoard = useMemo<BoardData | null>(() => {
     if (!replyBoard) return null;
-    const changes =
+    const files =
       replyBoard.enrichedItems?.filter(
-        (item): item is Post => 'type' in item && (item as Post).type === 'change'
+        (item): item is Post => 'type' in item && (item as Post).type === 'file'
       ) || [];
-    if (!changes.length) return null;
+    if (!files.length) return null;
     return {
       ...replyBoard,
-      items: changes.map(c => c.id),
-      enrichedItems: changes,
+      items: files.map(f => f.id),
+      enrichedItems: files,
     };
   }, [replyBoard]);
 
@@ -213,16 +213,16 @@ const PostPage: React.FC = () => {
           />
         )}
 
-        {post.type === 'change' && post.questId && (
+        {post.type === 'file' && post.questId && (
           <GitFileBrowserInline questId={post.questId} />
         )}
         {post.tags?.includes('review') && parentPost && (
           <PostCard post={parentPost} />
         )}
-        {changeRepliesBoard && (
+        {fileRepliesBoard && (
           <Board
-            boardId={`change-replies-${id}`}
-            board={changeRepliesBoard}
+            boardId={`file-replies-${id}`}
+            board={fileRepliesBoard}
             layout="grid"
             editable={false}
             compact={true}

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -188,7 +188,7 @@ export type QuestTaskStatus = 'To Do' | 'In Progress' | 'Blocked' | 'Done' | str
 export type PostType =
   | 'free_speech'
   | 'task'
-  | 'change';
+  | 'file';
   
 /**
  * Supported tags for labeling and filtering posts.

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -25,7 +25,7 @@ export const toTitleCase = (str: string): string =>
 export const POST_TYPE_LABELS: Record<PostType | 'request' | 'review', string> = {
   free_speech: "Free Speech",
   task: "Task",
-  change: "Change",
+  file: "File",
   request: "Request",
   review: "Review",
 };
@@ -122,7 +122,7 @@ const formatNodeId = (nodeId: string): string => {
     path = path.split(':').slice(2).join(':');
   }
   const segments = path.split(':');
-  const typeSeg = segments.find((s) => s.startsWith('T') || s.startsWith('F') || s.startsWith('L')) || '';
+  const typeSeg = [...segments].reverse().find((s) => s.startsWith('T') || s.startsWith('F') || s.startsWith('L')) || '';
   let typeLabel = '';
   if (typeSeg.startsWith('T')) typeLabel = 'Task';
   else if (typeSeg.startsWith('F')) typeLabel = 'File';
@@ -139,10 +139,11 @@ export const buildSummaryTags = async (
   void questId;
   const tags: SummaryTagData[] = [];
 
-  if (post.type === 'change') {
+  if (post.type === 'file') {
     if (post.nodeId) {
       const parts = post.nodeId.split(':');
-      const changeLabel = formatNodeId(post.nodeId);
+      const fileLabel = formatNodeId(post.nodeId);
+      tags.push({ type: 'file', label: fileLabel, detailLink: ROUTES.POST(post.id) });
       parts.pop();
       const taskNode = parts.join(':');
       if (taskNode) {
@@ -152,7 +153,6 @@ export const buildSummaryTags = async (
           detailLink: post.replyTo ? ROUTES.POST(post.replyTo) : undefined,
         });
       }
-      tags.push({ type: 'change', label: changeLabel, detailLink: ROUTES.POST(post.id) });
     }
     if (post.authorId) {
       const username = await getUsernameFromId(post.authorId);
@@ -225,7 +225,7 @@ export const buildSummaryTags = async (
       switch (lower) {
         case 'request':
         case 'review':
-        case 'change':
+        case 'file':
         case 'quest':
         case 'task':
         case 'log':
@@ -308,12 +308,12 @@ export const getPostSummary = (
   } else if (post.type === "task" && post.nodeId) {
     const user = post.author?.username || post.authorId;
     parts.push(`(Task - ${getQuestLinkLabel(post, title ?? '', false)} @${user})`);
-  } else if (post.type === "change") {
+  } else if (post.type === "file") {
     const user = post.author?.username || post.authorId;
     if (post.nodeId && !multipleSources) {
-      parts.push(`(Change - Q::${post.nodeId.replace(/^Q:[^:]+:/, '')} @${user})`);
+      parts.push(`(File - Q::${post.nodeId.replace(/^Q:[^:]+:/, '')} @${user})`);
     } else {
-      parts.push(`(Change @${user})`);
+      parts.push(`(File @${user})`);
     }
   } else if (post.type) {
     parts.push(`(${post.type.charAt(0).toUpperCase() + post.type.slice(1)})`);

--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -33,7 +33,7 @@ import CreatePost from '../src/components/post/CreatePost';
 import { addPost } from '../src/api/post';
 
 describe('CreatePost replying', () => {
-  it('offers free speech, task, and change when replying to a task as a participant', () => {
+  it('offers free speech, task, and file when replying to a task as a participant', () => {
     mockUseAuth.mockReturnValue({ user: { id: 'u1' } });
     const reply = { id: 't1', type: 'task', authorId: 'u1' } as Post;
     render(
@@ -44,7 +44,7 @@ describe('CreatePost replying', () => {
     const options = Array.from(
       screen.getByLabelText('Item Type').querySelectorAll('option')
     ).map((o) => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Task', 'Change']);
+    expect(options).toEqual(['Free Speech', 'Task', 'File']);
   });
 
   it('offers only free speech when replying to a task as an outsider', () => {

--- a/ethos-frontend/tests/CreatePostView.test.tsx
+++ b/ethos-frontend/tests/CreatePostView.test.tsx
@@ -49,12 +49,12 @@ describe.skip('CreatePost view filtering', () => {
     expect(getOptions()).toEqual(['Free Speech']);
   });
 
-  it('allows change and free speech posts in file-change view', () => {
+  it('allows file and free speech posts in file-change view', () => {
     render(
       <BrowserRouter>
         <CreatePost onCancel={() => {}} currentView="file-change" />
       </BrowserRouter>
     );
-    expect(getOptions()).toEqual(['Change', 'Free Speech']);
+    expect(getOptions()).toEqual(['File', 'Free Speech']);
   });
 });

--- a/ethos-frontend/tests/QuestBoardComponent.test.tsx
+++ b/ethos-frontend/tests/QuestBoardComponent.test.tsx
@@ -7,7 +7,7 @@ const mockBoard = {
   id: 'quest-board',
   enrichedItems: [
     { id: 'p1', type: 'task', content: 'Task', tags: ['request'] },
-    { id: 'c1', type: 'change', content: 'Change', tags: ['review'] },
+    { id: 'f1', type: 'file', content: 'File', tags: ['review'] },
   ],
 };
 

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -41,6 +41,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Task', 'Change']);
+    expect(options).toEqual(['Free Speech', 'Task', 'File']);
   });
 });


### PR DESCRIPTION
## Summary
- Rename the `change` post type to `file` across backend, frontend, and documentation
- Treat tasks as folders containing file posts and show file summary tags first in post headers
- Update node ID generation and tag components for new `file` type

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d17cefd5c832fb1c2fff02fd99cd8