### PR TITLE
Add project post type

### DIFF
--- a/ethos-backend/src/types/api.ts
+++ b/ethos-backend/src/types/api.ts
@@ -53,6 +53,7 @@ export type PostTag =
   | 'release'
   | 'repost'
   | 'quest'
+  | 'project'
   | 'task'
   | 'issue'
   | 'review'
@@ -68,7 +69,8 @@ export type PostType =
   | 'request'
   | 'task'
   | 'file'
-  | 'review';
+  | 'review'
+  | 'project';
 
 export type LinkStatus = 'active' | 'solved' | 'private' | 'pending';
 

--- a/ethos-frontend/src/components/board/PostTypeFilter.tsx
+++ b/ethos-frontend/src/components/board/PostTypeFilter.tsx
@@ -8,6 +8,7 @@ interface PostTypeFilterProps {
 
 const options = [
   { value: '', label: 'All Posts' },
+  { value: 'project', label: 'Projects' },
   { value: 'request', label: 'Requests' },
   { value: 'review', label: 'Reviews' },
 ];

--- a/ethos-frontend/src/components/controls/LinkControls.tsx
+++ b/ethos-frontend/src/components/controls/LinkControls.tsx
@@ -230,7 +230,7 @@ const LinkControls: React.FC<LinkControlsProps> = ({
         <> 
           {itemTypes.includes('post') && (
             <div className="flex gap-1 mb-1 flex-wrap">
-              {['all', 'free_speech', 'task', 'file', 'request', 'review'].map((t) => (
+              {['all', 'free_speech', 'task', 'file', 'project', 'request', 'review'].map((t) => (
                 <button
                   key={t}
                   type="button"

--- a/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
@@ -47,6 +47,14 @@ jest.mock('../../contexts/BoardContext', () => ({
 }));
 
 describe('review request quest board flow', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -67,24 +75,27 @@ describe('review request quest board flow', () => {
       },
     });
 
-    render(
-      <BrowserRouter>
-        <ReactionControls
-          post={{
-            id: 'f1',
-            authorId: 'u1',
-            type: 'file',
-            content: 'file',
-            visibility: 'public',
-            tags: [],
-            collaborators: [],
-            linkedItems: [],
-          }}
-          user={{ id: 'u1' }}
-          onUpdate={onUpdate}
-        />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ReactionControls
+            post={{
+              id: 'f1',
+              authorId: 'u1',
+              type: 'file',
+              content: 'file',
+              visibility: 'public',
+              tags: [],
+              collaborators: [],
+              linkedItems: [],
+            }}
+            user={{ id: 'u1' }}
+            onUpdate={onUpdate}
+          />
+        </BrowserRouter>
+      );
+    });
+    await act(async () => {});
 
     await waitFor(() => expect(screen.getByText('Request Review')).toBeEnabled());
     await act(async () => {
@@ -122,11 +133,14 @@ describe('review request quest board flow', () => {
       linkedItems: [],
     };
 
-    render(
-      <BrowserRouter>
-        <ReactionControls post={postWithRequest} user={{ id: 'u1' }} onUpdate={onUpdate} />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ReactionControls post={postWithRequest} user={{ id: 'u1' }} onUpdate={onUpdate} />
+        </BrowserRouter>
+      );
+    });
+    await act(async () => {});
 
     await waitFor(() => expect(screen.getByText('Requested')).toBeEnabled());
     await act(async () => {

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -259,7 +259,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         </button>
 
         {/* Repost */}
-        {['free_speech', 'task', 'file'].includes(post.type) && (
+        {['free_speech', 'task', 'file', 'project'].includes(post.type) && (
           <button
             aria-label="Repost"
             className={clsx('flex items-center gap-1', reactions.repost && 'text-indigo-600')}

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -129,7 +129,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [post.id, user?.id]);
+  }, [post.id, user?.id, post.tags, post.helpRequest]);
 
   // ---------- Helpers ----------
   const safeBump = (n: number, delta: number) => Math.max(0, n + delta);
@@ -187,7 +187,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     } finally {
       setReviewLoading(false);
     }
-  }, [user?.id, navigate, reviewRequested, post.id, post, onUpdate, appendToBoard]);
+  }, [user?.id, navigate, reviewRequested, post, onUpdate, appendToBoard]);
 
   const handleRequestHelp = useCallback(async () => {
     if (!user?.id) {
@@ -215,7 +215,7 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
     } finally {
       setHelpLoading(false);
     }
-  }, [user?.id, navigate, helpRequested, post.id, post, onUpdate, appendToBoard]);
+  }, [user?.id, navigate, helpRequested, post, onUpdate, appendToBoard]);
 
   const goToReplyPageOrToggle = useCallback(
     (nextType: ReplyType) => {

--- a/ethos-frontend/src/components/post/CreatePost.tsx
+++ b/ethos-frontend/src/components/post/CreatePost.tsx
@@ -85,9 +85,13 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
         : ['free_speech']
       : replyToType === 'file'
       ? ['free_speech', 'review']
+      : replyToType === 'project'
+      ? isParticipant
+        ? ['free_speech', 'task', 'file']
+        : ['free_speech']
       : ['free_speech']
     : boardId === 'timeline-board'
-    ? ['free_speech', 'file', 'task']
+    ? ['free_speech', 'file', 'task', 'project']
     : boardId === 'quest-board'
     ? initialType === 'request'
       ? ['request']
@@ -95,7 +99,7 @@ const { selectedBoard, appendToBoard, boards } = useBoardContext() || {};
     : boardType === 'quest'
     ? ['task', 'free_speech']
     : boardType === 'post'
-    ? ['free_speech', 'task', 'file']
+    ? ['free_speech', 'task', 'file', 'project']
     : POST_TYPES.map((p) => p.value as PostType);
 
 

--- a/ethos-frontend/src/components/ui/SummaryTag.tsx
+++ b/ethos-frontend/src/components/ui/SummaryTag.tsx
@@ -9,7 +9,8 @@ import {
   FaUser,
   FaHandsHelping,
   FaCheckCircle,
-  FaFile
+  FaFile,
+  FaProjectDiagram
 } from 'react-icons/fa';
 import clsx from 'clsx';
 import { TAG_LAYOUT } from '../../constants/styles';
@@ -30,7 +31,8 @@ export type SummaryTagType =
   | 'party_request'
   | 'quest_task'
   | 'meta_system'
-  | 'meta_announcement';
+  | 'meta_announcement'
+  | 'project';
 
 export type SummaryTagProps = SummaryTagData & { className?: string; onClick?: () => void };
 
@@ -43,6 +45,7 @@ const icons: Partial<Record<SummaryTagType, React.ComponentType<{className?: str
   request: FaHandsHelping,
   file: FaFile,
   solved: FaCheckCircle,
+  project: FaProjectDiagram,
 };
 
 const colors: Record<SummaryTagType, string> = {
@@ -61,6 +64,7 @@ const colors: Record<SummaryTagType, string> = {
   meta_system: 'bg-red-100 text-red-700 dark:bg-red-700 dark:text-red-200',
   meta_announcement: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-200',
   solved: 'bg-lime-100 text-lime-800 dark:bg-lime-800 dark:text-lime-200',
+  project: 'bg-orange-100 text-orange-800 dark:bg-orange-800 dark:text-orange-200',
 };
 
 const SummaryTag: React.FC<SummaryTagProps> = ({

--- a/ethos-frontend/src/constants/options.ts
+++ b/ethos-frontend/src/constants/options.ts
@@ -28,6 +28,7 @@ export const POST_TYPES: { value: PostType; label: string }[] = [
   { value: 'free_speech', label: 'Free Speech' },
   { value: 'task', label: 'Task' },
   { value: 'file', label: 'File' },
+  { value: 'project', label: 'Project' },
 ];
 
 export const SECONDARY_POST_TYPES = [

--- a/ethos-frontend/src/types/postTypes.ts
+++ b/ethos-frontend/src/types/postTypes.ts
@@ -190,7 +190,8 @@ export type PostType =
   | 'task'
   | 'file'
   | 'request'
-  | 'review';
+  | 'review'
+  | 'project';
   
 /**
  * Supported tags for labeling and filtering posts.
@@ -206,6 +207,7 @@ export type PostTag =
   | 'release'
   | 'repost'
   | 'quest'
+  | 'project'
   | 'task'
   | 'issue'
   | 'request'

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -28,6 +28,7 @@ export const POST_TYPE_LABELS: Record<PostType | 'request' | 'review', string> =
   file: "File",
   request: "Request",
   review: "Review",
+  project: "Project",
 };
 
 /**

--- a/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
+++ b/ethos-frontend/tests/PostTypeFilterOptions.test.tsx
@@ -7,6 +7,6 @@ describe('PostTypeFilter options', () => {
     render(<PostTypeFilter value="" onChange={() => {}} />);
     const select = screen.getByRole('combobox');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['All Posts', 'Requests', 'Reviews']);
+    expect(options).toEqual(['All Posts', 'Projects', 'Requests', 'Reviews']);
   });
 });

--- a/ethos-frontend/tests/QuestBoardComponent.test.tsx
+++ b/ethos-frontend/tests/QuestBoardComponent.test.tsx
@@ -33,6 +33,7 @@ jest.mock('../src/components/board/PostTypeFilter', () => ({
   default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
     <select data-testid="post-type-filter" value={value} onChange={e => onChange(e.target.value)}>
       <option value="">All Posts</option>
+      <option value="project">Projects</option>
       <option value="request">Requests</option>
       <option value="review">Reviews</option>
     </select>

--- a/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
+++ b/ethos-frontend/tests/TimelineBoardPostTypes.test.tsx
@@ -41,6 +41,6 @@ describe('Timeline board post types', () => {
     );
     const select = screen.getByLabelText('Item Type');
     const options = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
-    expect(options).toEqual(['Free Speech', 'File', 'Task']);
+    expect(options).toEqual(['Free Speech', 'File', 'Task', 'Project']);
   });
 });


### PR DESCRIPTION
## Summary
- add new `project` post type to backend types and post creation rules
- expose project posts in frontend types, filters, and UI options
- update tests to cover project post filtering and creation

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68a2544914a4832fb3fee76343c57733