### PR TITLE
refactor change posts into file posts

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -103,16 +103,16 @@ describe('PostCard summary tags', () => {
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
+    expect(await screen.findByText('File')).toBeInTheDocument();
     expect(await screen.findByText('Q::Task:T01')).toBeInTheDocument();
-    expect(await screen.findByText('Q::File:T01:F00')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
     const taskLink = await screen.findByRole('link', { name: 'Q::Task:T01' });
     expect(taskLink).toHaveAttribute('href', '/post/t1');
-    const fileLink = await screen.findByRole('link', { name: 'Q::File:T01:F00' });
+    const fileLink = await screen.findByRole('link', { name: 'File' });
     expect(fileLink).toHaveAttribute('href', '/post/f1');
     const tags = await screen.findAllByTestId('summary-tag');
     expect(tags).toHaveLength(3);
-    expect(tags[0].textContent).toContain('Q::File:T01:F00');
+    expect(tags[0].textContent).toContain('File');
   });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -140,10 +140,12 @@ export const buildSummaryTags = async (
   const tags: SummaryTagData[] = [];
 
   if (post.type === 'file') {
+    // Always include a leading File tag
+    tags.push({ type: 'file', label: 'File', detailLink: ROUTES.POST(post.id) });
+
+    // If nodeId is present, show the parent task folder
     if (post.nodeId) {
       const parts = post.nodeId.split(':');
-      const fileLabel = formatNodeId(post.nodeId);
-      tags.push({ type: 'file', label: fileLabel, detailLink: ROUTES.POST(post.id) });
       parts.pop();
       const taskNode = parts.join(':');
       if (taskNode) {
@@ -154,6 +156,8 @@ export const buildSummaryTags = async (
         });
       }
     }
+
+    // Append author tag last
     if (post.authorId) {
       const username = await getUsernameFromId(post.authorId);
       tags.push({


### PR DESCRIPTION
## Summary
- always prepend a File summary tag for file posts and show parent task
- update tests to expect File tags instead of Change labels

## Testing
- `npm test` in `ethos-frontend`
- `npm test` in `ethos-backend`


------
https://chatgpt.com/codex/tasks/task_e_689d1d8e3760832f9898ec3387198bb1