### PR TITLE
feat: omit default status tags on tasks

### DIFF
--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -205,9 +205,12 @@ export const buildSummaryTags = async (
     });
   }
 
-  // Status tag for task posts
+  // Status tag for task posts (exclude generic progress summaries)
   if (post.status && post.type === 'task') {
-    tags.push({ type: 'status', label: post.status, detailLink: ROUTES.POST(post.id) });
+    const lowerStatus = post.status.toLowerCase();
+    if (!['todo', 'to do', 'blocked', 'done'].includes(lowerStatus)) {
+      tags.push({ type: 'status', label: post.status, detailLink: ROUTES.POST(post.id) });
+    }
   }
 
   // Include non-system tags


### PR DESCRIPTION
## Summary
- omit rendering status tags for basic task statuses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b3324ed0832fa31faffc2545be18