### PR TITLE
Navigate reply button to post page and refine reply permissions

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -79,7 +79,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const [reviewState, setReviewState] = useState<ReviewState>('review');
   const [requestState, setRequestState] = useState<RequestState>('request');
 
-  const [showReplyPanel, setShowReplyPanel] = useState(false);
+  const [showReplyPanel] = useState(false);
   const [, setReplyInitialType] = useState<ReplyType>('free_speech');
 
   const navigate = useNavigate();
@@ -223,28 +223,9 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         return;
       }
 
-      const shouldNavigate = post.tags?.includes('request') || isTimelineBoard || isPostBoard;
-      if (shouldNavigate) {
-        navigate(ROUTES.POST(post.id) + '?reply=1');
-        return;
-      }
-
-      setShowReplyPanel(prev => {
-        const next = !prev;
-        onReplyToggle?.(next);
-        return next;
-      });
+      navigate(ROUTES.POST(post.id) + '?reply=1');
     },
-    [
-      isPostBoard,
-      isTimelineBoard,
-      navigate,
-      onReplyToggle,
-      post.id,
-      post.tags,
-      replyOverride,
-      user?.id,
-    ]
+    [navigate, post.id, replyOverride, user?.id]
   );
 
   // ---------- Render ----------

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -51,7 +51,13 @@ const CreatePost: React.FC<CreatePostProps> = ({
   const currentUserId = user?.id;
   const isParticipant = replyTo
     ? replyTo.authorId === currentUserId ||
-      (replyTo.collaborators || []).some((c) => c.userId === currentUserId)
+      (replyTo.collaborators || []).some((c) => c.userId === currentUserId) ||
+      (currentUserId
+        ? !!(
+            replyTo.reactions?.request?.[currentUserId] ||
+            replyTo.reactions?.review?.[currentUserId]
+          )
+        : false)
     : false;
 
   const [type, setType] = useState<PostType>(


### PR DESCRIPTION
## Summary
- Always navigate the reply action to the post detail page and auto-open the reply form
- Restrict reply types to free speech unless the user authored, collaborates on, or has a request/review assignment on the parent post

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d40ae71e8832fad54b4ee716adf2b