### PR TITLE
fix: declare optional modules for legacy migration job

### DIFF
--- a/ethos-backend/src/types/custom.d.ts
+++ b/ethos-backend/src/types/custom.d.ts
@@ -1,2 +1,4 @@
 declare module 'cors';
 declare module 'nodemailer';
+declare module 'node-cron';
+declare module 'prom-client';


### PR DESCRIPTION
## Summary
- declare node-cron and prom-client modules in backend custom typings to allow optional imports

## Testing
- `npm --prefix ethos-backend test`

------
https://chatgpt.com/codex/tasks/task_e_68a2516c4e9c832fb60d0496aa4ccf8f