### PR TITLE
fix: show friendly task summary tags

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -49,11 +49,11 @@ describe('PostCard summary tags', () => {
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(await screen.findByText('Q::Task:T1')).toBeInTheDocument();
+    expect(await screen.findByText('Task')).toBeInTheDocument();
     expect(await screen.findByText('In Progress')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const nodeLink = await screen.findByRole('link', { name: 'Q::Task:T1' });
+    const nodeLink = await screen.findByRole('link', { name: 'Task' });
     expect(nodeLink).toHaveAttribute('href', '/post/p1');
   });
 
@@ -76,10 +76,10 @@ describe('PostCard summary tags', () => {
         <PostCard post={enriched} questTitle="Quest A" />
       </BrowserRouter>
     );
-    expect(await screen.findByText('Q::File:T01:F00')).toBeInTheDocument();
+    expect(await screen.findByText('File')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const nodeLink = await screen.findByRole('link', { name: 'Q::File:T01:F00' });
+    const nodeLink = await screen.findByRole('link', { name: 'File' });
     expect(nodeLink).toHaveAttribute('href', '/post/p2');
   });
 
@@ -104,10 +104,10 @@ describe('PostCard summary tags', () => {
       </BrowserRouter>
     );
     expect(await screen.findByText('File')).toBeInTheDocument();
-    expect(await screen.findByText('Q::Task:T01')).toBeInTheDocument();
+    expect(await screen.findByText('Task')).toBeInTheDocument();
     const userLink = await screen.findByRole('link', { name: '@alice' });
     expect(userLink).toHaveAttribute('href', '/user/u1');
-    const taskLink = await screen.findByRole('link', { name: 'Q::Task:T01' });
+    const taskLink = await screen.findByRole('link', { name: 'Task' });
     expect(taskLink).toHaveAttribute('href', '/post/t1');
     const fileLink = await screen.findByRole('link', { name: 'File' });
     expect(fileLink).toHaveAttribute('href', '/post/f1');

--- a/ethos-frontend/src/components/post/PostListItem.test.tsx
+++ b/ethos-frontend/src/components/post/PostListItem.test.tsx
@@ -59,6 +59,6 @@ describe('PostListItem', () => {
         <PostListItem post={taskPost} />
       </BrowserRouter>
     );
-    expect((await screen.findAllByText('Q::Task:T00')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Task')).length).toBeGreaterThan(0);
   });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -122,12 +122,13 @@ const formatNodeId = (nodeId: string): string => {
     path = path.split(':').slice(2).join(':');
   }
   const segments = path.split(':');
-  const typeSeg = [...segments].reverse().find((s) => s.startsWith('T') || s.startsWith('F') || s.startsWith('L')) || '';
-  let typeLabel = '';
-  if (typeSeg.startsWith('T')) typeLabel = 'Task';
-  else if (typeSeg.startsWith('F')) typeLabel = 'File';
-  else if (typeSeg.startsWith('L')) typeLabel = 'Log';
-  return typeLabel ? `Q::${typeLabel}:${segments.join(':')}` : `Q:${segments.join(':')}`;
+  const typeSeg = [...segments]
+    .reverse()
+    .find((s) => s.startsWith('T') || s.startsWith('F') || s.startsWith('L')) || '';
+  if (typeSeg.startsWith('T')) return 'Task';
+  if (typeSeg.startsWith('F')) return 'File';
+  if (typeSeg.startsWith('L')) return 'Log';
+  return path;
 };
 
 export const buildSummaryTags = async (


### PR DESCRIPTION
## Summary
- display task-related summary tags as "Task" instead of full node path
- update unit tests for new tag labels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a140ad0e98832f8aa990678472761d