### PR TITLE
fix: prevent join request router from hijacking /api path

### DIFF
--- a/ethos-backend/src/server.ts
+++ b/ethos-backend/src/server.ts
@@ -21,7 +21,6 @@ import userRoutes from './routes/userRoutes';
 import notificationRoutes from './routes/notificationRoutes';
 import joinRequestRoutes from './routes/joinRequestRoutes';
 import healthRoutes from './routes/healthRoutes';
-import joinRequestRouter from './routes/joinRequestRoutes';
 import { initializeDatabase } from './db';
 import { runVersioning } from './lib/versioning';
 import prisma from './services/prismaClient';
@@ -124,7 +123,6 @@ app.use('/api/users', userRoutes);    // 👥 Public user profiles
 app.use('/api/notifications', notificationRoutes); // 🔔 User notifications
 app.use('/api/join-requests', joinRequestRoutes); // 🤝 Task join requests
 app.use('/api/health', healthRoutes); // ❤️ Health check
-app.use('/api', joinRequestRouter);
 
 // Generic error handler to prevent leaking stack traces in production
 app.use(


### PR DESCRIPTION
## Summary
- avoid mounting join request routes at the API root
- clean up duplicate import of joinRequestRoutes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2327edfe8832f9982f7494b96522e