### PR TITLE
Refactor notifications to use SQL persistence

### DIFF
--- a/ethos-backend/src/routes/notificationRoutes.ts
+++ b/ethos-backend/src/routes/notificationRoutes.ts
@@ -2,8 +2,7 @@ import express, { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import authOptional from '../middleware/authOptional';
-import { notificationsStore } from '../models/stores';
-import { pool, usePg } from '../db';
+import { pool } from '../db';
 
 import type { DBNotification } from '../types/db';
 
@@ -13,20 +12,16 @@ const router = express.Router();
 // GET /api/notifications - return notifications for current user
 router.get('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
   const userId = (req as any).user?.id;
-  if (usePg) {
-    try {
-      const result = await pool.query('SELECT * FROM notifications WHERE userid = $1', [userId]);
-      res.json(result.rows);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
+  try {
+    const result = await pool.query(
+      'SELECT * FROM notifications WHERE userid = $1',
+      [userId]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const all = notificationsStore.read();
-  const userNotes = all.filter(n => n.userId === userId);
-  res.json(userNotes);
 });
 
 // POST /api/notifications - create a new notification for a user
@@ -44,54 +39,44 @@ router.post('/', authOptional, async (req: Request<any, any, { userId: string; m
     read: false,
     createdAt: new Date().toISOString(),
   };
-  if (usePg) {
-    try {
-      await pool.query(
-        'INSERT INTO notifications (id, userid, message, link, read, createdat) VALUES ($1,$2,$3,$4,$5,$6)',
-        [newNote.id, newNote.userId, newNote.message, newNote.link, newNote.read, newNote.createdAt]
-      );
-      res.status(201).json(newNote);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
-      return;
-    }
+  try {
+    await pool.query(
+      'INSERT INTO notifications (id, userid, message, link, read, createdat) VALUES ($1,$2,$3,$4,$5,$6)',
+      [
+        newNote.id,
+        newNote.userId,
+        newNote.message,
+        newNote.link,
+        newNote.read,
+        newNote.createdAt,
+      ]
+    );
+    res.status(201).json(newNote);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const notes = notificationsStore.read();
-  notificationsStore.write([...notes, newNote]);
-  res.status(201).json(newNote);
 });
 
 // PATCH /api/notifications/:id/read - mark a notification read
 router.patch('/:id/read', authMiddleware, async (req: Request<{ id: string }>, res: Response): Promise<void> => {
   const userId = (req as any).user?.id;
   const { id } = req.params;
-  if (usePg) {
-    try {
-      const result = await pool.query('UPDATE notifications SET read = true WHERE id = $1 AND userid = $2 RETURNING *', [id, userId]);
-      const row = result.rows[0];
-      if (!row) {
-        res.status(404).json({ error: 'Notification not found' });
-        return;
-      }
-      res.json(row);
-      return;
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Database error' });
+  try {
+    const result = await pool.query(
+      'UPDATE notifications SET read = true WHERE id = $1 AND userid = $2 RETURNING *',
+      [id, userId]
+    );
+    const row = result.rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Notification not found' });
       return;
     }
+    res.json(row);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
   }
-  const notes = notificationsStore.read();
-  const note = notes.find(n => n.id === id && n.userId === userId);
-  if (!note) {
-    res.status(404).json({ error: 'Notification not found' });
-    return;
-  }
-  note.read = true;
-  notificationsStore.write(notes);
-  res.json(note);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- query notifications directly from Postgres instead of JSON store
- insert and update notifications via SQL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5175b724832f8e212f6943c7cd3c