### PR TITLE
Cascade delete request posts when parent is removed

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -1360,6 +1360,24 @@ router.delete(
           res.status(404).json({ error: 'Post not found' });
           return;
         }
+        await pool
+          .query(
+            "DELETE FROM reactions WHERE postid IN (SELECT id FROM posts WHERE repostedfrom = $1 AND type = 'request')",
+            [req.params.id]
+          )
+          .catch((err) => console.error(err));
+        await pool
+          .query(
+            "DELETE FROM posts WHERE repostedfrom = $1 AND type = 'request'",
+            [req.params.id]
+          )
+          .catch((err) => console.error(err));
+        await pool
+          .query(
+            "DELETE FROM reactions WHERE postid = $1 AND type IN ('request','review')",
+            [req.params.id]
+          )
+          .catch((err) => console.error(err));
         res.json({ success: true });
         return;
       } catch (err) {
@@ -1413,8 +1431,31 @@ router.delete(
       }
     }
 
+    const requestIds = posts
+      .filter(p => p.repostedFrom === post.id && p.type === 'request')
+      .map(p => p.id);
+    requestIds.forEach(rid => {
+      const rIndex = posts.findIndex(p => p.id === rid);
+      if (rIndex !== -1) posts.splice(rIndex, 1);
+    });
     posts.splice(index, 1);
     postsStore.write(posts);
+    const boards = boardsStore.read();
+    const questBoard = boards.find(b => b.id === 'quest-board');
+    if (questBoard) {
+      const toRemove = new Set([req.params.id, ...requestIds]);
+      questBoard.items = (questBoard.items || []).filter(id => !toRemove.has(id));
+      boardsStore.write(boards);
+    }
+    const reactions = reactionsStore.read();
+    const filtered = reactions.filter(r => {
+      const [postId] = r.split('_');
+      if (postId === req.params.id) {
+        return !(r.endsWith('_request') || r.endsWith('_review'));
+      }
+      return !requestIds.includes(postId);
+    });
+    reactionsStore.write(filtered);
     res.json({ success: true });
   }
 );

--- a/ethos-backend/tests/deleteRequestCascade.test.ts
+++ b/ethos-backend/tests/deleteRequestCascade.test.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import express from 'express';
+import type { DBPost } from '../src/types/db';
+import postRoutes from '../src/routes/postRoutes';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => {
+    _req.user = { id: 'u1' };
+    next();
+  },
+}));
+
+jest.mock('../src/models/stores', () => ({
+  postsStore: { read: jest.fn(() => []), write: jest.fn() },
+  usersStore: { read: jest.fn(() => []), write: jest.fn() },
+  reactionsStore: { read: jest.fn(() => []), write: jest.fn() },
+  questsStore: { read: jest.fn(() => []), write: jest.fn() },
+  notificationsStore: { read: jest.fn(() => []), write: jest.fn() },
+  boardsStore: { read: jest.fn(() => []), write: jest.fn() },
+}));
+
+jest.mock('../src/db', () => ({ pool: { query: jest.fn() }, usePg: false }));
+
+const { postsStore, reactionsStore, boardsStore } = require('../src/models/stores');
+
+const app = express();
+app.use(express.json());
+app.use('/posts', postRoutes);
+
+describe('post deletion removes linked requests', () => {
+  it('deletes request posts and reactions', async () => {
+    const original: DBPost = {
+      id: 'p1',
+      authorId: 'u1',
+      type: 'task',
+      content: '',
+      visibility: 'public',
+      timestamp: '',
+      replyTo: null,
+    };
+    const helpReq: DBPost = {
+      id: 'r1',
+      authorId: 'u1',
+      type: 'request',
+      content: '',
+      visibility: 'public',
+      timestamp: '',
+      repostedFrom: 'p1',
+      tags: ['request'],
+    };
+    const reviewReq: DBPost = {
+      id: 'r2',
+      authorId: 'u1',
+      type: 'request',
+      content: '',
+      visibility: 'public',
+      timestamp: '',
+      repostedFrom: 'p1',
+      tags: ['request', 'review'],
+    };
+    const posts = [original, helpReq, reviewReq];
+    postsStore.read.mockReturnValue(posts);
+    postsStore.write.mockClear();
+    reactionsStore.read.mockReturnValue(['p1_u1_request', 'p1_u1_review', 'x_u1_like']);
+    reactionsStore.write.mockClear();
+    boardsStore.read.mockReturnValue([{ id: 'quest-board', items: ['r1', 'r2'] }]);
+    boardsStore.write.mockClear();
+
+    const res = await request(app).delete('/posts/p1');
+    expect(res.status).toBe(200);
+    const writtenPosts = postsStore.write.mock.calls[0][0];
+    expect(writtenPosts).toHaveLength(0);
+    const writtenReactions = reactionsStore.write.mock.calls[0][0];
+    expect(writtenReactions).toEqual(['x_u1_like']);
+    const writtenBoards = boardsStore.write.mock.calls[0][0];
+    expect(writtenBoards[0].items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure quest board entries and linked request posts are deleted when parent post is removed
- extend cascade-delete regression test to cover quest board cleanup

## Testing
- `cd ethos-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f39eda204832fada3dad1b08a8590