### PR TITLE
Add backend and frontend tests for request flows

### DIFF
--- a/ethos-backend/tests/helpRequestRoutes.test.ts
+++ b/ethos-backend/tests/helpRequestRoutes.test.ts
@@ -1,0 +1,112 @@
+import request from 'supertest';
+import express from 'express';
+
+import postRoutes from '../src/routes/postRoutes';
+import type { DBPost } from '../src/types/db';
+import { postsStore, reactionsStore, questsStore } from '../src/models/stores';
+
+let mockUser = { id: 'u1', username: 'user1' } as any;
+jest.mock('../src/middleware/authMiddleware', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = mockUser;
+    next();
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/posts', postRoutes);
+
+beforeEach(() => {
+  postsStore.write([]);
+  reactionsStore.write([]);
+  questsStore.write([]);
+});
+
+describe('help request routes', () => {
+  it('creates a help request for a post', async () => {
+    const task: DBPost = {
+      id: 'p1',
+      authorId: 'u2',
+      type: 'task',
+      content: 'need help',
+      visibility: 'public',
+      createdAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+    } as DBPost;
+    postsStore.write([task]);
+
+    const res = await request(app).post('/posts/p1/request-help');
+    expect(res.status).toBe(201);
+    const posts = postsStore.read();
+    expect(posts).toHaveLength(2);
+    expect(posts[0].requestId).toBeDefined();
+    const requestPost = posts.find(p => p.id === posts[0].requestId);
+    expect(requestPost?.authorId).toBe('u1');
+    const reactions = reactionsStore.read();
+    expect(reactions).toContain('p1_u1_request');
+  });
+
+  it('accepts and declines a help request', async () => {
+    const reqPost: DBPost = {
+      id: 'r1',
+      authorId: 'u2',
+      type: 'request',
+      content: '',
+      visibility: 'public',
+      createdAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+      tags: ['request'],
+    } as DBPost;
+    postsStore.write([reqPost]);
+
+    let res = await request(app).post('/posts/r1/accept');
+    expect(res.status).toBe(200);
+    expect(postsStore.read()[0].tags).toContain('pending:u1');
+
+    res = await request(app).post('/posts/r1/unaccept');
+    expect(res.status).toBe(200);
+    expect(postsStore.read()[0].tags).not.toContain('pending:u1');
+  });
+
+  it('handles duplicate help requests for tasks', async () => {
+    const task: DBPost = {
+      id: 't1',
+      authorId: 'u2',
+      type: 'task',
+      content: 'task',
+      visibility: 'public',
+      createdAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+    } as DBPost;
+    postsStore.write([task]);
+
+    await request(app).post('/posts/tasks/t1/request-help');
+    await request(app).post('/posts/tasks/t1/request-help');
+
+    const posts = postsStore.read();
+    expect(posts).toHaveLength(1);
+    expect(posts[0].tags).toContain('request');
+    const reactions = reactionsStore.read();
+    expect(reactions).toHaveLength(1);
+  });
+
+  it('prevents non-creator from deleting a request', async () => {
+    const original: DBPost = {
+      id: 'p1',
+      authorId: 'u2',
+      type: 'task',
+      content: 'task',
+      visibility: 'public',
+      createdAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+    } as DBPost;
+    postsStore.write([original]);
+    await request(app).post('/posts/p1/request-help');
+
+    mockUser = { id: 'u2', username: 'user2' } as any;
+    const res = await request(app).delete('/posts/p1/request-help');
+    expect(res.status).toBe(404);
+  });
+});
+

--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -34,6 +34,9 @@ export default {
     '<rootDir>/tests/TimelineBoardPostTypes.test.tsx'
     ,'<rootDir>/src/components/controls/ReactionControls.permission.test.tsx'
     ,'<rootDir>/src/components/ui/SummaryTag.theme.test.tsx'
+    ,'<rootDir>/tests/AcceptRequestButton.test.tsx'
+    ,'<rootDir>/tests/NotificationsPage.test.tsx'
+    ,'<rootDir>/tests/PostCardCTA.test.tsx'
   ],
   globals: {
     'ts-jest': {

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import PostCard from '../src/components/post/PostCard';
+import RequestCard from '../src/components/request/RequestCard';
+import type { EnrichedPost } from '../src/types/postTypes';
 
 jest.mock('../src/api/post', () => ({
   __esModule: true,
@@ -38,6 +39,11 @@ jest.mock('../src/contexts/BoardContext', () => ({
   }),
 }));
 
+jest.mock('../src/contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return {
@@ -49,7 +55,7 @@ jest.mock('react-router-dom', () => {
 
 import { acceptRequest, unacceptRequest } from '../src/api/post';
 
-describe.skip('accept request button', () => {
+describe('request card join button', () => {
   const post = {
     id: 'p1',
     authorId: 'u2',
@@ -60,36 +66,38 @@ describe.skip('accept request button', () => {
     tags: ['request'],
     collaborators: [],
     linkedItems: [],
-  } as Post;
+  } as EnrichedPost;
 
   it('shows accept button for request posts', () => {
     render(
       <BrowserRouter>
-        <PostCard post={post} user={{ id: 'u1' }} />
+        <RequestCard post={post} />
       </BrowserRouter>
     );
-    expect(screen.getByText('Accept')).toBeInTheDocument();
+    expect(screen.getByText('Request Join')).toBeInTheDocument();
   });
 
-  it('calls API when clicked', () => {
+  it('calls API when clicked', async () => {
     render(
       <BrowserRouter>
-        <PostCard post={post} user={{ id: 'u1' }} />
+        <RequestCard post={post} />
       </BrowserRouter>
     );
-    fireEvent.click(screen.getByText('Accept'));
+    const btn = await screen.findByText('Request Join');
+    fireEvent.click(btn);
     expect(acceptRequest).toHaveBeenCalledWith('p1');
   });
 
-  it('toggles pending state on second click', () => {
+  it('toggles pending state on second click', async () => {
     render(
       <BrowserRouter>
-        <PostCard post={post} user={{ id: 'u1' }} />
+        <RequestCard post={post} />
       </BrowserRouter>
     );
-    const btn = screen.getByText('Accept');
+    const btn = await screen.findByText('Request Join');
     fireEvent.click(btn);
-    fireEvent.click(btn);
+    const joined = await screen.findByText(/Joined/);
+    fireEvent.click(joined);
     expect(unacceptRequest).toHaveBeenCalledWith('p1');
   });
 });

--- a/ethos-frontend/tests/NotificationsPage.test.tsx
+++ b/ethos-frontend/tests/NotificationsPage.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import NotificationsPage from '../src/pages/Notifications';
+
+const mockMarkRead = jest.fn();
+jest.mock('../src/contexts/NotificationContext', () => ({
+  __esModule: true,
+  useNotifications: () => ({
+    notifications: [
+      { id: 'n1', message: 'Join request', link: '/posts/p1', read: false },
+    ],
+    markRead: mockMarkRead,
+  }),
+}));
+
+describe('NotificationsPage', () => {
+  it('shows mark read CTA and handles action', () => {
+    render(
+      <BrowserRouter>
+        <NotificationsPage />
+      </BrowserRouter>
+    );
+    const btn = screen.getByText('Mark read');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(mockMarkRead).toHaveBeenCalledWith('n1');
+    expect(screen.getByText('View').getAttribute('href')).toBe('/posts/p1');
+  });
+});

--- a/ethos-frontend/tests/PostCardCTA.test.tsx
+++ b/ethos-frontend/tests/PostCardCTA.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from '../src/components/post/PostCard';
+import type { Post } from '../src/types/postTypes';
+import type { User } from '../src/types/userTypes';
+import { removeHelpRequest } from '../src/api/post';
+
+jest.mock('../src/api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+jest.mock('../src/api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn(id => Promise.resolve({ id, username: 'alice' })),
+}));
+
+jest.mock('../src/contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: 'quest-board' }),
+}));
+
+jest.mock('../src/hooks/useGraph', () => ({
+  __esModule: true,
+  useGraph: () => ({ loadGraph: jest.fn() }),
+}));
+
+describe('PostCard request CTA', () => {
+  const post: Post = {
+    id: 'p1',
+    authorId: 'u1',
+    type: 'task',
+    content: 'Task',
+    visibility: 'public',
+    timestamp: '',
+    tags: ['request'],
+    collaborators: [],
+    linkedItems: [],
+  } as unknown as Post;
+
+  it('shows request tag and allows cancel', async () => {
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' } as User} />
+      </BrowserRouter>
+    );
+    const tag = await screen.findByText('Request');
+    fireEvent.click(tag);
+    expect(removeHelpRequest).toHaveBeenCalledWith('p1', 'task');
+  });
+});


### PR DESCRIPTION
## Summary
- cover help request lifecycle in backend tests
- add request join, notification, and PostCard CTA tests
- wire new tests into frontend Jest config

## Testing
- `cd ethos-backend && npm test`
- `cd ethos-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c61f5bc0832fad8e70cf60c5e93f