### PR TITLE
test: verify file review requests appear on quest board

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -21,6 +21,7 @@ export default {
     '<rootDir>/src/api/quest.test.ts',
     '<rootDir>/src/components/controls/LinkControls.test.tsx',
     '<rootDir>/src/components/controls/ReactionControls.repost.test.tsx',
+    '<rootDir>/src/components/controls/ReactionControls.reviewRequest.test.tsx',
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/src/api/post.requestHelp.test.ts',

--- a/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ReactionControls from './ReactionControls';
+import ContributionCard from '../contribution/ContributionCard';
+
+// mock auth context for RequestCard
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', username: 'user' } }),
+}));
+
+const requestHelp = jest.fn();
+const removeHelpRequest = jest.fn();
+const fetchReactions = jest.fn(() => Promise.resolve([]));
+const fetchRepostCount = jest.fn(() => Promise.resolve({ count: 0 }));
+const fetchUserRepost = jest.fn(() => Promise.resolve(null));
+const addRepost = jest.fn(() => Promise.resolve({ id: 'r1' }));
+const removeRepost = jest.fn(() => Promise.resolve());
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchReactions: (...args: unknown[]) => fetchReactions(...args),
+  fetchRepostCount: (...args: unknown[]) => fetchRepostCount(...args),
+  fetchUserRepost: (...args: unknown[]) => fetchUserRepost(...args),
+  addRepost: (...args: unknown[]) => addRepost(...args),
+  removeRepost: (...args: unknown[]) => removeRepost(...args),
+  requestHelp: (...args: unknown[]) => requestHelp(...args),
+  removeHelpRequest: (...args: unknown[]) => removeHelpRequest(...args),
+}));
+
+const navigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+const appendToBoard = jest.fn();
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ appendToBoard }),
+}));
+
+describe('review request quest board flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds RequestCard to quest board when requesting review', async () => {
+    const onUpdate = jest.fn();
+    requestHelp.mockResolvedValue({
+      post: {
+        id: 'f1',
+        authorId: 'u1',
+        type: 'file',
+        content: 'file',
+        visibility: 'public',
+        timestamp: '',
+        tags: ['review', 'request'],
+        collaborators: [],
+        linkedItems: [],
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <ReactionControls
+          post={{
+            id: 'f1',
+            authorId: 'u1',
+            type: 'file',
+            content: 'file',
+            visibility: 'public',
+            tags: [],
+            collaborators: [],
+            linkedItems: [],
+          }}
+          user={{ id: 'u1' }}
+          onUpdate={onUpdate}
+        />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('Request Review')).toBeEnabled());
+    fireEvent.click(screen.getByText('Request Review'));
+
+    await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('f1', 'file'));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    expect(appendToBoard).toHaveBeenCalledWith('quest-board', expect.objectContaining({ id: 'f1' }));
+
+    const updatedPost = onUpdate.mock.calls[0][0];
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={updatedPost} boardId="quest-board" />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Submit Review')).toBeInTheDocument();
+    expect(updatedPost.tags).toEqual(expect.arrayContaining(['review', 'request']));
+  });
+
+  it('removes RequestCard and tags when cancelling review', async () => {
+    const onUpdate = jest.fn();
+    removeHelpRequest.mockResolvedValue({});
+
+    const postWithRequest = {
+      id: 'f1',
+      authorId: 'u1',
+      type: 'file',
+      content: 'file',
+      visibility: 'public',
+      timestamp: '',
+      tags: ['review', 'request'],
+      collaborators: [],
+      linkedItems: [],
+    };
+
+    render(
+      <BrowserRouter>
+        <ReactionControls post={postWithRequest} user={{ id: 'u1' }} onUpdate={onUpdate} />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('Requested')).toBeEnabled());
+    fireEvent.click(screen.getByText('Requested'));
+
+    await waitFor(() => expect(removeHelpRequest).toHaveBeenCalledWith('f1', 'file'));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    expect(appendToBoard).not.toHaveBeenCalled();
+
+    const updatedPost = onUpdate.mock.calls[0][0];
+    expect(updatedPost.tags).not.toEqual(expect.arrayContaining(['review', 'request']));
+
+    render(
+      <BrowserRouter>
+        <ContributionCard contribution={updatedPost} boardId="quest-board" />
+      </BrowserRouter>
+    );
+    expect(screen.queryByText('Submit Review')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering RequestCard creation for file review requests
- ensure cancelling review removes tags and no board append
- replace explicit any types in RequestCard tests with unknown to satisfy lint

## Testing
- `npm run lint --prefix ethos-frontend`
- `npm test --prefix ethos-frontend`
- `npm install --prefix ethos-backend`
- `npm test --prefix ethos-backend`

------
https://chatgpt.com/codex/tasks/task_e_689e4bf839dc832fa9081dd89e437bb8