### PR TITLE
Replace review/request reactions with reply for non-authors

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -30,6 +30,7 @@ export default {
     '<rootDir>/tests/PostTypeFilterOptions.test.tsx',
     '<rootDir>/tests/ThemeProvider.test.js',
     '<rootDir>/tests/TimelineBoardPostTypes.test.tsx'
+    ,'<rootDir>/src/components/controls/ReactionControls.permission.test.tsx'
   ],
   globals: {
     'ts-jest': {

--- a/ethos-frontend/src/components/controls/ReactionControls.permission.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.permission.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import ReactionControls from './ReactionControls';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  updateReaction: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: null }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('ReactionControls permissions', () => {
+  const user = { id: 'u1' } as User;
+
+  it('shows Reply instead of Review for non-authors of file posts', async () => {
+    const post = {
+      id: 'p1',
+      authorId: 'u2',
+      type: 'file',
+      content: '',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as Post;
+
+    render(
+      <BrowserRouter>
+        <ReactionControls post={post} user={user} />
+      </BrowserRouter>
+    );
+
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+    expect(screen.queryByText(/Review/)).toBeNull();
+  });
+
+  it('shows Reply instead of Request for non-authors of task posts', async () => {
+    const post = {
+      id: 'p2',
+      authorId: 'u3',
+      type: 'task',
+      content: '',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as Post;
+
+    render(
+      <BrowserRouter>
+      <ReactionControls post={post} user={user} />
+      </BrowserRouter>
+    );
+
+    const replies = await screen.findAllByText('Reply');
+    expect(replies).toHaveLength(1);
+    expect(screen.queryByText(/Request/)).toBeNull();
+  });
+});

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -89,6 +89,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const isPostHistory = ctxBoardId === 'my-posts';
   const isPostBoard = isPostHistory || ctxBoardType === 'post';
   const expanded = expandedProp !== undefined ? expandedProp : post.type === 'task';
+  const isAuthor = user?.id === post.authorId;
 
   // ---------- Fetch reactions on mount/changes ----------
   useEffect(() => {
@@ -279,59 +280,83 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
           </button>
         )}
 
-        {/* Review status for files */}
+        {/* Review status for files or reply for non-authors */}
         {post.type === 'file' && (
-          <button
-            className={clsx('flex items-center gap-1', reviewState !== 'review' && 'text-indigo-600')}
-            onClick={cycleReview}
-            disabled={loading}
-            aria-label="Review Status"
-          >
-            <FaClipboardCheck />
-            {reviewState === 'review'
-              ? 'Review'
-              : reviewState === 'pending'
-              ? 'Pending'
-              : 'Reviewed'}
-          </button>
+          isAuthor ? (
+            <button
+              className={clsx('flex items-center gap-1', reviewState !== 'review' && 'text-indigo-600')}
+              onClick={cycleReview}
+              disabled={loading}
+              aria-label="Review Status"
+            >
+              <FaClipboardCheck />
+              {reviewState === 'review'
+                ? 'Review'
+                : reviewState === 'pending'
+                ? 'Pending'
+                : 'Reviewed'}
+            </button>
+          ) : (
+            <button
+              className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
+              onClick={() => goToReplyPageOrToggle('free_speech')}
+              aria-label="Reply"
+            >
+              <FaReply />
+              {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
+            </button>
+          )
         )}
 
-        {/* Request status for tasks */}
+        {/* Request status for tasks or reply for non-authors */}
         {post.type === 'task' && (
-          <button
-            className={clsx('flex items-center gap-1', requestState !== 'request' && 'text-indigo-600')}
-            onClick={cycleRequest}
-            disabled={loading}
-            aria-label="Request Status"
-          >
-            <FaHandsHelping />
-            {requestState === 'request'
-              ? 'Request'
-              : requestState === 'pending'
-              ? 'Pending'
-              : 'Complete'}
-          </button>
+          isAuthor ? (
+            <button
+              className={clsx('flex items-center gap-1', requestState !== 'request' && 'text-indigo-600')}
+              onClick={cycleRequest}
+              disabled={loading}
+              aria-label="Request Status"
+            >
+              <FaHandsHelping />
+              {requestState === 'request'
+                ? 'Request'
+                : requestState === 'pending'
+                ? 'Pending'
+                : 'Complete'}
+            </button>
+          ) : (
+            <button
+              className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
+              onClick={() => goToReplyPageOrToggle('free_speech')}
+              aria-label="Reply"
+            >
+              <FaReply />
+              {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
+            </button>
+          )
         )}
 
         {/* Reply / Update */}
-        {post.type === 'file' ? (
+        {(post.type === 'file' && isAuthor) || (post.type === 'task' && isAuthor) || post.type === 'free_speech' ? (
           <button
             className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-            onClick={() => goToReplyPageOrToggle('file')}
-            aria-label="Update"
-          >
-            <FaReply /> {showReplyPanel ? 'Cancel' : 'Update'}
-          </button>
-        ) : (
-          <button
-            className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-            onClick={() => goToReplyPageOrToggle('free_speech')}
-            aria-label="Reply"
+            onClick={() =>
+              goToReplyPageOrToggle(
+                post.type === 'file' && isAuthor ? 'file' : 'free_speech'
+              )
+            }
+            aria-label={post.type === 'file' && isAuthor ? 'Update' : 'Reply'}
           >
             <FaReply />
-            {replyOverride ? replyOverride.label : (showReplyPanel ? 'Cancel' : 'Reply')}
+            {replyOverride
+              ? replyOverride.label
+              : showReplyPanel
+              ? 'Cancel'
+              : post.type === 'file' && isAuthor
+              ? 'Update'
+              : 'Reply'}
           </button>
-        )}
+        ) : null}
 
         {/* Timestamp */}
         {timestamp && (

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -167,7 +167,7 @@ const PostPage: React.FC = () => {
             ♻️ Reposted from @{post.repostedFrom.username}
           </div>
         )}
-        <PostCard post={post} showDetails />
+        <PostCard post={post} user={user as User} showDetails />
         {showReplyForm && (
           <div className="mt-4">
             <CreatePost
@@ -217,7 +217,7 @@ const PostPage: React.FC = () => {
           <GitFileBrowserInline questId={post.questId} />
         )}
         {post.tags?.includes('review') && parentPost && (
-          <PostCard post={parentPost} />
+          <PostCard post={parentPost} user={user as User} />
         )}
         {fileRepliesBoard && (
           <Board


### PR DESCRIPTION
## Summary
- Show Reply button instead of Review/Request reactions when viewing someone else's file or task
- Pass current user to post detail cards so reactions no longer redirect to login
- Add tests covering non-author reply behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d35861b44832f9ebdd36ba5a64f7e