### PR TITLE
Clarify independent file posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It’s a new operating system for solving problems together.
 * **Quick Sharing** – Use the action menu to copy post quotes or grab a direct link.
 * **Visual Quest Maps** – Tree, grid, or list views of how solutions evolve.
 * **Interactive Task Lists** – Check off markdown tasks directly within posts.
+* **Independent File Posts** – Create files without linking them to tasks and organize them later by attaching them to tasks.
 * **Freelancer-Oriented** – Designed to support real client work, solo projects, and peer-based micro-teams.
 * **Web3-Ready (Future)** – Enable decentralized contracts and token-based achievements.
 * **VS Code Git Graph Extension** – Visualize repository history directly inside Visual Studio Code.

--- a/docs/git-account-integration.md
+++ b/docs/git-account-integration.md
@@ -13,7 +13,7 @@ This guide outlines how Ethos connects a user's GitHub or GitLab account and map
 
 * After linking an account, connect a quest or project to a repository using `POST /api/git/connect`.
 * The top task `T00` corresponds to the repository root directory.
-* File posts appear as `F00`, `F01`, etc., representing files stored under the original task.
+* File posts appear as `F00`, `F01`, etc. They can be created without an initial task link and organized later by attaching them to specific tasks.
 * Each file post shows additions and insertions similar to a commit diff.
 
 ## Task Posts and Subtasks

--- a/docs/quest-map.md
+++ b/docs/quest-map.md
@@ -25,7 +25,7 @@ Node IDs are generated in [`nodeIdUtils.ts`](../ethos-backend/src/utils/nodeIdUt
 
 Every quest has a hidden root node. When a quest is created without a `headPostId`, the map starts from this automatic root. If a `headPostId` is set, edges originate from that post instead. New tasks link from the root (or head post) so that the map always has a starting point.
 
-The first task created in a quest uses the node ID `T00`. Root logs or files should nest under this task, for example `Q:demo:T00:L00`.
+The first task created in a quest uses the node ID `T00`. Root logs or files often nest under this task (for example `Q:demo:T00:L00`), but they can also be created independently and linked later when organizing the quest.
 
 ## Posts and edges in the quest map
 


### PR DESCRIPTION
## Summary
- document that file posts can be created without task links and attached later
- note flexibility in quest maps and git account integration
- list independent file posts in README key features

## Testing
- `npm test --prefix ethos-backend` *(fails: Cannot find module 'supertest')*
- `npm test --prefix ethos-frontend` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17f595760832f91c4569109237f5f