### PR TITLE
Ensure summary tags react to theme changes

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -31,6 +31,7 @@ export default {
     '<rootDir>/tests/ThemeProvider.test.js',
     '<rootDir>/tests/TimelineBoardPostTypes.test.tsx'
     ,'<rootDir>/src/components/controls/ReactionControls.permission.test.tsx'
+    ,'<rootDir>/src/components/ui/SummaryTag.theme.test.tsx'
   ],
   globals: {
     'ts-jest': {

--- a/ethos-frontend/src/components/ui/SummaryTag.theme.test.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.theme.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import SummaryTag from './SummaryTag';
+
+describe('SummaryTag theme switching', () => {
+  beforeAll(() => {
+    const style = document.createElement('style');
+    style.innerHTML = `
+      .bg-green-100 { background-color: #dcfce7; }
+      .dark .dark\\:bg-green-800 { background-color: #065f46; }
+      .text-green-800 { color: #166534; }
+      .dark .dark\\:text-green-200 { color: #bbf7d0; }
+    `;
+    document.head.appendChild(style);
+  });
+
+  it('updates colors when toggling dark mode', () => {
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <SummaryTag type="quest" label="Quest" />
+      </BrowserRouter>
+    );
+
+    const tag = getByTestId('summary-tag');
+    expect(getComputedStyle(tag).backgroundColor).toBe('rgb(220, 252, 231)');
+
+    document.documentElement.classList.add('dark');
+    expect(getComputedStyle(tag).backgroundColor).toBe('rgb(6, 95, 70)');
+
+    document.documentElement.classList.remove('dark');
+    expect(getComputedStyle(tag).backgroundColor).toBe('rgb(220, 252, 231)');
+  });
+});

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -12,7 +12,7 @@ import {
   FaFile
 } from 'react-icons/fa';
 import clsx from 'clsx';
-import { TAG_BASE, TAG_TRUNCATED } from '../../constants/styles';
+import { TAG_LAYOUT } from '../../constants/styles';
 import type { SummaryTagData } from '../../utils/displayUtils';
 
 export type SummaryTagType =
@@ -77,7 +77,10 @@ const SummaryTag: React.FC<SummaryTagProps> = ({
   const Icon = icons[type] ?? FaStickyNote;
   const colorClass = colors[type] || colors.type;
 
-  const baseClass = truncate ? TAG_TRUNCATED : TAG_BASE;
+  const baseClass = clsx(
+    TAG_LAYOUT,
+    truncate && 'max-w-[150px] whitespace-nowrap overflow-hidden text-ellipsis'
+  );
 
   if (username && usernameLink && detailLink) {
     return (

--- a/ethos-frontend/src/constants/styles.ts
+++ b/ethos-frontend/src/constants/styles.ts
@@ -1,5 +1,8 @@
+export const TAG_LAYOUT =
+  'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded';
+
 export const TAG_BASE =
-  'inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+  `${TAG_LAYOUT} bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200`;
 
 export const TAG_TRUNCATED =
   `${TAG_BASE} max-w-[150px] whitespace-nowrap overflow-hidden text-ellipsis`;


### PR DESCRIPTION
## Summary
- remove default dark colors from summary tag base layout so theme-specific colors can apply
- add unit test verifying summary tag colors switch when toggling dark mode

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d3cde6ff0832f8308e4ef857efd14