### PR TITLE
feat: move file posts to tasks

### DIFF
--- a/ethos-frontend/jest.config.js
+++ b/ethos-frontend/jest.config.js
@@ -24,6 +24,7 @@ export default {
     '<rootDir>/src/components/controls/ReactionControls.reviewRequest.test.tsx',
     '<rootDir>/src/components/post/PostCard.requestHelp.test.tsx',
     '<rootDir>/src/components/post/PostListItem.test.tsx',
+    '<rootDir>/src/components/post/PostCard.moveToTask.test.tsx',
     '<rootDir>/src/api/post.requestHelp.test.ts',
     '<rootDir>/tests/CreatePostReplyTypeRestrictions.test.tsx',
     '<rootDir>/tests/CreatePostReply.test.tsx',

--- a/ethos-frontend/src/components/post/PostCard.moveToTask.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.moveToTask.test.tsx
@@ -2,14 +2,19 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
 import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
 
-const updatePostMock = jest.fn((id, data) => Promise.resolve({ id, ...data }));
+const updatePostMock = jest.fn(
+  (id: string, data: Partial<Post>) => Promise.resolve({ id, ...data })
+);
 const updateBoardItemMock = jest.fn();
 
 jest.mock('../../api/post', () => ({
   __esModule: true,
   fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
-  updatePost: (...args: any[]) => updatePostMock(...args),
+  updatePost: (
+    ...args: Parameters<typeof updatePostMock>
+  ) => updatePostMock(...args),
   removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
   createJoinRequest: jest.fn(() => Promise.resolve({})),
   updateReaction: jest.fn(() => Promise.resolve()),
@@ -66,9 +71,21 @@ describe('PostCard Move to Task', () => {
       linkedItems: [],
     } as unknown as Post;
 
+    const user: User = {
+      id: 'u1',
+      email: 'test@example.com',
+      username: 'alice',
+      password: '',
+      role: 'user',
+      bio: '',
+      tags: [],
+      links: {},
+      experienceTimeline: [],
+    };
+
     render(
       <BrowserRouter>
-        <PostCard post={post} user={{ id: 'u1' } as any} />
+        <PostCard post={post} user={user} />
       </BrowserRouter>
     );
 

--- a/ethos-frontend/src/components/post/PostCard.moveToTask.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.moveToTask.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+
+const updatePostMock = jest.fn((id, data) => Promise.resolve({ id, ...data }));
+const updateBoardItemMock = jest.fn();
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+  updatePost: (...args: any[]) => updatePostMock(...args),
+  removeHelpRequest: jest.fn(() => Promise.resolve({ success: true })),
+  createJoinRequest: jest.fn(() => Promise.resolve({})),
+  updateReaction: jest.fn(() => Promise.resolve()),
+  addRepost: jest.fn(() => Promise.resolve({ id: 'r1' })),
+  removeRepost: jest.fn(() => Promise.resolve()),
+  fetchReactions: jest.fn(() => Promise.resolve([])),
+  fetchRepostCount: jest.fn(() => Promise.resolve({ count: 0 })),
+  fetchUserRepost: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../ui/TaskLinkDropdown', () => ({
+  __esModule: true,
+  default: ({ onSelect }: { onSelect: (id: string) => void }) => (
+    <div data-testid="task-picker">
+      <button onClick={() => onSelect('t1')}>Task1</button>
+    </div>
+  ),
+}));
+
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn(() => Promise.resolve({ id: 'u1', username: 'alice' })),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: 'b1', updateBoardItem: updateBoardItemMock }),
+}));
+
+jest.mock('../../hooks/useGraph', () => ({
+  useGraph: () => ({ loadGraph: jest.fn() }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('PostCard Move to Task', () => {
+  it('updates linkedItems when moving file post to task', async () => {
+    const post: Post = {
+      id: 'f1',
+      authorId: 'u1',
+      type: 'file',
+      content: 'file',
+      visibility: 'public',
+      timestamp: '',
+      tags: [],
+      collaborators: [],
+      linkedItems: [],
+    } as unknown as Post;
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' } as any} />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByText(/Move to Task/i));
+    fireEvent.click(screen.getByText('Task1'));
+
+    await waitFor(() =>
+      expect(updatePostMock).toHaveBeenCalledWith(
+        'f1',
+        expect.objectContaining({
+          linkedItems: [
+            { itemId: 't1', itemType: 'post', linkType: 'task_edge', nodeId: '' },
+          ],
+        })
+      )
+    );
+    expect(updateBoardItemMock).toHaveBeenCalled();
+  });
+});
+

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -13,6 +13,8 @@ import { fetchQuestById } from '../../api/quest';
 import ReactionControls from '../controls/ReactionControls';
 import { SummaryTag, Button } from '../ui';
 import { useBoardContext } from '../../contexts/BoardContext';
+import TaskLinkDropdown from '../ui/TaskLinkDropdown';
+import type { BoardItem } from '../../contexts/BoardContextTypes';
 import MarkdownRenderer from '../ui/MarkdownRenderer';
 import MediaPreview from '../ui/MediaPreview';
 import EditPost from './EditPost';
@@ -101,7 +103,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();
-  const { selectedBoard } = useBoardContext() || {};
+  const { selectedBoard, updateBoardItem } = useBoardContext() || {};
 
   const initialJoinState = post.collaborators?.some(c =>
     c.pending?.includes(user?.id || '')
@@ -111,6 +113,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const [userJoinState, setUserJoinState] = useState<'NONE' | 'PENDING'>(initialJoinState);
   const [joinLoading, setJoinLoading] = useState(false);
   const [joinNotice, setJoinNotice] = useState('');
+  const [showTaskPicker, setShowTaskPicker] = useState(false);
 
   const dispatchTaskUpdated = (p: Post) => {
     if (p.type === 'task') {
@@ -147,6 +150,32 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const ctxBoardId = boardId || selectedBoard;
+
+  const handleSelectTask = async (taskId: string) => {
+    try {
+      const existing = post.linkedItems || [];
+      const already = existing.some(
+        (l) => l.itemId === taskId && l.itemType === 'post'
+      );
+      if (already) {
+        setShowTaskPicker(false);
+        return;
+      }
+      const updated = await updatePost(post.id, {
+        linkedItems: [
+          ...existing,
+          { itemId: taskId, itemType: 'post', linkType: 'task_edge', nodeId: '' },
+        ],
+      });
+      onUpdate?.(updated);
+      if (ctxBoardId) updateBoardItem?.(ctxBoardId, updated as BoardItem);
+    } catch (err) {
+      console.error('[PostCard] Failed to move post to task:', err);
+      alert('Failed to move to task.');
+    } finally {
+      setShowTaskPicker(false);
+    }
+  };
 
   const isQuestBoardRequest =
     post.tags?.includes('request') && ctxBoardId === 'quest-board';
@@ -351,6 +380,22 @@ const PostCard: React.FC<PostCardProps> = ({
           >
             Send Review
           </Button>
+        )}
+        {post.type === 'file' && (
+          <div className="relative mb-2">
+            <Button
+              variant="contrast"
+              onClick={() => setShowTaskPicker((p) => !p)}
+            >
+              Move to Task
+            </Button>
+            {showTaskPicker && (
+              <TaskLinkDropdown
+                onSelect={handleSelectTask}
+                onClose={() => setShowTaskPicker(false)}
+              />
+            )}
+          </div>
         )}
         <ReactionControls
           post={post}


### PR DESCRIPTION
## Summary
- add Move to Task control for file posts
- allow selecting a task and patch linkedItems
- test moving file post to task

## Testing
- `npx jest src/components/post/PostCard.moveToTask.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68a181882ef4832f8c84f277a5d88a82