### PR TITLE
feat: add request and review post types

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -11,7 +11,7 @@ import type { User } from '../../types/userTypes';
 import { updatePost, removeHelpRequest } from '../../api/post';
 import { fetchQuestById } from '../../api/quest';
 import ReactionControls from '../controls/ReactionControls';
-import { SummaryTag } from '../ui';
+import { SummaryTag, Button } from '../ui';
 import { useBoardContext } from '../../contexts/BoardContext';
 import MarkdownRenderer from '../ui/MarkdownRenderer';
 import MediaPreview from '../ui/MediaPreview';
@@ -136,14 +136,29 @@ const PostCard: React.FC<PostCardProps> = ({
   );
 
   const qid = questId || post.questId;
+  const isAuthor = user?.id === post.authorId;
+  const defaultJoinState = post.collaborators?.some(c => c.userId === user?.id)
+    ? 'MEMBER'
+    : post.collaborators?.some(c => c.pending?.includes(user?.id || ''))
+      ? 'PENDING'
+      : 'NONE';
+  const [joinState, setJoinState] = useState<'NONE' | 'PENDING' | 'MEMBER'>(defaultJoinState);
+
+  const handleRequestJoin = () => {
+    navigate(ROUTES.POST(post.id) + '?reply=1&intro=1');
+    setJoinState('PENDING');
+  };
+
+  const handleSendReview = () => {
+    navigate(ROUTES.POST(post.id) + '?reply=1&initialType=review');
+  };
 
   useEffect(() => {
     if (expandedView && qid) {
       loadGraph(qid);
     }
   }, [expandedView, qid, loadGraph]);
-
-  const canEdit = user?.id === post.authorId || post.collaborators?.some(c => c.userId === user?.id);
+  const canEdit = isAuthor || post.collaborators?.some(c => c.userId === user?.id);
   const ts = post.timestamp || post.createdAt;
   const timestamp = ts
     ? formatDistanceToNow(new Date(ts), { addSuffix: true })
@@ -269,6 +284,51 @@ const PostCard: React.FC<PostCardProps> = ({
     );
   };
 
+  const renderControls = () => {
+    if (post.type === 'request' && isAuthor) {
+      return (
+        <div className="text-sm text-secondary">
+          Collaborators: {post.collaborators?.length || 0}
+        </div>
+      );
+    }
+
+    return (
+      <>
+        {post.type === 'request' && !isAuthor && (
+          <Button
+            variant="contrast"
+            className="mb-2"
+            onClick={handleRequestJoin}
+            disabled={joinState !== 'NONE'}
+            title={joinState !== 'NONE' ? 'Request pending approval' : undefined}
+          >
+            {joinState === 'PENDING' ? 'Pending' : 'Request to Join'}
+          </Button>
+        )}
+        {post.type === 'review' && !isAuthor && (
+          <Button
+            variant="contrast"
+            className="mb-2"
+            onClick={handleSendReview}
+          >
+            Send Review
+          </Button>
+        )}
+        <ReactionControls
+          post={post}
+          user={user}
+          onUpdate={onUpdate}
+          replyOverride={replyOverride}
+          boardId={ctxBoardId || undefined}
+          timestamp={!isQuestBoardRequest ? timestamp : undefined}
+          expanded={expandedView}
+          hideReply={hideReplyButton}
+        />
+      </>
+    );
+  };
+
 
   if (editMode) {
     return (
@@ -300,16 +360,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {titleText}
           </h3>
         )}
-        <ReactionControls
-          post={post}
-          user={user}
-          onUpdate={onUpdate}
-          timestamp={!isQuestBoardRequest ? timestamp : undefined}
-          replyOverride={replyOverride}
-          boardId={ctxBoardId || undefined}
-          expanded={expandedView}
-          hideReply={hideReplyButton}
-        />
+        {renderControls()}
       </div>
     );
   }
@@ -381,16 +432,7 @@ const PostCard: React.FC<PostCardProps> = ({
         )}
       </div>
 
-      <ReactionControls
-        post={post}
-        user={user}
-        onUpdate={onUpdate}
-        replyOverride={replyOverride}
-        boardId={ctxBoardId || undefined}
-        timestamp={!isQuestBoardRequest ? timestamp : undefined}
-        expanded={expandedView}
-        hideReply={hideReplyButton}
-      />
+      {renderControls()}
     </div>
   );
 };

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -188,7 +188,9 @@ export type QuestTaskStatus = 'To Do' | 'In Progress' | 'Blocked' | 'Done' | str
 export type PostType =
   | 'free_speech'
   | 'task'
-  | 'file';
+  | 'file'
+  | 'request'
+  | 'review';
   
 /**
  * Supported tags for labeling and filtering posts.


### PR DESCRIPTION
## Summary
- extend `PostType` with `request` and `review`
- add join/request and review actions to `PostCard`
- rename join state helper to avoid duplicate identifier

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c61b2bb8832f8f732116bd64b655