### PR TITLE
refactor: use SQL for users and notifications

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -9,11 +9,11 @@ dotenv.config();
  * cannot be established (e.g. during tests where no DB is available) the flag
  * is flipped off and the app gracefully falls back to the JSON store.
  */
-export let usePg =
+let usePg =
   !!process.env.DATABASE_URL &&
   (process.env.NODE_ENV !== 'test' || process.env.USE_PG === 'true');
 
-export let pool: Pool = usePg
+let pool: Pool = usePg
   ? new Pool({ connectionString: process.env.DATABASE_URL })
   : ({} as Pool);
 
@@ -21,7 +21,7 @@ export let pool: Pool = usePg
  * Disable PostgreSQL usage and fall back to the JSON store.
  * This helper is useful if a database error occurs after startup.
  */
-export function disablePg(): void {
+function disablePg(): void {
   usePg = false;
   pool = {} as Pool;
 }
@@ -30,7 +30,7 @@ export function disablePg(): void {
  * Ensure required tables and starter data exist when using PostgreSQL.
  * This allows fresh deployments to work without running separate migrations.
  */
-export async function initializeDatabase(): Promise<void> {
+async function initializeDatabase(): Promise<void> {
   if (!usePg) return;
 
   try {
@@ -150,3 +150,5 @@ export async function initializeDatabase(): Promise<void> {
     }
   }
 }
+
+export { pool, usePg, disablePg, initializeDatabase };

--- a/ethos-backend/src/routes/notificationRoutes.ts
+++ b/ethos-backend/src/routes/notificationRoutes.ts
@@ -2,8 +2,7 @@ import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
-import { notificationsStore } from '../models/stores';
-import { pool, usePg } from '../db';
+import { pool } from '../db';
 
 import type { DBNotification } from '../types/db';
 
@@ -13,20 +12,16 @@ const router = express.Router();
 // GET /api/notifications - return notifications for current user
 router.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
   const userId = (req as any).user?.id;
-  if (usePg) {
-    try {
-      const result = await pool.query('SELECT * FROM notifications WHERE userid = $1', [userId]);
-      res.json(result.rows);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
+  try {
+    const result = await pool.query(
+      'SELECT * FROM notifications WHERE userid = $1',
+      [userId]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const all = notificationsStore.read();
-  const userNotes = all.filter(n => n.userId === userId);
-  res.json(userNotes);
 });
 
 // POST /api/notifications - create a new notification for a user
@@ -44,54 +39,44 @@ router.post('/', authOptional, async (req: Request<any, any, { userId: string; m
     read: false,
     createdAt: new Date().toISOString(),
   };
-  if (usePg) {
-    try {
-      await pool.query(
-        'INSERT INTO notifications (id, userid, message, link, read, createdat) VALUES ($1,$2,$3,$4,$5,$6)',
-        [newNote.id, newNote.userId, newNote.message, newNote.link, newNote.read, newNote.createdAt]
-      );
-      res.status(201).json(newNote);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
+  try {
+    await pool.query(
+      'INSERT INTO notifications (id, userid, message, link, read, createdat) VALUES ($1,$2,$3,$4,$5,$6)',
+      [
+        newNote.id,
+        newNote.userId,
+        newNote.message,
+        newNote.link,
+        newNote.read,
+        newNote.createdAt,
+      ]
+    );
+    res.status(201).json(newNote);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const notes = notificationsStore.read();
-  notificationsStore.write([...notes, newNote]);
-  res.status(201).json(newNote);
 });
 
 // PATCH /api/notifications/:id/read - mark a notification read
 router.patch('/:id/read', authMiddleware, async (req: Request<{ id: string }>, res: Response): Promise<void> => {
   const userId = (req as any).user?.id;
   const { id } = req.params;
-  if (usePg) {
-    try {
-      const result = await pool.query('UPDATE notifications SET read = true WHERE id = $1 AND userid = $2 RETURNING *', [id, userId]);
-      const row = result.rows[0];
-      if (!row) {
-        res.status(404).json({ error: 'Notification not found' });
-        return;
-      }
-      res.json(row);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
+  try {
+    const result = await pool.query(
+      'UPDATE notifications SET read = true WHERE id = $1 AND userid = $2 RETURNING *',
+      [id, userId]
+    );
+    const row = result.rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Notification not found' });
       return;
     }
+    res.json(row);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const notes = notificationsStore.read();
-  const note = notes.find(n => n.id === id && n.userId === userId);
-  if (!note) {
-    res.status(404).json({ error: 'Notification not found' });
-    return;
-  }
-  note.read = true;
-  notificationsStore.write(notes);
-  res.json(note);
 });
 
 export default router;

--- a/ethos-backend/src/routes/userRoutes.ts
+++ b/ethos-backend/src/routes/userRoutes.ts
@@ -2,8 +2,7 @@ import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import authOptional from '../middleware/authOptional';
 import { authMiddleware } from '../middleware/authMiddleware';
-import { usersStore, notificationsStore } from '../models/stores';
-import { pool, usePg } from '../db';
+import { pool } from '../db';
 
 
 const router = express.Router();
@@ -18,32 +17,19 @@ router.get(
   ): Promise<void> => {
     const { search } = req.query;
 
-    if (usePg) {
-      try {
-        let query = 'SELECT id, username FROM users';
-        const params: any[] = [];
-        if (search) {
-          query += ' WHERE LOWER(username) LIKE $1';
-          params.push(`%${search.toLowerCase()}%`);
-        }
-        const result = await pool.query(query, params);
-        res.json(result.rows);
-        return;
-      } catch (err) {
-        console.error(err);
-        res.status(500).json({ error: 'Database error' });
-        return;
+    try {
+      let query = 'SELECT id, username FROM users';
+      const params: any[] = [];
+      if (search) {
+        query += ' WHERE LOWER(username) LIKE $1';
+        params.push(`%${search.toLowerCase()}%`);
       }
+      const result = await pool.query(query, params);
+      res.json(result.rows);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    let users = usersStore
-      .read()
-      .map(u => ({ id: u.id, username: u.username }));
-    if (search) {
-      const term = search.toLowerCase();
-      users = users.filter(u => u.username.toLowerCase().includes(term));
-    }
-    res.json(users);
   }
 );
 
@@ -52,35 +38,21 @@ router.get(
   '/:id',
   authOptional,
   async (req: Request<{ id: string }>, res: Response): Promise<void> => {
-    if (usePg) {
-      try {
-        const result = await pool.query('SELECT * FROM users WHERE id = $1', [
-          req.params.id,
-        ]);
-        const row = result.rows[0];
-        if (!row) {
-          res.status(404).json({ error: 'User not found' });
-          return;
-        }
-        const { id, username, tags, bio, links, experienceTimeline, xp } = row;
-        res.json({ id, username, tags, bio, links, experienceTimeline, xp });
-        return;
-      } catch (err) {
-        console.error(err);
-        res.status(500).json({ error: 'Database error' });
+    try {
+      const result = await pool.query('SELECT * FROM users WHERE id = $1', [
+        req.params.id,
+      ]);
+      const row = result.rows[0];
+      if (!row) {
+        res.status(404).json({ error: 'User not found' });
         return;
       }
+      const { id, username, tags, bio, links, experienceTimeline, xp } = row;
+      res.json({ id, username, tags, bio, links, experienceTimeline, xp });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    const user = usersStore.read().find(u => u.id === req.params.id);
-    if (!user) {
-      res.status(404).json({ error: 'User not found' });
-      return;
-    }
-
-    // Return only public fields
-    const { id, username, tags, bio, links, experienceTimeline, xp } = user as any;
-    res.json({ id, username, tags, bio, links, experienceTimeline, xp });
   }
 );
 
@@ -89,85 +61,54 @@ router.post(
   '/:id/follow',
   authMiddleware,
   async (req: Request<{ id: string }>, res: Response): Promise<void> => {
-    if (usePg) {
-      try {
-        const followerId = (req as any).user?.id;
-        const targetResult = await pool.query(
-          'SELECT id, followers FROM users WHERE id = $1',
-          [req.params.id]
-        );
-        const followerResult = await pool.query(
-          'SELECT id, following, username FROM users WHERE id = $1',
-          [followerId]
-        );
-        const target = targetResult.rows[0];
-        const follower = followerResult.rows[0];
-        if (!target || !follower) {
-          res.status(404).json({ error: 'User not found' });
-          return;
-        }
-        const newFollowers = Array.from(
-          new Set([...(target.followers || []), followerId])
-        );
-        const newFollowing = Array.from(
-          new Set([...(follower.following || []), target.id])
-        );
-        await pool.query('UPDATE users SET followers = $1 WHERE id = $2', [
-          newFollowers,
-          target.id,
-        ]);
-        await pool.query('UPDATE users SET following = $1 WHERE id = $2', [
-          newFollowing,
-          followerId,
-        ]);
-
-        const notes = notificationsStore.read();
-        const newNote = {
-          id: uuidv4(),
-          userId: target.id,
-          message: `${follower.username} followed you`,
-          link: `/profile/${follower.id}`,
-          read: false,
-          createdAt: new Date().toISOString(),
-        };
-        notificationsStore.write([...notes, newNote]);
-
-        res.json({ followers: newFollowers });
-        return;
-      } catch (err) {
-        console.error(err);
-        res.status(500).json({ error: 'Database error' });
+    try {
+      const followerId = (req as any).user?.id;
+      const targetResult = await pool.query(
+        'SELECT id, followers FROM users WHERE id = $1',
+        [req.params.id]
+      );
+      const followerResult = await pool.query(
+        'SELECT id, following, username FROM users WHERE id = $1',
+        [followerId]
+      );
+      const target = targetResult.rows[0];
+      const follower = followerResult.rows[0];
+      if (!target || !follower) {
+        res.status(404).json({ error: 'User not found' });
         return;
       }
+      const newFollowers = Array.from(
+        new Set([...(target.followers || []), followerId])
+      );
+      const newFollowing = Array.from(
+        new Set([...(follower.following || []), target.id])
+      );
+      await pool.query('UPDATE users SET followers = $1 WHERE id = $2', [
+        newFollowers,
+        target.id,
+      ]);
+      await pool.query('UPDATE users SET following = $1 WHERE id = $2', [
+        newFollowing,
+        followerId,
+      ]);
+
+      await pool.query(
+        'INSERT INTO notifications (id, userid, message, link, read, createdat) VALUES ($1,$2,$3,$4,$5,$6)',
+        [
+          uuidv4(),
+          target.id,
+          `${follower.username} followed you`,
+          `/profile/${follower.id}`,
+          false,
+          new Date().toISOString(),
+        ]
+      );
+
+      res.json({ followers: newFollowers });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    const users = usersStore.read();
-    const target = users.find(u => u.id === req.params.id);
-    const follower = users.find(u => u.id === (req as any).user?.id);
-    if (!target || !follower) {
-      res.status(404).json({ error: 'User not found' });
-      return;
-    }
-    target.followers = Array.from(
-      new Set([...(target.followers || []), follower.id])
-    );
-    follower.following = Array.from(
-      new Set([...(follower.following || []), target.id])
-    );
-    usersStore.write(users);
-
-    const notes = notificationsStore.read();
-    const newNote = {
-      id: uuidv4(),
-      userId: target.id,
-      message: `${follower.username} followed you`,
-      link: `/profile/${follower.id}`,
-      read: false,
-      createdAt: new Date().toISOString(),
-    };
-    notificationsStore.write([...notes, newNote]);
-
-    res.json({ followers: target.followers });
   }
 );
 
@@ -176,57 +117,41 @@ router.post(
   '/:id/unfollow',
   authMiddleware,
   async (req: Request<{ id: string }>, res: Response): Promise<void> => {
-    if (usePg) {
-      try {
-        const followerId = (req as any).user?.id;
-        const targetResult = await pool.query(
-          'SELECT id, followers FROM users WHERE id = $1',
-          [req.params.id]
-        );
-        const followerResult = await pool.query(
-          'SELECT id, following FROM users WHERE id = $1',
-          [followerId]
-        );
-        const target = targetResult.rows[0];
-        const follower = followerResult.rows[0];
-        if (!target || !follower) {
-          res.status(404).json({ error: 'User not found' });
-          return;
-        }
-        const newFollowers = (target.followers || []).filter(
-          (id: string) => id !== followerId
-        );
-        const newFollowing = (follower.following || []).filter(
-          (id: string) => id !== target.id
-        );
-        await pool.query('UPDATE users SET followers = $1 WHERE id = $2', [
-          newFollowers,
-          target.id,
-        ]);
-        await pool.query('UPDATE users SET following = $1 WHERE id = $2', [
-          newFollowing,
-          followerId,
-        ]);
-        res.json({ followers: newFollowers });
-        return;
-      } catch (err) {
-        console.error(err);
-        res.status(500).json({ error: 'Database error' });
+    try {
+      const followerId = (req as any).user?.id;
+      const targetResult = await pool.query(
+        'SELECT id, followers FROM users WHERE id = $1',
+        [req.params.id]
+      );
+      const followerResult = await pool.query(
+        'SELECT id, following FROM users WHERE id = $1',
+        [followerId]
+      );
+      const target = targetResult.rows[0];
+      const follower = followerResult.rows[0];
+      if (!target || !follower) {
+        res.status(404).json({ error: 'User not found' });
         return;
       }
+      const newFollowers = (target.followers || []).filter(
+        (id: string) => id !== followerId
+      );
+      const newFollowing = (follower.following || []).filter(
+        (id: string) => id !== target.id
+      );
+      await pool.query('UPDATE users SET followers = $1 WHERE id = $2', [
+        newFollowers,
+        target.id,
+      ]);
+      await pool.query('UPDATE users SET following = $1 WHERE id = $2', [
+        newFollowing,
+        followerId,
+      ]);
+      res.json({ followers: newFollowers });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    const users = usersStore.read();
-    const target = users.find(u => u.id === req.params.id);
-    const follower = users.find(u => u.id === (req as any).user?.id);
-    if (!target || !follower) {
-      res.status(404).json({ error: 'User not found' });
-      return;
-    }
-    target.followers = (target.followers || []).filter(id => id !== follower.id);
-    follower.following = (follower.following || []).filter(id => id !== target.id);
-    usersStore.write(users);
-    res.json({ followers: target.followers });
   }
 );
 


### PR DESCRIPTION
## Summary
- switch user and notification routes to direct SQL queries
- insert follow notifications and follower lists via database updates
- drop `usePg` and JSON store code paths
- re-export database helpers for compatibility with remaining routes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4e96a834832f8d9219e77f3a863d