### PR TITLE
Ensure review requests mark posts as active quests

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -21,6 +21,7 @@ export default {
     '<rootDir>/src/api/quest.test.ts',
     '<rootDir>/src/components/controls/LinkControls.test.tsx',
     '<rootDir>/src/components/controls/ReactionControls.repost.test.tsx',
+    '<rootDir>/src/components/controls/ReactionControls.requestReview.test.tsx',
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/src/api/post.requestHelp.test.ts',

--- a/ethos-frontend/src/components/controls/ReactionControls.requestReview.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.requestReview.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import ReactionControls from './ReactionControls';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+import { requestHelp } from '../../api/post';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  updateReaction: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  requestHelp: jest.fn(() =>
+    Promise.resolve({
+      post: {
+        id: 'f1',
+        authorId: 'u1',
+        type: 'file',
+        content: 'File',
+        visibility: 'public',
+        timestamp: '',
+        tags: ['review'],
+        collaborators: [],
+        linkedItems: [],
+        helpRequest: true,
+      },
+    })
+  ),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ appendToBoard: jest.fn(), selectedBoard: null }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('ReactionControls request review', () => {
+  const post: Post = {
+    id: 'f1',
+    authorId: 'u1',
+    type: 'file',
+    content: 'File',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+  } as Post;
+  const user = { id: 'u1' } as User;
+
+  it('adds request tag when requesting review', async () => {
+    const onUpdate = jest.fn();
+    render(
+      <BrowserRouter>
+        <ReactionControls post={post} user={user} onUpdate={onUpdate} />
+      </BrowserRouter>
+    );
+
+    const btn = await screen.findByText(/Request Review/i);
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('f1', 'file'));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+    const updatedPost = onUpdate.mock.calls[0][0] as Post;
+    expect(updatedPost.tags).toContain('review');
+    expect(updatedPost.tags).toContain('request');
+  });
+});
+

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -174,8 +174,12 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         setReviewRequested(false);
       } else {
         const res = await requestHelp(post.id, 'file');
-        onUpdate?.(res.post);
-        appendToBoard?.('quest-board', res.post as unknown as BoardItem);
+        const updated = {
+          ...res.post,
+          tags: [...new Set([...(res.post.tags || []), 'request'])],
+        } as Post;
+        onUpdate?.(updated);
+        appendToBoard?.('quest-board', updated as unknown as BoardItem);
         setReviewRequested(true);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- add `request` tag when a file review is requested and keep quest board synced
- cover review request flow with a unit test

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4bf75e68832f9b6da7904d781836