### PR TITLE
Ensure request posts update boards correctly

### DIFF
--- a/ethos-frontend/src/components/board/Board.tsx
+++ b/ethos-frontend/src/components/board/Board.tsx
@@ -191,6 +191,13 @@ const Board: React.FC<BoardProps> = ({
 
   const filteredItems = useMemo(() => {
     let result = [...items];
+    const currentBoardId = board?.id || boardId || '';
+    if (['timeline-board', 'my-posts'].includes(currentBoardId)) {
+      result = result.filter(
+        (item) => !('tags' in item && (item as Post).tags?.includes('request'))
+      );
+    }
+
     const { itemType: iType, postType: pType, linkType: lType } = effectiveFilter;
 
     if (iType) {
@@ -222,7 +229,7 @@ const Board: React.FC<BoardProps> = ({
         const bVal = sortKey === 'createdAt' ? b.createdAt ?? '' : resolveTitle(b);
         return sortOrder === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
       });
-  }, [items, effectiveFilter, filterText, sortKey, sortOrder]);
+  }, [items, effectiveFilter, filterText, sortKey, sortOrder, board?.id, boardId]);
 
   const renderableItems = useMemo(
     () => getRenderableBoardItems(filteredItems),

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -16,6 +16,8 @@ import { ROUTES } from '../../constants/routes';
 import TaskCard from '../quest/TaskCard';
 
 import { updateReaction, fetchReactions, requestHelp, removeHelpRequest } from '../../api/post';
+import { useBoardContext } from '../../contexts/BoardContext';
+import type { BoardItem } from '../../contexts/BoardContextTypes';
         
 import type {
   Post,
@@ -85,6 +87,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
   const navigate = useNavigate();
 
   // ---------- Board context ----------
+  const { appendToBoard } = useBoardContext() || {};
   const expanded = expandedProp !== undefined ? expandedProp : post.type === 'task';
   const isAuthor = user?.id === post.authorId;
 
@@ -172,6 +175,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       } else {
         const res = await requestHelp(post.id, 'file');
         onUpdate?.(res.post);
+        appendToBoard?.('quest-board', res.post as unknown as BoardItem);
         setReviewRequested(true);
       }
     } catch (err) {
@@ -179,7 +183,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     } finally {
       setReviewLoading(false);
     }
-  }, [user?.id, navigate, reviewRequested, post.id, post, onUpdate]);
+  }, [user?.id, navigate, reviewRequested, post.id, post, onUpdate, appendToBoard]);
 
   const handleRequestHelp = useCallback(async () => {
     if (!user?.id) {
@@ -199,6 +203,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
       } else {
         const res = await requestHelp(post.id, 'task');
         onUpdate?.(res.post);
+        appendToBoard?.('quest-board', res.post as unknown as BoardItem);
         setHelpRequested(true);
       }
     } catch (err) {
@@ -206,7 +211,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     } finally {
       setHelpLoading(false);
     }
-  }, [user?.id, navigate, helpRequested, post.id, post, onUpdate]);
+  }, [user?.id, navigate, helpRequested, post.id, post, onUpdate, appendToBoard]);
 
   const goToReplyPageOrToggle = useCallback(
     (nextType: ReplyType) => {

--- a/ethos-frontend/tests/RequestPostRendering.test.tsx
+++ b/ethos-frontend/tests/RequestPostRendering.test.tsx
@@ -43,14 +43,4 @@ describe('Request post rendering', () => {
     expect(screen.getByText('Need help')).toBeInTheDocument();
     expect(screen.getByText(/Accept/i)).toBeInTheDocument();
   });
-
-  it('uses RequestCard on timeline board', () => {
-    render(
-      <BrowserRouter>
-        <ContributionCard contribution={requestPost} boardId="timeline-board" />
-      </BrowserRouter>
-    );
-    expect(screen.getByText('Need help')).toBeInTheDocument();
-    expect(screen.getByText(/Accept/i)).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Summary
- append newly created request posts to the quest board so "Request Review" updates UI
- hide request posts from timeline boards
- adjust tests for new request post handling

## Testing
- `npm test --prefix ethos/ethos-frontend`

------
https://chatgpt.com/codex/tasks/task_e_689dfc23242c832fb2b5fa092b5d2c66