### PR TITLE
feat: render join request events in reply thread

### DIFF
--- a/ethos-frontend/src/components/post/ReplyThread.joinRequest.test.tsx
+++ b/ethos-frontend/src/components/post/ReplyThread.joinRequest.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ReplyThread from './ReplyThread';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+
+const mockReplies: Post[] = [
+  {
+    id: 'r1',
+    authorId: 'u2',
+    author: { id: 'u2', username: 'alice' },
+    type: 'free_speech',
+    content: '',
+    visibility: 'public',
+    timestamp: '',
+    tags: [],
+    collaborators: [],
+    linkedItems: [],
+    system_event: 'join_request',
+    status: 'Pending',
+  } as unknown as Post,
+];
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve(mockReplies)),
+}));
+
+const listeners: Record<string, Function> = {};
+const socket = {
+  emit: jest.fn(),
+  on: jest.fn((event: string, handler: Function) => {
+    listeners[event] = handler;
+  }),
+  off: jest.fn((event: string) => {
+    delete listeners[event];
+  }),
+};
+
+jest.mock('../../hooks/useSocket', () => ({
+  __esModule: true,
+  useSocket: () => ({ socket }),
+}));
+
+describe('ReplyThread join request events', () => {
+  it('renders join request and updates on socket events', async () => {
+    render(
+      <BrowserRouter>
+        <ReplyThread postId="p1" user={{ id: 'u1' } as User} />
+      </BrowserRouter>,
+    );
+
+    expect(
+      await screen.findByText('@alice requested to join this task • Pending'),
+    ).toBeInTheDocument();
+
+    act(() => {
+      listeners['join_request:update']?.({ postId: 'r1', status: 'Approved' });
+    });
+
+    expect(
+      await screen.findByText('@alice requested to join this task • Approved'),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/ethos-frontend/src/components/post/ReplyThread.tsx
+++ b/ethos-frontend/src/components/post/ReplyThread.tsx
@@ -4,6 +4,7 @@ import { fetchRepliesByPostId } from '../../api/post';
 import { Spinner } from '../ui';
 import type { Post } from '../../types/postTypes';
 import type { User } from '../../types/userTypes';
+import { useSocket } from '../../hooks/useSocket';
 
 interface ReplyThreadProps {
   postId: string;
@@ -13,6 +14,7 @@ interface ReplyThreadProps {
 const ReplyThread: React.FC<ReplyThreadProps> = ({ postId, user }) => {
   const [replies, setReplies] = useState<Post[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const { socket } = useSocket();
 
   useEffect(() => {
     fetchRepliesByPostId(postId)
@@ -20,14 +22,40 @@ const ReplyThread: React.FC<ReplyThreadProps> = ({ postId, user }) => {
       .finally(() => setLoaded(true));
   }, [postId]);
 
+  useEffect(() => {
+    if (!socket) return;
+    const room = `post-${postId}`;
+    const handleJoinRequestUpdate = (payload: { postId: string; status: string }) => {
+      setReplies(prev =>
+        prev.map(r => (r.id === payload.postId ? { ...r, status: payload.status } : r))
+      );
+    };
+    socket.emit('join', { room });
+    socket.on('join_request:update', handleJoinRequestUpdate);
+    return () => {
+      socket.emit('leave', { room });
+      socket.off('join_request:update', handleJoinRequestUpdate);
+    };
+  }, [socket, postId]);
+
   if (!loaded) return <Spinner />;
   if (replies.length === 0) return null;
 
   return (
     <div className="mt-2 space-y-2 border-l-2 border-blue-200 pl-4">
-      {replies.map((r) => (
-        <PostCard key={r.id} post={r} user={user} compact />
-      ))}
+      {replies.map(r => {
+        const eventType = (r as any).system_event;
+        if (eventType === 'join_request') {
+          const status = ((r as any).status || 'Pending') as string;
+          const username = r.author?.username || 'unknown';
+          return (
+            <div key={r.id} className="text-sm text-secondary italic">
+              @{username} requested to join this task • {status}
+            </div>
+          );
+        }
+        return <PostCard key={r.id} post={r} user={user} compact />;
+      })}
     </div>
   );
 };

--- a/ethos-frontend/src/hooks/useSocket.ts
+++ b/ethos-frontend/src/hooks/useSocket.ts
@@ -11,6 +11,9 @@ interface SocketEvents {
   'auth:reset-page-visited': (payload: { token: string }) => void;
   'auth:password-reset-success': (payload: { userId: string }) => void;
   'navigation:404': (payload: { userId: string | null }) => void;
+  'join_request:update': (
+    payload: { postId: string; status: 'Pending' | 'Approved' | 'Declined' }
+  ) => void;
 }
 
 // ---------------------------


### PR DESCRIPTION
## Summary
- show join request system events inside reply threads
- listen for `join_request:update` socket events to keep status current
- cover join request behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c61d45e0832f8eb356473bf0d120