### PR TITLE
feat: update request card action label

### DIFF
--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -115,7 +115,10 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
           ) : joined ? (
             <><FaUserCheck className="inline mr-1" /> Joined</>
           ) : (
-            <><FaUserPlus className="inline mr-1" /> {post.questId && role ? 'Join' : 'Accept'}</>
+            <>
+              <FaUserPlus className="inline mr-1" />
+              {post.type === 'file' ? 'Submit Review' : 'Request Join'}
+            </>
           )}
         </Button>
       </div>

--- a/ethos-frontend/tests/RequestPostRendering.test.tsx
+++ b/ethos-frontend/tests/RequestPostRendering.test.tsx
@@ -41,7 +41,7 @@ describe('Request post rendering', () => {
       </BrowserRouter>
     );
     expect(screen.getByText('Need help')).toBeInTheDocument();
-    expect(screen.getByText(/Accept/i)).toBeInTheDocument();
+    expect(screen.getByText(/Request Join/i)).toBeInTheDocument();
   });
 
   it('uses RequestCard on timeline board', () => {
@@ -51,6 +51,20 @@ describe('Request post rendering', () => {
       </BrowserRouter>
     );
     expect(screen.getByText('Need help')).toBeInTheDocument();
-    expect(screen.getByText(/Accept/i)).toBeInTheDocument();
+    expect(screen.getByText(/Request Join/i)).toBeInTheDocument();
+  });
+
+  it('shows Submit Review for file requests', () => {
+    const fileRequest: EnrichedPost = {
+      ...requestPost,
+      id: 'f1',
+      type: 'file',
+    };
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={fileRequest} boardId="timeline-board" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText(/Submit Review/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- rename request card action button to 'Request Join' or 'Submit Review'
- adjust tests for new button labels

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dfcf51e8c832f99de3b37eb858702