### PR TITLE
Include linked items only when present

### DIFF
--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -121,7 +121,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
       content: details,
       ...(details ? { details } : {}),
       visibility: 'public',
-      linkedItems: autoLinkItems,
+      ...(autoLinkItems.length > 0 ? { linkedItems: autoLinkItems } : {}),
       ...(type === 'review' ? { tags: ['review'] } : {}),
       ...(type === 'request' ? { tags: ['request'] } : {}),
       ...(questIdFromBoard ? { questId: questIdFromBoard } : {}),

--- a/ethos-frontend/tests/CreatePostReply.test.tsx
+++ b/ethos-frontend/tests/CreatePostReply.test.tsx
@@ -61,7 +61,7 @@ describe('CreatePost replying', () => {
     expect(options).toEqual(['Free Speech']);
   });
 
-  it('includes reply questId in payload', async () => {
+  it('includes reply questId and linkedItems in payload', async () => {
     const reply = { id: 'r1', type: 'task', questId: 'q123' } as Post;
     render(
       <BrowserRouter>
@@ -75,7 +75,10 @@ describe('CreatePost replying', () => {
     fireEvent.click(screen.getByText('Create Post'));
     await waitFor(() => expect(addPost).toHaveBeenCalled());
     expect(addPost).toHaveBeenCalledWith(
-      expect.objectContaining({ questId: 'q123' })
+      expect.objectContaining({
+        questId: 'q123',
+        linkedItems: [{ itemId: 'q123', itemType: 'quest' }],
+      })
     );
   });
 });

--- a/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
+++ b/ethos-frontend/tests/CreatePostRequestNoTask.test.tsx
@@ -41,5 +41,22 @@ describe('CreatePost request without task', () => {
     fireEvent.click(screen.getByText('Create Post'));
     await waitFor(() => expect(addPost).toHaveBeenCalled());
     expect(window.alert).not.toHaveBeenCalled();
+    const call = (addPost as jest.Mock).mock.calls[0][0];
+    expect('linkedItems' in call).toBe(false);
+  });
+
+  it('includes linkedItems when questId is provided', async () => {
+    (addPost as jest.Mock).mockClear();
+    window.alert = jest.fn();
+    render(
+      <BrowserRouter>
+        <CreatePost onCancel={() => {}} initialType="request" questId="q1" />
+      </BrowserRouter>
+    );
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Need help' } });
+    fireEvent.click(screen.getByText('Create Post'));
+    await waitFor(() => expect(addPost).toHaveBeenCalled());
+    const call = (addPost as jest.Mock).mock.calls[0][0];
+    expect(call.linkedItems).toEqual([{ itemId: 'q1', itemType: 'quest' }]);
   });
 });


### PR DESCRIPTION
## Summary
- Avoid sending empty `linkedItems` in CreatePost payload
- Test that `linkedItems` are omitted when no quest is linked
- Test that `linkedItems` are preserved when linking to a quest

## Testing
- `cd ethos-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a170ae4a68832fb107de027532c310