### PR TITLE
Add notification for task join requests

### DIFF
--- a/ethos-backend/src/routes/postRoutes.ts
+++ b/ethos-backend/src/routes/postRoutes.ts
@@ -1160,11 +1160,14 @@ router.post(
 
       const follower = users.find(u => u.id === req.user!.id);
       if (follower && post.authorId !== follower.id) {
+        const taskTitle = post.title || makeQuestNodeTitle(post.content);
+        const joinRequestId = created.id;
         const newNote = {
           id: uuidv4(),
           userId: post.authorId,
-          message: `${follower.username} requested to join your post`,
-          link: `/posts/${post.id}`,
+          message: `${follower.username} would like to join ${taskTitle}.`,
+          link: `/boards/thread/${post.id}?joinRequestId=${joinRequestId}`,
+          joinRequestId,
           read: false,
           createdAt: new Date().toISOString(),
         };

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -282,6 +282,8 @@ export interface DBNotification {
   userId: string;
   message: string;
   link?: string;
+  /** Optional join request ID for later approve/decline actions */
+  joinRequestId?: string;
   read?: boolean;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Notify task owners when someone requests to join
- Track joinRequestId in notification schema for future approval actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c6119f7c832fa73c4990e01ca9be