### PR TITLE
feat: refine post reply UX

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -73,6 +73,7 @@ const Board: React.FC<BoardProps> = ({
   readOnly = false,
   compact = false,
   showCreate = true,
+  createLabel,
   hideControls = true,
   filter = EMPTY_FILTER,
   onScrollEnd,
@@ -102,6 +103,15 @@ const Board: React.FC<BoardProps> = ({
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editMode, setEditMode] = useState(false);
+
+  const createBtnLabel = createLabel ||
+    (board?.boardType === 'quest'
+      ? 'Quest'
+      : board?.id === 'quest-board'
+      ? 'Request'
+      : ['timeline-board', 'my-posts'].includes(board?.id || '')
+      ? 'Post'
+      : 'Item');
 
   const {
     itemType = '',
@@ -433,18 +443,8 @@ const Board: React.FC<BoardProps> = ({
               onClick={() => setShowCreateForm((p) => !p)}
             >
               {showCreateForm
-                ? board?.boardType === 'quest'
-                  ? '- Cancel Quest'
-                  : board?.id === 'quest-board'
-                  ? '- Cancel Request'
-                  : '- Cancel Item'
-                : board?.boardType === 'quest'
-                ? '+ Add Quest'
-                : board?.id === 'quest-board'
-                ? '+ Add Request'
-                : ['timeline-board', 'my-posts'].includes(board?.id || '')
-                ? '+ Add Post'
-                : '+ Add Item'}
+                ? `- Cancel ${createBtnLabel}`
+                : `+ Add ${createBtnLabel}`}
             </Button>
           )}
           {editable && (

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -50,6 +50,8 @@ interface ReactionControlsProps {
   timestamp?: string;
   /** Controlled expand state */
   expanded?: boolean;
+  /** Hide the reply button */
+  hideReply?: boolean;
 }
 
 const INITIAL_COUNTS: ReactionCountMap = { like: 0, heart: 0, repost: 0 };
@@ -64,6 +66,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   onReplyToggle,
   timestamp,
   expanded: expandedProp,
+  hideReply,
 }) => {
   // ---------- UI / local state ----------
   const [reactions, setReactions] = useState<{ like: boolean; heart: boolean; repost: boolean }>({
@@ -297,14 +300,16 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
                 : 'Reviewed'}
             </button>
           ) : (
-            <button
-              className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-              onClick={() => goToReplyPageOrToggle('free_speech')}
-              aria-label="Reply"
-            >
-              <FaReply />
-              {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
-            </button>
+            !hideReply && (
+              <button
+                className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
+                onClick={() => goToReplyPageOrToggle('free_speech')}
+                aria-label="Reply"
+              >
+                <FaReply />
+                {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
+              </button>
+            )
           )
         )}
 
@@ -325,19 +330,21 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
                 : 'Complete'}
             </button>
           ) : (
-            <button
-              className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
-              onClick={() => goToReplyPageOrToggle('free_speech')}
-              aria-label="Reply"
-            >
-              <FaReply />
-              {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
-            </button>
+            !hideReply && (
+              <button
+                className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
+                onClick={() => goToReplyPageOrToggle('free_speech')}
+                aria-label="Reply"
+              >
+                <FaReply />
+                {replyOverride ? replyOverride.label : showReplyPanel ? 'Cancel' : 'Reply'}
+              </button>
+            )
           )
         )}
 
         {/* Reply / Update */}
-        { post.type === 'free_speech' && (
+        {post.type === 'free_speech' && !hideReply && (
           <button
             className={clsx('flex items-center gap-1', showReplyPanel && 'text-green-600')}
             onClick={() =>
@@ -345,7 +352,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
                 post.type === 'file' && isAuthor ? 'file' : 'free_speech'
               )
             }
-            aria-label={ 'Reply'}
+            aria-label={'Reply'}
           >
             <FaReply />
             {replyOverride

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -71,6 +71,8 @@ interface PostCardProps {
   boardId?: string;
   /** Controlled expanded state */
   expanded?: boolean;
+  /** Hide reply reaction button */
+  hideReplyButton?: boolean;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -89,6 +91,7 @@ const PostCard: React.FC<PostCardProps> = ({
   expanded,
   showDetails = false,
   onToggleExpand,
+  hideReplyButton,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [headPostId, setHeadPostId] = useState<string | null>(null);
@@ -297,6 +300,7 @@ const PostCard: React.FC<PostCardProps> = ({
           replyOverride={replyOverride}
           boardId={ctxBoardId || undefined}
           expanded={expandedView}
+          hideReply={hideReplyButton}
         />
       </div>
     );
@@ -377,6 +381,7 @@ const PostCard: React.FC<PostCardProps> = ({
         boardId={ctxBoardId || undefined}
         timestamp={!isQuestBoardRequest ? timestamp : undefined}
         expanded={expandedView}
+        hideReply={hideReplyButton}
       />
     </div>
   );

--- a/ethos-frontend/src/pages/post/[id].tsx
+++ b/ethos-frontend/src/pages/post/[id].tsx
@@ -167,7 +167,7 @@ const PostPage: React.FC = () => {
             ♻️ Reposted from @{post.repostedFrom.username}
           </div>
         )}
-        <PostCard post={post} user={user as User} showDetails />
+        <PostCard post={post} user={user as User} showDetails hideReplyButton />
         {showReplyForm && (
           <div className="mt-4">
             <CreatePost
@@ -242,6 +242,7 @@ const PostPage: React.FC = () => {
             editable={false}
             compact={true}
             user={user as User}
+            createLabel="Reply"
           />
         ) : (
           <Spinner />

--- a/ethos-frontend/src/types/boardTypes.ts
+++ b/ethos-frontend/src/types/boardTypes.ts
@@ -105,6 +105,8 @@ export interface BoardProps {
   initialExpanded?: boolean;
   /** Render contributions as header-only cards */
   headerOnly?: boolean;
+  /** Label used for create button */
+  createLabel?: string;
 }
 
 /** Props for the EditBoard component */


### PR DESCRIPTION
## Summary
- hide reply reaction button on post detail view
- rename thread board add button to "Add Reply"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d3b8bf6b0832f937eb0c2d4222eb5