### PR TITLE
Add task join request support

### DIFF
--- a/ethos-backend/prisma/schema.prisma
+++ b/ethos-backend/prisma/schema.prisma
@@ -154,3 +154,17 @@ model Reaction {
   @@unique([postId, userId, type])
   @@map("reactions")
 }
+
+model TaskJoinRequest {
+  id            String   @id @default(uuid())
+  taskId        String
+  requesterId   String
+  requestPostId String?
+  status        String
+  createdAt     DateTime @default(now())
+  decidedAt     DateTime?
+  decidedBy     String?
+  meta          Json?
+
+  @@map("task_join_requests")
+}

--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -152,6 +152,20 @@ async function initializeDatabase(): Promise<void> {
       id TEXT PRIMARY KEY,
       data JSONB
     );
+    CREATE TABLE IF NOT EXISTS task_join_requests (
+      id UUID PRIMARY KEY,
+      task_id TEXT,
+      requester_id TEXT,
+      request_post_id TEXT,
+      status TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      decided_at TIMESTAMPTZ,
+      decided_by TEXT,
+      meta JSONB
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS task_join_requests_unique_active
+      ON task_join_requests(task_id, requester_id)
+      WHERE status IN ('PENDING','APPROVED');
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS tags TEXT[];
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS visibility TEXT;
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS boardid TEXT;

--- a/ethos-backend/src/models/memoryStores.ts
+++ b/ethos-backend/src/models/memoryStores.ts
@@ -21,3 +21,4 @@ export const reactionsStore = createMemoryStore<DBSchema['reactions']>([]);
 export const reviewsStore = createMemoryStore<DBSchema['reviews']>([]);
 export const boardLogsStore = createMemoryStore<DBSchema['boardLogs']>([]);
 export const notificationsStore = createMemoryStore<DBSchema['notifications']>([]);
+export const joinRequestsStore = createMemoryStore<DBSchema['joinRequests']>([]);

--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -490,3 +490,21 @@ export interface Review {
 
   createdAt: string;
 }
+
+// --------------------------------------------
+// Join Requests
+// --------------------------------------------
+
+export type JoinRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface JoinRequest {
+  id: string;
+  taskId: string;
+  requesterId: string;
+  requestPostId?: string;
+  status: JoinRequestStatus;
+  createdAt: string;
+  decidedAt?: string;
+  decidedBy?: string;
+  meta?: Record<string, any>;
+}

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -16,6 +16,7 @@ import type {
   ReviewTargetType,
   ApprovalStatus,
   GitAccount,
+  JoinRequestStatus,
 } from './api';
 
 // types/db.ts
@@ -286,6 +287,18 @@ export interface DBNotification {
   createdAt: string;
 }
 
+export interface DBTaskJoinRequest {
+  id: string;
+  taskId: string;
+  requesterId: string;
+  requestPostId?: string;
+  status: JoinRequestStatus;
+  createdAt: string;
+  decidedAt?: string;
+  decidedBy?: string;
+  meta?: Record<string, any>;
+}
+
 export interface DBBoardLog {
   id: string;
   boardId: string;
@@ -309,6 +322,7 @@ export interface DBSchema {
   reviews: DBReview[];
   boardLogs: DBBoardLog[];
   notifications: DBNotification[];
+  joinRequests: DBTaskJoinRequest[];
 }
 
 // Optional utility type for referencing a single entry type by file


### PR DESCRIPTION
## Summary
- add `TaskJoinRequest` model to Prisma schema and SQL initialization
- expose join request types and register in DB schema and memory store
- define public API types for join requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c60e1e70832fb9914316cf6b6e4d