### PR TITLE
Hide join button for task members and creators

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -331,7 +331,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
     return (
       <>
-        {post.type === 'request' && !isAuthor && (
+        {post.type === 'request' && !isAuthor && joinState !== 'MEMBER' && (
           <Button
             variant="contrast"
             className="mb-2"

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -22,6 +22,8 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
   const navigate = useNavigate();
   const collaboratorUsers = post.enrichedCollaborators || [];
   const collaboratorCount = collaboratorUsers.filter(c => c.userId).length || 0;
+  const isCollaborator = collaboratorUsers.some(c => c.userId === user?.id);
+  const isAuthor = user?.id === post.authorId;
   const [joining, setJoining] = useState(false);
   const [joined, setJoined] = useState(
     !!user && post.tags?.includes(`pending:${user.id}`)
@@ -108,20 +110,24 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
           )}
         </div>
       )}
-      <div className="flex gap-2">
-        <Button variant="primary" size="sm" onClick={handleJoin} disabled={joining}>
-          {joining ? (
-            '...'
-          ) : joined ? (
-            <><FaUserCheck className="inline mr-1" /> Joined</>
-          ) : (
-            <>
-              <FaUserPlus className="inline mr-1" />
-              {post.type === 'file' ? 'Submit Review' : 'Request Join'}
-            </>
-          )}
-        </Button>
-      </div>
+      {!isAuthor && !isCollaborator && (
+        <div className="flex gap-2">
+          <Button variant="primary" size="sm" onClick={handleJoin} disabled={joining}>
+            {joining ? (
+              '...'
+            ) : joined ? (
+              <>
+                <FaUserCheck className="inline mr-1" /> Joined
+              </>
+            ) : (
+              <>
+                <FaUserPlus className="inline mr-1" />
+                {post.type === 'file' ? 'Submit Review' : 'Request Join'}
+              </>
+            )}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/ethos-frontend/tests/AcceptRequestButton.test.tsx
+++ b/ethos-frontend/tests/AcceptRequestButton.test.tsx
@@ -100,4 +100,30 @@ describe('request card join button', () => {
     fireEvent.click(joined);
     expect(unacceptRequest).toHaveBeenCalledWith('p1');
   });
+
+  it('hides join button for existing collaborators', () => {
+    const collabPost = {
+      ...post,
+      enrichedCollaborators: [{ userId: 'u1' }],
+    } as EnrichedPost;
+    render(
+      <BrowserRouter>
+        <RequestCard post={collabPost} />
+      </BrowserRouter>
+    );
+    expect(screen.queryByText('Request Join')).not.toBeInTheDocument();
+  });
+
+  it('hides join button for the task creator', () => {
+    const authorPost = {
+      ...post,
+      authorId: 'u1',
+    } as EnrichedPost;
+    render(
+      <BrowserRouter>
+        <RequestCard post={authorPost} />
+      </BrowserRouter>
+    );
+    expect(screen.queryByText('Request Join')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- hide request join button for post authors and existing collaborators
- show join option only to non-members on post details
- add tests for hiding join button in these scenarios

## Testing
- `CI=1 npm test` *(fails: TypeError: (0 , post_1.fetchReactions) is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a12e5dc83c832f846f3eb454fea6c3