### PR TITLE
feat: broadcast join request socket events

### DIFF
--- a/ethos-backend/src/routes/joinRequestRoutes.ts
+++ b/ethos-backend/src/routes/joinRequestRoutes.ts
@@ -1,7 +1,8 @@
-import express, { Request, Response } from 'express';
+import express, { Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { io } from '../server';
+import type { AuthenticatedRequest } from '../types/express';
 
 interface JoinRequest {
   id: string;
@@ -16,7 +17,7 @@ const joinRequests: JoinRequest[] = [];
 const router = express.Router();
 
 // Create a new join request
-router.post('/', authMiddleware, (req: Request, res: Response): void => {
+router.post('/', authMiddleware, (req: AuthenticatedRequest, res: Response): void => {
   const { taskId, ownerId } = req.body as { taskId?: string; ownerId?: string };
   const requesterId = req.user?.id;
 
@@ -45,7 +46,7 @@ router.post('/', authMiddleware, (req: Request, res: Response): void => {
 });
 
 // Approve or decline a join request
-router.patch('/:id', authMiddleware, (req: Request, res: Response): void => {
+router.patch('/:id', authMiddleware, (req: AuthenticatedRequest<{ id: string }>, res: Response): void => {
   const { id } = req.params;
   const { status } = req.body as { status?: 'approved' | 'declined' };
 

--- a/ethos-backend/src/routes/joinRequestRoutes.ts
+++ b/ethos-backend/src/routes/joinRequestRoutes.ts
@@ -1,0 +1,74 @@
+import express, { Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { io } from '../server';
+
+interface JoinRequest {
+  id: string;
+  taskId: string;
+  ownerId: string;
+  requesterId: string;
+  status: 'pending' | 'approved' | 'declined';
+}
+
+const joinRequests: JoinRequest[] = [];
+
+const router = express.Router();
+
+// Create a new join request
+router.post('/', authMiddleware, (req: Request, res: Response): void => {
+  const { taskId, ownerId } = req.body as { taskId?: string; ownerId?: string };
+  const requesterId = req.user?.id;
+
+  if (!taskId || !ownerId || !requesterId) {
+    res.status(400).json({ error: 'Missing required fields' });
+    return;
+  }
+
+  const joinRequest: JoinRequest = {
+    id: uuidv4(),
+    taskId,
+    ownerId,
+    requesterId,
+    status: 'pending',
+  };
+  joinRequests.push(joinRequest);
+
+  // Notify relevant rooms of the new join request
+  [
+    `task:${taskId}`,
+    `user:${ownerId}`,
+    `user:${requesterId}`,
+  ].forEach((room) => io.to(room).emit('join_request:created', joinRequest));
+
+  res.status(201).json(joinRequest);
+});
+
+// Approve or decline a join request
+router.patch('/:id', authMiddleware, (req: Request, res: Response): void => {
+  const { id } = req.params;
+  const { status } = req.body as { status?: 'approved' | 'declined' };
+
+  const jr = joinRequests.find((r) => r.id === id);
+  if (!jr) {
+    res.status(404).json({ error: 'Join request not found' });
+    return;
+  }
+  if (status !== 'approved' && status !== 'declined') {
+    res.status(400).json({ error: 'Invalid status' });
+    return;
+  }
+
+  jr.status = status;
+
+  // Notify relevant rooms of the update
+  [
+    `task:${jr.taskId}`,
+    `user:${jr.ownerId}`,
+    `user:${jr.requesterId}`,
+  ].forEach((room) => io.to(room).emit('join_request:updated', jr));
+
+  res.json(jr);
+});
+
+export default router;

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -19,6 +19,7 @@ import boardRoutes from './routes/boardRoutes';
 import reviewRoutes from './routes/reviewRoutes';
 import userRoutes from './routes/userRoutes';
 import notificationRoutes from './routes/notificationRoutes';
+import joinRequestRoutes from './routes/joinRequestRoutes';
 import healthRoutes from './routes/healthRoutes';
 import { initializeDatabase } from './db';
 
@@ -117,6 +118,7 @@ app.use('/api/boards', boardRoutes);  // 🧭 Boards and view layouts
 app.use('/api/reviews', reviewRoutes); // ⭐ Reviews
 app.use('/api/users', userRoutes);    // 👥 Public user profiles
 app.use('/api/notifications', notificationRoutes); // 🔔 User notifications
+app.use('/api/join-requests', joinRequestRoutes); // 🤝 Join requests
 app.use('/api/health', healthRoutes); // ❤️ Health check
 
 // Generic error handler to prevent leaking stack traces in production
@@ -150,7 +152,7 @@ const PORT: number = parseInt(process.env.PORT || '4173', 10);
  * Create HTTP and Socket.IO servers and start listening.
  */
 const httpServer = createServer(app);
-const io = new SocketIOServer(httpServer, {
+export const io = new SocketIOServer(httpServer, {
   cors: {
     origin: ALLOWED_ORIGINS,
     credentials: true,


### PR DESCRIPTION
## Summary
- export socket.io instance and add join request routes
- notify task and user rooms when join requests are created or updated

## Testing
- `cd ethos-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c6127960832f8e71c6fa210a831e