### PR TITLE
feat: add join request API and types

### DIFF
--- a/ethos-frontend/src/api/joinRequest.ts
+++ b/ethos-frontend/src/api/joinRequest.ts
@@ -1,0 +1,23 @@
+import { axiosWithAuth } from '../utils/authUtils';
+import type { JoinRequest } from '../types/joinRequestTypes';
+
+const BASE_URL = '/join-requests';
+
+export const createJoinRequest = async (
+  taskId: string,
+  requestPostId?: string,
+): Promise<JoinRequest> => {
+  const res = await axiosWithAuth.post(BASE_URL, { taskId, requestPostId });
+  return res.data;
+};
+
+export const approveJoinRequest = async (id: string): Promise<JoinRequest> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}/approve`);
+  return res.data;
+};
+
+export const declineJoinRequest = async (id: string): Promise<JoinRequest> => {
+  const res = await axiosWithAuth.patch(`${BASE_URL}/${id}/decline`);
+  return res.data;
+};
+

--- a/ethos-frontend/src/types/api.ts
+++ b/ethos-frontend/src/types/api.ts
@@ -12,6 +12,7 @@ export * from './gitTypes';
 export * from './reviewTypes';
 export * from './common';
 export * from './reviewTypes';
+export * from './joinRequestTypes';
 
 export type UUID = string;
 export type Timestamp = string;

--- a/ethos-frontend/src/types/joinRequestTypes.ts
+++ b/ethos-frontend/src/types/joinRequestTypes.ts
@@ -1,0 +1,13 @@
+export type JoinRequestStatus = 'pending' | 'approved' | 'declined';
+
+export interface JoinRequest {
+  id: string;
+  taskId: string;
+  requesterId: string;
+  status: JoinRequestStatus;
+  requestPostId?: string;
+  approverId?: string;
+  createdAt: string;
+  approvedAt?: string;
+}
+


### PR DESCRIPTION
## Summary
- add JoinRequest types and status definition
- expose new join request API helpers
- re-export join request types from central types module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c619fd84832f8da95f8b95ebc9db