### PR TITLE
feat: add request and review post types

### DIFF
--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -188,7 +188,9 @@ export type QuestTaskStatus = 'To Do' | 'In Progress' | 'Blocked' | 'Done' | str
 export type PostType =
   | 'free_speech'
   | 'task'
-  | 'file';
+  | 'file'
+  | 'request'
+  | 'review';
   
 /**
  * Supported tags for labeling and filtering posts.


### PR DESCRIPTION
## Summary
- extend `PostType` with `request` and `review`
- add join/request and review actions to `PostCard`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c61b2bb8832f8f732116bd64b655