### PR TITLE
feat: add request actions for tasks and reviews

### DIFF
--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Post, EnrichedPost } from '../../types/postTypes';
 import { Button, AvatarStack, SummaryTag } from '../ui';
 import { POST_TYPE_LABELS, toTitleCase } from '../../utils/displayUtils';
@@ -18,6 +19,7 @@ interface RequestCardProps {
 
 const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const collaboratorUsers = post.enrichedCollaborators || [];
   const collaboratorCount = collaboratorUsers.filter(c => c.userId).length || 0;
   const [joining, setJoining] = useState(false);
@@ -45,6 +47,11 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
         const res = await acceptRequest(post.id);
         onUpdate?.(res.post);
         setJoined(true);
+        if (post.type === 'file') {
+          navigate(ROUTES.POST(post.id) + '?reply=1&initialType=review');
+        } else {
+          navigate(ROUTES.POST(post.id) + '?reply=1&intro=1');
+        }
       }
     } catch (err) {
       console.error('[RequestCard] Failed to join:', err);


### PR DESCRIPTION
## Summary
- add Request Help and Request Review reactions for task and file posts
- navigate to post details with reply form when accepting requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d89b16d1c832fa1f12a9445671f3c