### PR TITLE
feat: add migration rollback and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ The backend logger supports a `LOG_LEVEL` environment variable. Set it to
 `error`, `warn`, `info` (default), or `debug` to control the verbosity of
 console output. Each log line includes a timestamp for easier tracing.
 
+### Rolling Back a Migration
+
+If a database migration causes issues, you can restore the previous schema by
+running:
+
+```bash
+npm --prefix ethos-backend run rollback
+```
+
+The script marks the latest Prisma migration as rolled back, redeploys the
+remaining migrations, and pushes success/failure metrics to the configured
+Prometheus Pushgateway (`PUSHGATEWAY_URL`). Configure your monitoring system to
+alert on spikes in `migration_rollback_failure_total`.
+
 ### API Routes
 
 - `POST /quests/:id/complete` – mark a quest as completed. Cascades the `solved` tag to linked posts when `cascadeSolution` is set and logs notifications for links with `notifyOnChange`.

--- a/ethos-backend/package-lock.json
+++ b/ethos-backend/package-lock.json
@@ -22,6 +22,7 @@
         "node-cron": "^4.2.1",
         "nodemailer": "^7.0.3",
         "pg": "^8.16.3",
+        "prom-client": "^15.1.3",
         "simple-git": "^3.28.0",
         "socket.io": "^4.7.4",
         "uuid": "^11.1.0"
@@ -1014,6 +1015,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -1865,6 +1875,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -5549,6 +5565,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6454,6 +6483,15 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/ethos-backend/package.json
+++ b/ethos-backend/package.json
@@ -7,7 +7,8 @@
     "dev": "ts-node-dev src/server.ts",
     "build": "tsc",
     "start": "node dist/src/server.js",
-    "test": "jest"
+    "test": "jest",
+    "rollback": "ts-node scripts/rollbackMigration.ts"
   },
   "keywords": [],
   "author": "",
@@ -27,6 +28,7 @@
     "node-cron": "^4.2.1",
     "nodemailer": "^7.0.3",
     "pg": "^8.16.3",
+    "prom-client": "^15.1.3",
     "simple-git": "^3.28.0",
     "socket.io": "^4.7.4",
     "uuid": "^11.1.0"

--- a/ethos-backend/scripts/rollbackMigration.ts
+++ b/ethos-backend/scripts/rollbackMigration.ts
@@ -1,0 +1,58 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { Counter, Pushgateway, Registry } from 'prom-client';
+
+const backendDir = path.join(__dirname, '..');
+const migrationsDir = path.join(backendDir, 'prisma', 'migrations');
+
+const registry = new Registry();
+const rollbackSuccess = new Counter({
+  name: 'migration_rollback_success_total',
+  help: 'Number of successful migration rollbacks',
+  registers: [registry],
+});
+const rollbackFailure = new Counter({
+  name: 'migration_rollback_failure_total',
+  help: 'Number of failed migration rollback attempts',
+  registers: [registry],
+});
+const gateway = new Pushgateway(
+  process.env.PUSHGATEWAY_URL ?? 'http://localhost:9091',
+  [],
+  registry
+);
+
+function getLastMigration(): string | null {
+  const dirs = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => fs.statSync(path.join(migrationsDir, f)).isDirectory())
+    .sort();
+  if (dirs.length < 1) {
+    console.log('No migrations found');
+    return null;
+  }
+  return dirs[dirs.length - 1];
+}
+
+async function rollback(): Promise<void> {
+  const last = getLastMigration();
+  if (!last) return;
+  try {
+    execSync(`npx prisma migrate resolve --rolled-back ${last}`, {
+      cwd: backendDir,
+      stdio: 'inherit',
+    });
+    execSync('npx prisma migrate deploy', { cwd: backendDir, stdio: 'inherit' });
+    rollbackSuccess.inc();
+    await gateway.pushAdd({ jobName: 'migration_rollback' });
+    console.log(`Rolled back migration ${last}`);
+  } catch (err) {
+    rollbackFailure.inc();
+    await gateway.pushAdd({ jobName: 'migration_rollback' });
+    console.error(`Failed to roll back migration ${last}`);
+    process.exit(1);
+  }
+}
+
+void rollback();

--- a/ethos-backend/src/jobs/migrateLegacyData.ts
+++ b/ethos-backend/src/jobs/migrateLegacyData.ts
@@ -1,11 +1,29 @@
 import cron from 'node-cron';
 import fs from 'fs/promises';
 import path from 'path';
+import { Counter, Pushgateway, Registry } from 'prom-client';
 import prisma from '../services/prismaClient';
 import { info, error } from '../utils/logger';
 
 const LOG_FILE = path.join(process.cwd(), 'migration.log');
 const BATCH_SIZE = 100;
+
+const registry = new Registry();
+const migrationSuccess = new Counter({
+  name: 'legacy_data_migration_success_total',
+  help: 'Number of successful legacy data migrations',
+  registers: [registry],
+});
+const migrationFailure = new Counter({
+  name: 'legacy_data_migration_failure_total',
+  help: 'Number of failed legacy data migrations',
+  registers: [registry],
+});
+const gateway = new Pushgateway(
+  process.env.PUSHGATEWAY_URL ?? 'http://localhost:9091',
+  [],
+  registry
+);
 
 async function logToFile(message: string): Promise<void> {
   const timestamp = new Date().toISOString();
@@ -49,8 +67,12 @@ export function scheduleLegacyDataMigration(): void {
     info('Starting legacy data migration');
     try {
       await migrateLegacyData();
+      migrationSuccess.inc();
+      await gateway.pushAdd({ jobName: 'legacy_data_migration' });
       info('Legacy data migration completed');
     } catch (err) {
+      migrationFailure.inc();
+      await gateway.pushAdd({ jobName: 'legacy_data_migration' });
       error('Legacy data migration failed', err);
     }
   });


### PR DESCRIPTION
## Summary
- add TypeScript script to rollback last Prisma migration and publish metrics
- track migration success/failure metrics in legacy data migration job
- document rollback procedure and metrics in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix ethos-backend test`


------
https://chatgpt.com/codex/tasks/task_e_68a15916735c832fa3c013ec0c93619a