### PR TITLE
feat: add join request routes

### DIFF
--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -152,6 +152,14 @@ async function initializeDatabase(): Promise<void> {
       id TEXT PRIMARY KEY,
       data JSONB
     );
+    CREATE TABLE IF NOT EXISTS join_requests (
+      id UUID PRIMARY KEY,
+      task_id TEXT,
+      user_id TEXT,
+      status TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      UNIQUE(task_id, user_id)
+    );
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS tags TEXT[];
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS visibility TEXT;
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS boardid TEXT;

--- a/ethos-backend/src/models/memoryStores.ts
+++ b/ethos-backend/src/models/memoryStores.ts
@@ -21,3 +21,4 @@ export const reactionsStore = createMemoryStore<DBSchema['reactions']>([]);
 export const reviewsStore = createMemoryStore<DBSchema['reviews']>([]);
 export const boardLogsStore = createMemoryStore<DBSchema['boardLogs']>([]);
 export const notificationsStore = createMemoryStore<DBSchema['notifications']>([]);
+export const joinRequestsStore = createMemoryStore<DBSchema['joinRequests']>([]);

--- a/ethos-backend/src/routes/joinRequestRoutes.ts
+++ b/ethos-backend/src/routes/joinRequestRoutes.ts
@@ -1,0 +1,212 @@
+import express, { Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { authMiddleware } from '../middleware/authMiddleware';
+import type { AuthenticatedRequest } from '../types/express';
+import { postsStore, joinRequestsStore } from '../models/stores';
+import { pool, usePg } from '../db';
+import type { DBJoinRequest } from '../types/db';
+
+const router = express.Router();
+
+router.post(
+  '/tasks/:taskId/join-requests',
+  authMiddleware,
+  async (
+    req: AuthenticatedRequest<{ taskId: string }>,
+    res: Response
+  ): Promise<void> => {
+    const taskId = req.params.taskId;
+    const userId = req.user!.id;
+    try {
+      if (usePg) {
+        const { rows: taskRows } = await pool.query(
+          'SELECT id, authorid FROM posts WHERE id = $1',
+          [taskId]
+        );
+        if (taskRows.length === 0) {
+          res.status(404).json({ error: 'Task not found' });
+          return;
+        }
+        if (taskRows[0].authorid === userId) {
+          res.status(400).json({ error: 'Cannot request to join own task' });
+          return;
+        }
+        const { rows: existing } = await pool.query(
+          'SELECT id FROM join_requests WHERE task_id = $1 AND user_id = $2',
+          [taskId, userId]
+        );
+        if (existing.length > 0) {
+          res.status(400).json({ error: 'Join request already exists' });
+          return;
+        }
+        const id = uuidv4();
+        await pool.query(
+          'INSERT INTO join_requests (id, task_id, user_id, status) VALUES ($1,$2,$3,$4)',
+          [id, taskId, userId, 'pending']
+        );
+        res.json({ id, taskId, userId, status: 'pending' });
+        return;
+      }
+
+      const posts = postsStore.read();
+      const task = posts.find(p => p.id === taskId && p.type === 'task');
+      if (!task) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+      if (task.authorId === userId) {
+        res.status(400).json({ error: 'Cannot request to join own task' });
+        return;
+      }
+      const joinRequests = joinRequestsStore.read();
+      if (joinRequests.some(j => j.taskId === taskId && j.userId === userId)) {
+        res.status(400).json({ error: 'Join request already exists' });
+        return;
+      }
+      const newReq: DBJoinRequest = {
+        id: uuidv4(),
+        taskId,
+        userId,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+      };
+      joinRequestsStore.write([...joinRequests, newReq]);
+      res.json(newReq);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
+    }
+  }
+);
+
+router.post(
+  '/join-requests/:id/approve',
+  authMiddleware,
+  async (
+    req: AuthenticatedRequest<{ id: string }>,
+    res: Response
+  ): Promise<void> => {
+    const id = req.params.id;
+    const userId = req.user!.id;
+    try {
+      if (usePg) {
+        const { rows } = await pool.query(
+          'SELECT * FROM join_requests WHERE id = $1',
+          [id]
+        );
+        if (rows.length === 0) {
+          res.status(404).json({ error: 'Join request not found' });
+          return;
+        }
+        const jr = rows[0];
+        const { rows: taskRows } = await pool.query(
+          'SELECT authorid FROM posts WHERE id = $1',
+          [jr.task_id]
+        );
+        if (taskRows.length === 0) {
+          res.status(404).json({ error: 'Task not found' });
+          return;
+        }
+        if (taskRows[0].authorid !== userId) {
+          res.status(403).json({ error: 'Not task owner' });
+          return;
+        }
+        await pool.query(
+          'UPDATE join_requests SET status = $1 WHERE id = $2',
+          ['approved', id]
+        );
+        res.json({ id, taskId: jr.task_id, userId: jr.user_id, status: 'approved' });
+        return;
+      }
+
+      const joinRequests = joinRequestsStore.read();
+      const jr = joinRequests.find(j => j.id === id);
+      if (!jr) {
+        res.status(404).json({ error: 'Join request not found' });
+        return;
+      }
+      const task = postsStore.read().find(p => p.id === jr.taskId);
+      if (!task) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+      if (task.authorId !== userId) {
+        res.status(403).json({ error: 'Not task owner' });
+        return;
+      }
+      jr.status = 'approved';
+      joinRequestsStore.write([...joinRequests]);
+      res.json(jr);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
+    }
+  }
+);
+
+router.post(
+  '/join-requests/:id/decline',
+  authMiddleware,
+  async (
+    req: AuthenticatedRequest<{ id: string }>,
+    res: Response
+  ): Promise<void> => {
+    const id = req.params.id;
+    const userId = req.user!.id;
+    try {
+      if (usePg) {
+        const { rows } = await pool.query(
+          'SELECT * FROM join_requests WHERE id = $1',
+          [id]
+        );
+        if (rows.length === 0) {
+          res.status(404).json({ error: 'Join request not found' });
+          return;
+        }
+        const jr = rows[0];
+        const { rows: taskRows } = await pool.query(
+          'SELECT authorid FROM posts WHERE id = $1',
+          [jr.task_id]
+        );
+        if (taskRows.length === 0) {
+          res.status(404).json({ error: 'Task not found' });
+          return;
+        }
+        if (taskRows[0].authorid !== userId) {
+          res.status(403).json({ error: 'Not task owner' });
+          return;
+        }
+        await pool.query(
+          'UPDATE join_requests SET status = $1 WHERE id = $2',
+          ['declined', id]
+        );
+        res.json({ id, taskId: jr.task_id, userId: jr.user_id, status: 'declined' });
+        return;
+      }
+
+      const joinRequests = joinRequestsStore.read();
+      const jr = joinRequests.find(j => j.id === id);
+      if (!jr) {
+        res.status(404).json({ error: 'Join request not found' });
+        return;
+      }
+      const task = postsStore.read().find(p => p.id === jr.taskId);
+      if (!task) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+      if (task.authorId !== userId) {
+        res.status(403).json({ error: 'Not task owner' });
+        return;
+      }
+      jr.status = 'declined';
+      joinRequestsStore.write([...joinRequests]);
+      res.json(jr);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Database error' });
+    }
+  }
+);
+
+export default router;

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -20,6 +20,7 @@ import reviewRoutes from './routes/reviewRoutes';
 import userRoutes from './routes/userRoutes';
 import notificationRoutes from './routes/notificationRoutes';
 import healthRoutes from './routes/healthRoutes';
+import joinRequestRoutes from './routes/joinRequestRoutes';
 import { initializeDatabase } from './db';
 
 // Load environment variables from `.env` file
@@ -118,6 +119,7 @@ app.use('/api/reviews', reviewRoutes); // ⭐ Reviews
 app.use('/api/users', userRoutes);    // 👥 Public user profiles
 app.use('/api/notifications', notificationRoutes); // 🔔 User notifications
 app.use('/api/health', healthRoutes); // ❤️ Health check
+app.use('/api', joinRequestRoutes);
 
 // Generic error handler to prevent leaking stack traces in production
 app.use(

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -286,6 +286,14 @@ export interface DBNotification {
   createdAt: string;
 }
 
+export interface DBJoinRequest {
+  id: string;
+  taskId: string;
+  userId: string;
+  status: 'pending' | 'approved' | 'declined';
+  createdAt: string;
+}
+
 export interface DBBoardLog {
   id: string;
   boardId: string;
@@ -309,6 +317,7 @@ export interface DBSchema {
   reviews: DBReview[];
   boardLogs: DBBoardLog[];
   notifications: DBNotification[];
+  joinRequests: DBJoinRequest[];
 }
 
 // Optional utility type for referencing a single entry type by file


### PR DESCRIPTION
## Summary
- add join request endpoints for creating, approving and declining requests
- ensure join requests validate task ownership and avoid duplicates
- wire join request routes into server and schema

## Testing
- `cd ethos-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c60f61e0832f882d066f463a8af1