### PR TITLE
Enable linking posts to tasks from timeline board

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -87,7 +87,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       ? ['free_speech', 'review']
       : ['free_speech']
     : boardId === 'timeline-board'
-    ? ['free_speech', 'task']
+    ? ['free_speech', 'file', 'task']
     : boardId === 'quest-board'
     ? initialType === 'request'
       ? ['request']

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -272,6 +272,7 @@ const PostCard: React.FC<PostCardProps> = ({
           allowDelete={allowDelete}
           content={post.content}
           permalink={`${window.location.origin}${ROUTES.POST(post.id)}`}
+          postType={post.type}
         />
       </div>
     </div>

--- a/ethos-frontend/src/components/ui/TaskLinkDropdown.tsx
+++ b/ethos-frontend/src/components/ui/TaskLinkDropdown.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { FaChevronRight, FaChevronDown } from 'react-icons/fa';
+import { fetchAllPosts } from '../../api/post';
+import type { Post } from '../../types/postTypes';
+
+interface TaskLinkDropdownProps {
+  onSelect: (taskId: string) => void;
+  onClose: () => void;
+}
+
+interface TaskNode {
+  id: string;
+  title: string;
+  children: TaskNode[];
+}
+
+const buildTree = (tasks: Post[]): TaskNode[] => {
+  const map: Record<string, TaskNode> = {};
+  const roots: TaskNode[] = [];
+
+  tasks.forEach((t) => {
+    const label = t.title || t.content.slice(0, 30);
+    const key = t.nodeId || t.id;
+    map[key] = { id: t.id, title: label, children: [] };
+  });
+
+  tasks.forEach((t) => {
+    const key = t.nodeId || t.id;
+    const parts = key.split(':');
+    parts.pop();
+    const parentKey = parts.join(':');
+    const parent = map[parentKey];
+    if (parent) {
+      parent.children.push(map[key]);
+    } else {
+      roots.push(map[key]);
+    }
+  });
+
+  return roots;
+};
+
+const TaskLinkDropdown: React.FC<TaskLinkDropdownProps> = ({ onSelect, onClose }) => {
+  const [tree, setTree] = useState<TaskNode[]>([]);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    fetchAllPosts()
+      .then((posts) => {
+        const tasks = posts.filter((p) => p.type === 'task');
+        setTree(buildTree(tasks));
+      })
+      .catch((err) => console.error('[TaskLinkDropdown] failed to load tasks', err));
+  }, []);
+
+  const toggle = (id: string) =>
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  const renderNode = (node: TaskNode): React.ReactNode => (
+    <li key={node.id} className="pl-2">
+      <div
+        className="flex items-center cursor-pointer" 
+        onClick={() => { onSelect(node.id); onClose(); }}
+      >
+        {node.children.length > 0 && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); toggle(node.id); }}
+            className="mr-1"
+          >
+            {expanded[node.id] ? <FaChevronDown /> : <FaChevronRight />}
+          </button>
+        )}
+        <span className="truncate">{node.title}</span>
+      </div>
+      {node.children.length > 0 && expanded[node.id] && (
+        <ul className="ml-4">
+          {node.children.map((child) => renderNode(child))}
+        </ul>
+      )}
+    </li>
+  );
+
+  return (
+    <div className="absolute left-full top-0 ml-1 w-64 max-h-64 overflow-auto border rounded bg-white bg-surface dark:bg-background shadow">
+      <ul className="text-sm p-2">
+        {tree.map((n) => renderNode(n))}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskLinkDropdown;

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -41,6 +41,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'Task']);
+    expect(options).toEqual(['Free Speech', 'File', 'Task']);
   });
 });


### PR DESCRIPTION
## Summary
- allow Free Speech, File, and Task types when creating posts on the timeline board
- add "Link Post" option for file and task posts with dropdown to choose a task
- support linking posts to selected tasks and include tests for timeline options

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13eb321b8832f90ac37a0009a1e1c