### PR TITLE
Use PostgreSQL for project data and map edges

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -129,6 +129,13 @@ export async function initializeDatabase(): Promise<void> {
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS boardid TEXT;
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS timestamp TIMESTAMPTZ;
     ALTER TABLE quests ADD COLUMN IF NOT EXISTS tags TEXT[];
+    ALTER TABLE quests ADD COLUMN IF NOT EXISTS status TEXT;
+    ALTER TABLE quests ADD COLUMN IF NOT EXISTS linkedPosts JSONB;
+    ALTER TABLE quests ADD COLUMN IF NOT EXISTS taskGraph JSONB;
+    ALTER TABLE projects ADD COLUMN IF NOT EXISTS status TEXT;
+    ALTER TABLE projects ADD COLUMN IF NOT EXISTS questIds TEXT[];
+    ALTER TABLE projects ADD COLUMN IF NOT EXISTS deliverables TEXT[];
+    ALTER TABLE projects ADD COLUMN IF NOT EXISTS mapEdges JSONB;
   `);
 
   const { rows } = await pool.query(

--- a/ethos-backend/src/routes/projectRoutes.ts
+++ b/ethos-backend/src/routes/projectRoutes.ts
@@ -1,204 +1,132 @@
 import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
-import { projectsStore } from '../models/stores';
 import type { DBProject } from '../types/db';
 import type { AuthenticatedRequest } from '../types/express';
-import { pool, usePg } from '../db';
+import { pool } from '../db';
 
 const router = express.Router();
 
 
 // GET all projects
 router.get('/', async (_req: Request, res: Response): Promise<void> => {
-  if (usePg) {
-    try {
-      const result = await pool.query('SELECT * FROM projects');
-      res.json(result.rows);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
+  try {
+    const result = await pool.query('SELECT * FROM projects');
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const projects = projectsStore.read();
-  res.json(projects);
 });
 
 // GET a single project
 router.get('/:id', async (req: Request<{ id: string }>, res: Response): Promise<void> => {
-  if (usePg) {
-    try {
-      const result = await pool.query('SELECT * FROM projects WHERE id = $1', [req.params.id]);
-      const project = result.rows[0];
-      if (!project) {
-        res.status(404).json({ error: 'Project not found' });
-        return;
-      }
-      res.json(project);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
+  try {
+    const result = await pool.query('SELECT * FROM projects WHERE id = $1', [req.params.id]);
+    const project = result.rows[0];
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
       return;
     }
+    res.json(project);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const { id } = req.params;
-  const projects = projectsStore.read();
-  const project = projects.find((p) => p.id === id);
-  if (!project) {
-    res.status(404).json({ error: 'Project not found' });
-    return;
-  }
-  res.json(project);
 });
 
 // CREATE a new project
 router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  if (usePg) {
-    const { title, description = '', visibility = 'public', tags = [] } = req.body;
-    const authorId = req.user?.id;
-    if (!authorId || !title) {
-      res.status(400).json({ error: 'Missing required fields' });
-      return;
-    }
-    const id = uuidv4();
-    try {
-      await pool.query(
-        'INSERT INTO projects (id, authorid, title, description, visibility, tags) VALUES ($1,$2,$3,$4,$5,$6)',
-        [id, authorId, title, description, visibility, JSON.stringify(tags)]
-      );
-      res.status(201).json({ id, authorId, title, description, visibility, tags });
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
-  }
   const { title, description = '', visibility = 'public', tags = [] } = req.body;
   const authorId = req.user?.id;
   if (!authorId || !title) {
     res.status(400).json({ error: 'Missing required fields' });
     return;
   }
-  const newProject: DBProject = {
-    id: uuidv4(),
-    authorId,
-    title,
-    description,
-    visibility,
-    approvalStatus: 'approved',
-    status: 'active',
-    tags,
-    createdAt: new Date().toISOString(),
-    questIds: [],
-    headPostId: '',
-    linkedPosts: [],
-    quests: [],
-    deliverables: [],
-    mapEdges: [],
-    collaborators: [],
-  };
-  const projects = projectsStore.read();
-  projects.push(newProject);
-  projectsStore.write(projects);
-  res.status(201).json(newProject);
+  const id = uuidv4();
+  try {
+    await pool.query(
+      'INSERT INTO projects (id, authorid, title, description, visibility, tags) VALUES ($1,$2,$3,$4,$5,$6)',
+      [id, authorId, title, description, visibility, JSON.stringify(tags)]
+    );
+    res.status(201).json({ id, authorId, title, description, visibility, tags });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
 });
 
 // PATCH update a project
 router.patch('/:id', authMiddleware, async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
-  if (usePg) {
-    try {
-      const fields = Object.keys(req.body);
-      const values = Object.values(req.body);
-      if (fields.length > 0) {
-        const sets = fields.map((f, i) => `${f} = $${i + 1}`).join(', ');
-        values.push(req.params.id);
-        const result = await pool.query(`UPDATE projects SET ${sets} WHERE id = $${fields.length + 1} RETURNING *`, values);
-        const row = result.rows[0];
-        if (!row) {
-          res.status(404).json({ error: 'Project not found' });
-          return;
-        }
-        res.json(row);
-        return;
-      }
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
+  try {
+    const fields = Object.keys(req.body);
+    const values = Object.values(req.body);
+    if (fields.length === 0) {
+      res.status(400).json({ error: 'No fields to update' });
       return;
     }
+    const sets = fields.map((f, i) => `${f} = $${i + 1}`).join(', ');
+    values.push(req.params.id);
+    const result = await pool.query(
+      `UPDATE projects SET ${sets} WHERE id = $${fields.length + 1} RETURNING *`,
+      values
+    );
+    const row = result.rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+    res.json(row);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const { id } = req.params;
-  const updates = req.body as Partial<DBProject>;
-  const projects = projectsStore.read();
-  const project = projects.find((p) => p.id === id);
-  if (!project) {
-    res.status(404).json({ error: 'Project not found' });
-    return;
-  }
-  Object.assign(project, updates);
-  projectsStore.write(projects);
-  res.json(project);
 });
 
 // DELETE a project
 router.delete('/:id', authMiddleware, async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
-  if (usePg) {
-    try {
-      const result = await pool.query('DELETE FROM projects WHERE id = $1 RETURNING *', [req.params.id]);
-      const row = result.rows[0];
-      if (!row) {
-        res.status(404).json({ error: 'Project not found' });
-        return;
-      }
-      res.json({ success: true });
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
+  try {
+    const result = await pool.query('DELETE FROM projects WHERE id = $1 RETURNING *', [req.params.id]);
+    const row = result.rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Project not found' });
       return;
     }
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const { id } = req.params;
-  const projects = projectsStore.read();
-  const index = projects.findIndex((p) => p.id === id);
-  if (index === -1) {
-    res.status(404).json({ error: 'Project not found' });
-    return;
-  }
-  projects.splice(index, 1);
-  projectsStore.write(projects);
-  res.json({ success: true });
 });
 
 // GET project map edges
-router.get('/:id/map', (req: Request<{ id: string }>, res: Response) => {
-  const { id } = req.params;
-  const projects = projectsStore.read();
-  const project = projects.find((p) => p.id === id);
-  if (!project) {
-    res.status(404).json({ error: 'Project not found' });
-    return;
+router.get('/:id/map', async (req: Request<{ id: string }>, res: Response): Promise<void> => {
+  try {
+    const result = await pool.query('SELECT mapEdges FROM projects WHERE id = $1', [req.params.id]);
+    const project = result.rows[0];
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+    res.json({ edges: project.mapedges || [] });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  res.json({ edges: project.mapEdges || [] });
 });
 
 // PATCH update map edges
-router.patch('/:id/map', authMiddleware, (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
+router.patch('/:id/map', authMiddleware, async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
   const { id } = req.params;
   const { edges } = req.body as { edges: DBProject['mapEdges'] };
-  const projects = projectsStore.read();
-  const project = projects.find((p) => p.id === id);
-  if (!project) {
-    res.status(404).json({ error: 'Project not found' });
-    return;
+  try {
+    await pool.query('UPDATE projects SET mapEdges = $2 WHERE id = $1', [id, JSON.stringify(edges || [])]);
+    const result = await pool.query('SELECT mapEdges FROM projects WHERE id = $1', [id]);
+    res.json({ success: true, edges: result.rows[0]?.mapedges || [] });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  project.mapEdges = edges || [];
-  projectsStore.write(projects);
-  res.json({ success: true, edges: project.mapEdges });
 });
 
 export default router;

--- a/ethos-backend/src/routes/questRoutes.ts
+++ b/ethos-backend/src/routes/questRoutes.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
-import { boardsStore, questsStore, projectsStore, postsStore, usersStore, reactionsStore, notificationsStore } from '../models/stores';
+import { boardsStore, questsStore, postsStore, usersStore, reactionsStore, notificationsStore } from '../models/stores';
 import { pool, usePg } from '../db';
 import { enrichQuest, enrichPost } from '../utils/enrich';
 import { generateNodeId } from '../utils/nodeIdUtils';
@@ -406,23 +406,32 @@ router.post('/:id/flag', authMiddleware, (req: AuthRequest<{ id: string }>, res:
 router.get(
   '/:id/map',
   authOptional,
-  (req: AuthRequest<{ id: string }>, res: Response): void => {
+  async (req: AuthRequest<{ id: string }>, res: Response): Promise<void> => {
     const { id } = req.params;
-  const quests = questsStore.read();
-  const quest = quests.find((q) => q.id === id);
-  if (!quest) {
-    logQuest404(id, req.originalUrl);
-    res.status(404).json({ error: 'Quest not found' });
-    return;
-  }
+    try {
+      const questResult = await pool.query('SELECT * FROM quests WHERE id = $1', [id]);
+      const quest = questResult.rows[0];
+      if (!quest) {
+        logQuest404(id, req.originalUrl);
+        res.status(404).json({ error: 'Quest not found' });
+        return;
+      }
 
-    const posts = postsStore.read();
-    const users = usersStore.read();
-    const nodes = posts
-      .filter((p) => p.questId === id)
-      .map((p) => enrichPost(p, { users, currentUserId: req.user?.id || null }));
+      const postsResult = await pool.query('SELECT * FROM posts WHERE questid = $1', [id]);
+      const usersResult = await pool.query('SELECT * FROM users');
+      const nodes = postsResult.rows.map((p) =>
+        enrichPost(p, {
+          users: usersResult.rows,
+          quests: [quest],
+          currentUserId: req.user?.id || null,
+        })
+      );
 
-    res.json({ nodes, edges: quest.taskGraph || [] });
+      res.json({ nodes, edges: quest.taskgraph || [] });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
+    }
   }
 );
 
@@ -430,10 +439,10 @@ router.get(
 router.patch(
   '/:id/map',
   authMiddleware,
-  (
+  async (
     req: AuthRequest<{ id: string }, any, { edges: TaskEdge[] }>,
     res: Response,
-  ): void => {
+  ): Promise<void> => {
     const { id } = req.params;
     const { edges } = req.body;
 
@@ -442,18 +451,19 @@ router.patch(
       return;
     }
 
-    const quests = questsStore.read();
-    const quest = quests.find((q) => q.id === id);
-    if (!quest) {
-      logQuest404(id, req.originalUrl);
-      res.status(404).json({ error: 'Quest not found' });
-      return;
+    try {
+      const questResult = await pool.query('SELECT id FROM quests WHERE id = $1', [id]);
+      if (questResult.rowCount === 0) {
+        logQuest404(id, req.originalUrl);
+        res.status(404).json({ error: 'Quest not found' });
+        return;
+      }
+      await pool.query('UPDATE quests SET taskGraph = $2 WHERE id = $1', [id, JSON.stringify(edges)]);
+      res.json({ success: true, edges });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    quest.taskGraph = edges;
-    questsStore.write(quests);
-
-    res.json({ success: true, edges: quest.taskGraph });
   },
 );
 
@@ -641,38 +651,46 @@ router.get(
 router.post(
   '/:id/promote',
   authMiddleware,
-  (req: AuthRequest<{ id: string }>, res: Response): void => {
+  async (req: AuthRequest<{ id: string }>, res: Response): Promise<void> => {
     const { id } = req.params;
 
-    const quests = questsStore.read();
-    const questIndex = quests.findIndex((q) => q.id === id);
-    if (questIndex === -1) {
-      logQuest404(id, req.originalUrl);
-      res.status(404).json({ error: 'Quest not found' });
-      return;
+    try {
+      const questRes = await pool.query('SELECT * FROM quests WHERE id = $1', [id]);
+      const quest = questRes.rows[0];
+      if (!quest) {
+        logQuest404(id, req.originalUrl);
+        res.status(404).json({ error: 'Quest not found' });
+        return;
+      }
+
+      const childQuestIds = (quest.linkedposts || [])
+        .filter((l: any) => l.itemType === 'quest')
+        .map((l: any) => l.itemId);
+
+      await pool.query(
+        'INSERT INTO projects (id, authorid, title, description, visibility, status, tags, questIds) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)',
+        [
+          quest.id,
+          quest.authorid,
+          quest.title,
+          quest.description,
+          quest.visibility,
+          quest.status,
+          JSON.stringify(quest.tags || []),
+          JSON.stringify(childQuestIds),
+        ]
+      );
+
+      await pool.query('DELETE FROM quests WHERE id = $1', [id]);
+      if (childQuestIds.length > 0) {
+        await pool.query('UPDATE quests SET projectId = $2 WHERE id = ANY($1::text[])', [childQuestIds, quest.id]);
+      }
+
+      res.json({ ...quest, questIds: childQuestIds });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
     }
-
-    const quest = quests[questIndex];
-    const childQuestIds = (quest.linkedPosts || [])
-      .filter((l) => l.itemType === 'quest')
-      .map((l) => l.itemId);
-
-    const projects = projectsStore.read();
-    const newProject: DBProject = {
-      ...quest,
-      questIds: childQuestIds,
-    };
-    projects.push(newProject);
-    projectsStore.write(projects);
-
-    quests.splice(questIndex, 1);
-    childQuestIds.forEach((cid) => {
-      const child = quests.find((q) => q.id === cid);
-      if (child) child.projectId = newProject.id;
-    });
-    questsStore.write(quests);
-
-    res.json(newProject);
   }
 );
 


### PR DESCRIPTION
## Summary
- Replace JSON-backed project routes with direct PostgreSQL CRUD queries
- Store and update project and quest map edges in the database
- Add initialization for quest and project JSONB/array columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4ea0a7ec832f8cb85de52d2f0510