### PR TITLE
Restrict file posting on timeline and simplify create workflow

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -25,6 +25,7 @@ export default {
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/src/api/post.requestHelp.test.ts',
+    '<rootDir>/tests/CreatePostReplyTypeRestrictions.test.tsx',
     '<rootDir>/tests/CreatePostReply.test.tsx',
     '<rootDir>/tests/CreatePostRequestNoTask.test.tsx',
     '<rootDir>/tests/BoardUtilsRequestPosts.test.ts',

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -61,9 +61,7 @@ const CreatePost: React.FC<CreatePostProps> = ({
 
   const [type, setType] = useState<PostType | 'review'>(
     restrictedReply
-      ? replyToType === 'file' && isParticipant
-        ? 'free_speech'
-        : 'free_speech'
+      ? 'free_speech'
       : initialType === 'request'
       ? 'task'
       : initialType === 'review'

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { POST_TYPES, STATUS_OPTIONS } from '../../constants/options';
+import { POST_TYPES, STATUS_OPTIONS, SECONDARY_POST_TYPES } from '../../constants/options';
 import { addPost } from '../../api/post';
 import { Button, Select, Label, FormSection, Input, MarkdownEditor } from '../ui';
 import CollaberatorControls from '../controls/CollaberatorControls';
-import LinkControls from '../controls/LinkControls';
 import { useBoardContext } from '../../contexts/BoardContext';
 import { useAuth } from '../../contexts/AuthContext';
 import type { BoardType } from '../../types/boardTypes';
@@ -60,22 +59,21 @@ const CreatePost: React.FC<CreatePostProps> = ({
         : false)
     : false;
 
-  const [type, setType] = useState<PostType>(
+  const [type, setType] = useState<PostType | 'review'>(
     restrictedReply
       ? replyToType === 'file' && isParticipant
-        ? 'file'
+        ? 'free_speech'
         : 'free_speech'
       : initialType === 'request'
       ? 'task'
       : initialType === 'review'
-      ? 'file'
+      ? 'review'
       : initialType
   );
   const [status, setStatus] = useState<string>('To Do');
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>(initialContent || '');
   const [details, setDetails] = useState<string>('');
-  const [linkedItems, setLinkedItems] = useState<LinkedItem[]>([]);
   const [collaborators, setCollaborators] = useState<CollaberatorRoles[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   
@@ -86,16 +84,16 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   const boardType: BoardType | undefined =
     boardId ? boards?.[boardId]?.boardType : boards?.[selectedBoard || '']?.boardType;
 
-  const allowedPostTypes: PostType[] = restrictedReply
+  const allowedPostTypes: (PostType | 'review')[] = restrictedReply
     ? replyToType === 'task'
       ? isParticipant
         ? ['free_speech', 'task', 'file']
         : ['free_speech']
       : replyToType === 'file'
-      ? isParticipant
-        ? ['free_speech', 'file']
-        : ['free_speech']
+      ? ['free_speech', 'review']
       : ['free_speech']
+    : boardId === 'timeline-board'
+    ? ['free_speech', 'task']
     : boardId === 'quest-board'
     ? ['task', 'file']
     : boardType === 'quest'
@@ -116,43 +114,37 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       ? boardQuestMatch[1]
       : questId || replyTo?.questId || null;
 
-    const autoLinkItems = [...linkedItems];
-    if (questIdFromBoard && !autoLinkItems.some((l) => l.itemId === questIdFromBoard)) {
+    const autoLinkItems: LinkedItem[] = [];
+    if (questIdFromBoard) {
       autoLinkItems.push({ itemId: questIdFromBoard, itemType: 'quest' });
     }
 
-    const validation = validateLinks(type, autoLinkItems, !!replyTo);
-    if (!validation.valid) {
-      alert(validation.message);
-      setIsSubmitting(false);
-      return;
-    }
-
-      const payload: Partial<Post> = {
-        type,
-        title: type === 'task' ? content : title || undefined,
-        content,
-        ...(type === 'task' && details ? { details } : {}),
-        visibility: 'public',
-        linkedItems: autoLinkItems,
-        ...(type === 'task' ? { status } : {}),
-        ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
-        ...(targetBoard ? { boardId: targetBoard } : {}),
-        ...(replyTo ? { replyTo: replyTo.id, parentPostId: replyTo.id, linkType: 'reply' } : {}),
-        ...(repostSource
-          ? {
-              parentPostId: repostSource.id,
-              linkType: 'repost',
-              repostedFrom: {
-                originalPostId: repostSource.id,
-                username: repostSource.author?.username,
-                originalContent: repostSource.content,
-                originalTimestamp: repostSource.timestamp,
-              },
-            }
-          : {}),
-        ...(requiresQuestRoles(type) && { collaborators }),
-      };
+    const payload: Partial<Post> = {
+      type: type === 'review' ? 'file' : type,
+      title: type === 'task' ? content : title || undefined,
+      content,
+      ...(type === 'task' && details ? { details } : {}),
+      visibility: 'public',
+      linkedItems: autoLinkItems,
+      ...(type === 'task' ? { status } : {}),
+      ...(type === 'review' ? { tags: ['review'] } : {}),
+      ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),
+      ...(targetBoard ? { boardId: targetBoard } : {}),
+      ...(replyTo ? { replyTo: replyTo.id, parentPostId: replyTo.id, linkType: 'reply' } : {}),
+      ...(repostSource
+        ? {
+            parentPostId: repostSource.id,
+            linkType: 'repost',
+            repostedFrom: {
+              originalPostId: repostSource.id,
+              username: repostSource.author?.username,
+              originalContent: repostSource.content,
+              originalTimestamp: repostSource.timestamp,
+            },
+          }
+        : {}),
+      ...(requiresQuestRoles(type) && { collaborators }),
+    };
 
     try {
       const newPost = await addPost(payload);
@@ -199,11 +191,15 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
           id="post-type"
           value={type}
           onChange={(e) => {
-            const val = e.target.value as PostType;
+            const val = e.target.value as PostType | 'review';
             setType(val);
             if (val === 'task') setStatus('To Do');
           }}
           options={allowedPostTypes.map((t) => {
+            if (t === 'review') {
+              const opt = SECONDARY_POST_TYPES.find(o => o.value === 'review')!;
+              return { value: opt.value, label: opt.label };
+            }
             const opt = POST_TYPES.find((o) => o.value === t)!;
             return { value: opt.value, label: opt.label };
           })}
@@ -271,19 +267,6 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
 
       </FormSection>
 
-      {showLinkControls(type) && !replyTo && (
-        <FormSection title="Linked Items">
-          <LinkControls
-            label="Item"
-            value={linkedItems}
-            onChange={setLinkedItems}
-            allowCreateNew
-            allowNodeSelection
-            itemTypes={['quest', 'post']}
-          />
-        </FormSection>
-      )}
-
       {requiresQuestRoles(type) && !replyTo && (
         <FormSection title="Collaborators">
           <CollaberatorControls value={collaborators} onChange={setCollaborators} />
@@ -318,37 +301,8 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
   );
 };
 
-function requiresQuestRoles(type: PostType): boolean {
+function requiresQuestRoles(type: PostType | 'review'): boolean {
   return type === 'task';
-}
-
-function showLinkControls(type: PostType): boolean {
-  return ['task', 'file'].includes(type);
-}
-
-function validateLinks(
-  type: PostType,
-  items: LinkedItem[],
-  hasParent: boolean = false,
-): {
-  valid: boolean;
-  message?: string;
-} {
-  switch (type) {
-    case 'free_speech':
-      return items.some(i => i.itemType === 'post')
-        ? { valid: false, message: 'Free speech posts cannot have links.' }
-        : { valid: true };
-    case 'file':
-      return hasParent || items.some(i => i.itemType === 'post')
-        ? { valid: true }
-        : {
-            valid: false,
-            message: 'Please link a task before submitting.',
-          };
-    default:
-      return { valid: true };
-  }
 }
 
 export default CreatePost;

--- a/ethos-frontend/tests/CreatePostReplyTypeRestrictions.test.tsx
+++ b/ethos-frontend/tests/CreatePostReplyTypeRestrictions.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import type { Post } from '../src/types/postTypes';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: null, boards: {}, appendToBoard: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+import CreatePost from '../src/components/post/CreatePost';
+
+describe('CreatePost reply type restrictions', () => {
+  it('only shows free speech when replying to free speech', () => {
+    const parent = { id: 'p1', type: 'free_speech', authorId: 'u1' } as Post;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={parent} />
+      </BrowserRouter>
+    );
+    const options = Array.from(screen.getByLabelText('Item Type').querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Free Speech']);
+  });
+
+  it('shows free speech and review when replying to a file', () => {
+    const parent = { id: 'f1', type: 'file', authorId: 'u1' } as Post;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={parent} />
+      </BrowserRouter>
+    );
+    const options = Array.from(screen.getByLabelText('Item Type').querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Free Speech', 'Review']);
+  });
+});

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -41,6 +41,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Task', 'File']);
+    expect(options).toEqual(['Free Speech', 'Task']);
   });
 });


### PR DESCRIPTION
## Summary
- prevent file posts on timeline board; allow only free speech or tasks
- drop link controls and allow file replies to offer review option
- add test coverage for type restrictions

## Testing
- `npx jest tests/TimelineBoardPostTypes.test.tsx --runInBand`
- `npx jest tests/CreatePostReply.test.tsx --runInBand`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a011334f9c832fa4ac655d6a55f873