### PR TITLE
Handle join request notifications

### DIFF
--- a/ethos-frontend/src/api/post.ts
+++ b/ethos-frontend/src/api/post.ts
@@ -321,3 +321,29 @@ export const unfollowPost = async (id: string): Promise<{ followers: string[] }>
   const res = await axiosWithAuth.post(`${BASE_URL}/${id}/unfollow`);
   return res.data;
 };
+
+/**
+ * ✅ Approve a pending join request for a task/post
+ */
+export const approveJoinRequest = async (
+  taskId: string,
+  joinRequestId: string,
+): Promise<{ collaborators: string[] }> => {
+  const res = await axiosWithAuth.post(
+    `${BASE_URL}/${taskId}/join-requests/${joinRequestId}/approve`,
+  );
+  return res.data;
+};
+
+/**
+ * ❌ Decline a pending join request for a task/post
+ */
+export const declineJoinRequest = async (
+  taskId: string,
+  joinRequestId: string,
+): Promise<{ success: boolean }> => {
+  const res = await axiosWithAuth.post(
+    `${BASE_URL}/${taskId}/join-requests/${joinRequestId}/decline`,
+  );
+  return res.data;
+};

--- a/ethos-frontend/src/pages/Notifications.tsx
+++ b/ethos-frontend/src/pages/Notifications.tsx
@@ -1,32 +1,78 @@
 import React from 'react';
-import { useNotifications } from '../contexts/NotificationContext';
 import { Link } from 'react-router-dom';
+import { useNotifications } from '../contexts/NotificationContext';
+import { approveJoinRequest, declineJoinRequest } from '../api/post';
+import type { Notification } from '../types/notificationTypes';
 
 const NotificationsPage: React.FC = () => {
   const { notifications, markRead } = useNotifications();
+
+  const handleApprove = async (n: Notification) => {
+    if (!n.joinRequestId || !n.taskId) return;
+    try {
+      await approveJoinRequest(n.taskId, n.joinRequestId);
+      // Optimistically update collaborator count & thread badge
+      window.dispatchEvent(
+        new CustomEvent('join-request-approved', { detail: { taskId: n.taskId } })
+      );
+      await markRead(n.id);
+    } catch (err) {
+      console.error('[Notifications] Failed to approve join request', err);
+    }
+  };
+
+  const handleDecline = async (n: Notification) => {
+    if (!n.joinRequestId || !n.taskId) return;
+    try {
+      await declineJoinRequest(n.taskId, n.joinRequestId);
+      await markRead(n.id);
+    } catch (err) {
+      console.error('[Notifications] Failed to decline join request', err);
+    }
+  };
 
   return (
     <div className="p-4 max-w-3xl mx-auto">
       <h1 className="text-xl font-bold mb-4">Notifications</h1>
       {notifications.length === 0 && <p>No notifications.</p>}
       <ul className="space-y-4">
-        {notifications.map(n => (
-          <li key={n.id} className="border p-3 rounded flex justify-between items-start">
-            <div>
-              <p className={n.read ? 'text-secondary' : 'font-semibold'}>{n.message}</p>
-              {n.link && (
-                <Link to={n.link} className="text-blue-600 underline text-sm" onClick={() => markRead(n.id)}>
-                  View
-                </Link>
+        {notifications.map(n => {
+          const isJoinRequest = !!n.joinRequestId && !!n.taskId;
+          return (
+            <li key={n.id} className="border p-3 rounded flex justify-between items-start">
+              <div>
+                <p className={n.read ? 'text-secondary' : 'font-semibold'}>{n.message}</p>
+                {n.link && (
+                  <Link to={n.link} className="text-blue-600 underline text-sm" onClick={() => markRead(n.id)}>
+                    View
+                  </Link>
+                )}
+              </div>
+              {isJoinRequest ? (
+                <div className="flex gap-2">
+                  <button
+                    className="text-sm text-green-600"
+                    onClick={() => handleApprove(n)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="text-sm text-red-600"
+                    onClick={() => handleDecline(n)}
+                  >
+                    Decline
+                  </button>
+                </div>
+              ) : (
+                !n.read && (
+                  <button className="text-sm" onClick={() => markRead(n.id)}>
+                    Mark read
+                  </button>
+                )
               )}
-            </div>
-            {!n.read && (
-              <button className="text-sm" onClick={() => markRead(n.id)}>
-                Mark read
-              </button>
-            )}
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/ethos-frontend/src/types/notificationTypes.ts
+++ b/ethos-frontend/src/types/notificationTypes.ts
@@ -5,4 +5,8 @@ export interface Notification {
   link?: string;
   read?: boolean;
   createdAt: string;
+  /** Optional join request identifier if this notification is about a request to join */
+  joinRequestId?: string;
+  /** Task or post identifier related to the join request */
+  taskId?: string;
 }


### PR DESCRIPTION
## Summary
- support joinRequestId and taskId fields on notifications
- show approve/decline actions for join requests and mark notifications read
- expose API helpers to approve or decline join requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c61ea030832fb3a66f0f41dfced0