### PR TITLE
Restrict file posting on timeline and simplify create workflow

### DIFF
--- a/ethos-backend/prisma/migrations/20250726213532_add_ethos_tables/migration.sql
+++ b/ethos-backend/prisma/migrations/20250726213532_add_ethos_tables/migration.sql
@@ -14,6 +14,13 @@ CREATE TABLE posts (
     type TEXT NOT NULL,
     title TEXT,
     content TEXT NOT NULL,
+    details TEXT,
+    visibility TEXT,
+    tags TEXT[],
+    status TEXT,
+    boardId TEXT,
+    nodeId TEXT,
+    timestamp TIMESTAMP(3),
     createdAt TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/ethos-backend/prisma/schema.prisma
+++ b/ethos-backend/prisma/schema.prisma
@@ -29,6 +29,13 @@ model Post {
   type      String
   title     String?
   content   String
+  details   String?
+  visibility String?
+  tags      String[] @default([])
+  status    String?
+  boardId   String?
+  nodeId    String?
+  timestamp DateTime?
   createdAt DateTime @default(now())
 
   author User @relation(fields: [authorId], references: [id])

--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -63,12 +63,18 @@ async function initializeDatabase(): Promise<void> {
       type TEXT,
       content TEXT,
       title TEXT,
+      details TEXT,
       visibility TEXT,
       tags TEXT[],
+      status TEXT,
       boardid TEXT,
+      nodeid TEXT,
       timestamp TIMESTAMPTZ,
       createdat TIMESTAMPTZ DEFAULT NOW()
     );
+    ALTER TABLE posts ADD COLUMN IF NOT EXISTS details TEXT;
+    ALTER TABLE posts ADD COLUMN IF NOT EXISTS nodeid TEXT;
+    ALTER TABLE posts ADD COLUMN IF NOT EXISTS status TEXT;
     CREATE TABLE IF NOT EXISTS quests (
       id UUID PRIMARY KEY,
       authorid TEXT,

--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -298,16 +298,19 @@ router.post(
     if (usePg) {
       try {
         await pool.query(
-          'INSERT INTO posts (id, authorid, type, content, title, visibility, tags, boardid, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+          'INSERT INTO posts (id, authorid, type, content, title, details, visibility, tags, status, boardid, nodeid, timestamp) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)',
           [
             newPost.id,
             newPost.authorId,
             newPost.type,
             newPost.content,
             newPost.title,
+            newPost.details,
             newPost.visibility,
             newPost.tags,
+            newPost.status,
             effectiveBoardId,
+            newPost.nodeId,
             newPost.timestamp,
           ]
         );

--- a/ethos-backend/tests/postPersistence.test.ts
+++ b/ethos-backend/tests/postPersistence.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import express from 'express';
+
+import postRoutes from '../src/routes/postRoutes';
+import { setupTestDb } from './testDb';
+import { pool } from '../src/db';
+
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (_req: any, _res: any, next: any) => {
+    _req.user = { id: 'u1' };
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/posts', postRoutes);
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+describe('post persistence', () => {
+  it('stores nodeId and details for task posts', async () => {
+    const res = await request(app)
+      .post('/posts')
+      .send({ type: 'task', content: 'My task', details: 'More info' });
+    expect(res.status).toBe(201);
+    const id = res.body.id;
+    const dbRes = await pool.query('SELECT nodeid, details FROM posts WHERE id=$1', [id]);
+    expect(dbRes.rows[0].nodeid).toBe('T00');
+    expect(dbRes.rows[0].details).toBe('More info');
+  });
+});

--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -25,6 +25,7 @@ export default {
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
     '<rootDir>/src/api/post.requestHelp.test.ts',
+    '<rootDir>/tests/CreatePostReplyTypeRestrictions.test.tsx',
     '<rootDir>/tests/CreatePostReply.test.tsx',
     '<rootDir>/tests/CreatePostRequestNoTask.test.tsx',
     '<rootDir>/tests/BoardUtilsRequestPosts.test.ts',

--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -69,7 +69,7 @@ describe('CreatePost replying', () => {
       </BrowserRouter>
     );
     fireEvent.change(screen.getByLabelText('Title'), { target: { value: 't' } });
-    fireEvent.change(screen.getByLabelText('Description'), {
+    fireEvent.change(screen.getByLabelText('Details'), {
       target: { value: 'content' },
     });
     fireEvent.click(screen.getByText('Create Post'));

--- a/ethos-frontend/tests/CreatePostReplyTypeRestrictions.test.tsx
+++ b/ethos-frontend/tests/CreatePostReplyTypeRestrictions.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import type { Post } from '../src/types/postTypes';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  addPost: jest.fn(() => Promise.resolve({ id: 'p1' })),
+}));
+
+jest.mock('../src/api/board', () => ({
+  __esModule: true,
+  updateBoard: jest.fn(),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: null, boards: {}, appendToBoard: jest.fn() }),
+}));
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+import CreatePost from '../src/components/post/CreatePost';
+
+describe('CreatePost reply type restrictions', () => {
+  it('only shows free speech when replying to free speech', () => {
+    const parent = { id: 'p1', type: 'free_speech', authorId: 'u1' } as Post;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={parent} />
+      </BrowserRouter>
+    );
+    const options = Array.from(screen.getByLabelText('Item Type').querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Free Speech']);
+  });
+
+  it('shows free speech and review when replying to a file', () => {
+    const parent = { id: 'f1', type: 'file', authorId: 'u1' } as Post;
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} replyTo={parent} />
+      </BrowserRouter>
+    );
+    const options = Array.from(screen.getByLabelText('Item Type').querySelectorAll('option')).map(o => o.textContent);
+    expect(options).toEqual(['Free Speech', 'Review']);
+  });
+});

--- a/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
+++ b/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
@@ -26,12 +26,6 @@ jest.mock('../src/contexts/AuthContext', () => ({
   __esModule: true,
   useAuth: () => mockUseAuth(),
 }));
-
-// Avoid LinkControls side effects
-jest.mock('../src/components/controls/LinkControls', () => ({
-  __esModule: true,
-  default: () => <div />,
-}));
 import CreatePost from '../src/components/post/CreatePost';
 import { addPost } from '../src/api/post';
 
@@ -43,7 +37,7 @@ describe('CreatePost request without task', () => {
         <CreatePost onCancel={() => {}} initialType="request" />
       </BrowserRouter>
     );
-    fireEvent.change(screen.getByLabelText('Task Title'), { target: { value: 'Need help' } });
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Need help' } });
     fireEvent.click(screen.getByText('Create Post'));
     await waitFor(() => expect(addPost).toHaveBeenCalled());
     expect(window.alert).not.toHaveBeenCalled();

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -41,6 +41,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Task', 'File']);
+    expect(options).toEqual(['Free Speech', 'Task']);
   });
 });


### PR DESCRIPTION
## Summary
- streamline CreatePost with universal title/details fields and remove task-specific controls
- update request and reply tests for the simplified form
- persist task nodeId and details in Postgres so task posts retain their summary tags after reload

## Testing
- `npm test --prefix ethos-backend`
- `npx jest tests/CreatePostReply.test.tsx --runInBand`
- `npx jest tests/CreatePostRequestNoTask.test.tsx --runInBand`
- `npx jest tests/CreatePostReplyTypeRestrictions.test.tsx --runInBand`
- `npx jest tests/TimelineBoardPostTypes.test.tsx --runInBand`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a011334f9c832fa4ac655d6a55f873