### PR TITLE
feat: add record versioning

### DIFF
--- a/ethos-backend/prisma/schema.prisma
+++ b/ethos-backend/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   password String
   role     String?
   status   String?
+  version  Int     @default(1)
   posts    Post[]
   quests   Quest[]
   boards   Board[]
@@ -37,6 +38,7 @@ model Post {
   nodeId    String?
   timestamp DateTime?
   createdAt DateTime @default(now())
+  version   Int      @default(1)
 
   author User @relation(fields: [authorId], references: [id])
   reviews Review[]
@@ -64,6 +66,7 @@ model Quest {
   taskGraph     Json?
   helpRequest   Boolean?
   followers     String[]
+  version       Int      @default(1)
 
   author  User    @relation(fields: [authorId], references: [id])
   project Project? @relation(fields: [projectId], references: [id])
@@ -87,6 +90,7 @@ model Board {
   category    String?
   userId      String
   questId     String?
+  version     Int      @default(1)
 
   user  User  @relation(fields: [userId], references: [id])
   quest Quest? @relation(fields: [questId], references: [id])
@@ -105,6 +109,7 @@ model Project {
   questIds    String[]
   deliverables String[]
   mapEdges    Json?
+  version     Int      @default(1)
 
   author User   @relation(fields: [authorId], references: [id])
   quests Quest[]
@@ -125,6 +130,7 @@ model Review {
   questId    String?
   postId     String?
   createdAt  DateTime @default(now())
+  version    Int      @default(1)
 
   reviewer User  @relation(fields: [reviewerId], references: [id])
   quest    Quest? @relation(fields: [questId], references: [id])
@@ -139,6 +145,7 @@ model Notification {
   link      String?
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
+  version   Int      @default(1)
 
   user User @relation(fields: [userId], references: [id])
   @@map("notifications")
@@ -165,6 +172,7 @@ model TaskJoinRequest {
   decidedAt     DateTime?
   decidedBy     String?
   meta          Json?
+  version       Int      @default(1)
 
   @@map("task_join_requests")
 }

--- a/ethos-backend/src/db.ts
+++ b/ethos-backend/src/db.ts
@@ -55,7 +55,8 @@ async function initializeDatabase(): Promise<void> {
       email TEXT UNIQUE,
       password TEXT,
       role TEXT,
-      status TEXT
+      status TEXT,
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS posts (
       id UUID PRIMARY KEY,
@@ -70,7 +71,8 @@ async function initializeDatabase(): Promise<void> {
       boardid TEXT,
       nodeid TEXT,
       timestamp TIMESTAMPTZ,
-      createdat TIMESTAMPTZ DEFAULT NOW()
+      createdat TIMESTAMPTZ DEFAULT NOW(),
+      version INT DEFAULT 1
     );
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS details TEXT;
     ALTER TABLE posts ADD COLUMN IF NOT EXISTS nodeid TEXT;
@@ -80,7 +82,8 @@ async function initializeDatabase(): Promise<void> {
       authorid TEXT,
       title TEXT,
       description TEXT,
-      visibility TEXT
+      visibility TEXT,
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS boards (
       id TEXT PRIMARY KEY,
@@ -94,7 +97,8 @@ async function initializeDatabase(): Promise<void> {
       defaultFor TEXT,
       createdAt TIMESTAMPTZ DEFAULT NOW(),
       userId TEXT,
-      questId TEXT
+      questId TEXT,
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS projects (
       id UUID PRIMARY KEY,
@@ -102,7 +106,8 @@ async function initializeDatabase(): Promise<void> {
       title TEXT,
       description TEXT,
       visibility TEXT,
-      tags TEXT[]
+      tags TEXT[],
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS reviews (
       id UUID PRIMARY KEY,
@@ -117,7 +122,8 @@ async function initializeDatabase(): Promise<void> {
       modelid TEXT,
       questid TEXT,
       postid TEXT,
-      createdat TIMESTAMPTZ DEFAULT NOW()
+      createdat TIMESTAMPTZ DEFAULT NOW(),
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS notifications (
       id UUID PRIMARY KEY,
@@ -125,7 +131,8 @@ async function initializeDatabase(): Promise<void> {
       message TEXT,
       link TEXT,
       read BOOLEAN,
-      createdat TIMESTAMPTZ DEFAULT NOW()
+      createdat TIMESTAMPTZ DEFAULT NOW(),
+      version INT DEFAULT 1
     );
     CREATE TABLE IF NOT EXISTS password_reset_tokens (
       token TEXT PRIMARY KEY,
@@ -161,7 +168,8 @@ async function initializeDatabase(): Promise<void> {
       created_at TIMESTAMPTZ DEFAULT NOW(),
       decided_at TIMESTAMPTZ,
       decided_by TEXT,
-      meta JSONB
+      meta JSONB,
+      version INT DEFAULT 1
     );
     CREATE UNIQUE INDEX IF NOT EXISTS task_join_requests_unique_active
       ON task_join_requests(task_id, requester_id)
@@ -180,6 +188,14 @@ async function initializeDatabase(): Promise<void> {
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS questIds TEXT[];
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS deliverables TEXT[];
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS mapEdges JSONB;
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE posts ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE quests ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE boards ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE projects ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE reviews ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE notifications ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
+    ALTER TABLE task_join_requests ADD COLUMN IF NOT EXISTS version INT DEFAULT 1;
   `);
 
   const { rows } = await pool.query(

--- a/ethos-backend/src/lib/versioning.ts
+++ b/ethos-backend/src/lib/versioning.ts
@@ -1,0 +1,57 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Function signature for upgrading a record from a given version to the next.
+ */
+type UpgradeFn = (record: any, prisma: PrismaClient) => Promise<void>;
+
+/**
+ * Upgrade maps for each Prisma model. Keys represent the current version of the
+ * record. When a record of that version is encountered, the associated function
+ * runs and should mutate it to the next version.
+ */
+const upgrades: Record<string, Record<number, UpgradeFn>> = {
+  post: {},
+  quest: {},
+  board: {},
+  project: {},
+  review: {},
+  user: {},
+  notification: {},
+  taskJoinRequest: {},
+};
+
+/**
+ * Apply any pending upgrades for all configured models. Each model is scanned
+ * for records whose `version` field is lower than the latest known version and
+ * sequential upgrade functions are executed until the record is up to date.
+ */
+export async function runVersioning(prisma: PrismaClient): Promise<void> {
+  for (const [model, upgradeMap] of Object.entries(upgrades)) {
+    const delegate = (prisma as any)[model];
+    if (!delegate) continue;
+
+    const latest = Object.keys(upgradeMap).length
+      ? Math.max(...Object.keys(upgradeMap).map(Number)) + 1
+      : 1;
+
+    const records = await delegate.findMany({
+      where: { version: { lt: latest } },
+    });
+
+    for (const record of records) {
+      let current = record.version ?? 1;
+      while (current < latest) {
+        const fn = upgradeMap[current];
+        if (fn) await fn(record, prisma);
+        current++;
+      }
+      await delegate.update({
+        where: { id: record.id },
+        data: { version: current },
+      });
+    }
+  }
+}
+
+export { upgrades, UpgradeFn };

--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -23,6 +23,8 @@ import joinRequestRoutes from './routes/joinRequestRoutes';
 import healthRoutes from './routes/healthRoutes';
 import joinRequestRouter from './routes/joinRequestRoutes';
 import { initializeDatabase } from './db';
+import { runVersioning } from './lib/versioning';
+import prisma from './services/prismaClient';
 
 // Load environment variables from `.env` file
 dotenv.config();
@@ -169,6 +171,7 @@ io.on('connection', (socket) => {
 });
 
 initializeDatabase()
+  .then(() => runVersioning(prisma))
   .then(() => {
     httpServer.listen(PORT, () => {
       info(`🚀 Backend server running at http://localhost:${PORT}`);

--- a/ethos-backend/src/types/db.ts
+++ b/ethos-backend/src/types/db.ts
@@ -84,6 +84,8 @@ export interface DBPost {
 
   /** Users following this post */
   followers?: string[];
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 // types/db.ts
@@ -126,6 +128,8 @@ export interface DBQuest {
 
   /** Users following this quest */
   followers?: string[];
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 export interface TaskEdge {
@@ -147,6 +151,8 @@ export interface DBProject {
   questIds: string[];
   deliverables: string[];
   mapEdges?: TaskEdge[];
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 // types/db.ts
@@ -165,6 +171,8 @@ export interface DBBoard {
   userId: string;
   /** Optional quest association */
   questId?: string;
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 // Efficient DB model for quick lookups and storage
@@ -255,6 +263,8 @@ export interface DBUser {
 
   createdAt?: string;
   updatedAt?: string;
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 export interface DBUserExperienceEvent {
@@ -277,6 +287,8 @@ export interface DBReview {
   questId?: string;
   postId?: string;
   createdAt: string;
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 export interface DBNotification {
@@ -288,6 +300,8 @@ export interface DBNotification {
   joinRequestId?: string;
   read?: boolean;
   createdAt: string;
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 export interface DBTaskJoinRequest {
@@ -300,6 +314,8 @@ export interface DBTaskJoinRequest {
   decidedAt?: string;
   decidedBy?: string;
   meta?: Record<string, any>;
+  /** Record version for upgrade tracking */
+  version?: number;
 }
 
 export interface DBBoardLog {


### PR DESCRIPTION
## Summary
- add version column to core prisma models and initialization SQL
- introduce upgrade framework with versioned functions
- execute version upgrades during server startup

## Testing
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a15006585c832f8684a5cc0f552eb7