### PR TITLE
Remove Move to Task button in favor of Add to Folder

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.addToFolder.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.addToFolder.test.tsx
@@ -57,8 +57,8 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-describe('PostCard Move to Task', () => {
-  it('updates linkedItems when moving file post to task', async () => {
+describe('PostCard Add to Folder', () => {
+  it('updates linkedItems when using Add to Folder option', async () => {
     const post: Post = {
       id: 'f1',
       authorId: 'u1',
@@ -89,7 +89,10 @@ describe('PostCard Move to Task', () => {
       </BrowserRouter>
     );
 
-    fireEvent.click(screen.getByText(/Move to Task/i));
+    expect(screen.queryByText(/Move to Task/i)).toBeNull();
+
+    fireEvent.click(screen.getByLabelText(/More options/i));
+    fireEvent.click(screen.getByText(/Add to Folder/i));
     fireEvent.click(screen.getByText('Task1'));
 
     await waitFor(() =>

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -13,8 +13,6 @@ import { fetchQuestById } from '../../api/quest';
 import ReactionControls from '../controls/ReactionControls';
 import { SummaryTag, Button } from '../ui';
 import { useBoardContext } from '../../contexts/BoardContext';
-import TaskLinkDropdown from '../ui/TaskLinkDropdown';
-import type { BoardItem } from '../../contexts/BoardContextTypes';
 import MarkdownRenderer from '../ui/MarkdownRenderer';
 import MediaPreview from '../ui/MediaPreview';
 import EditPost from './EditPost';
@@ -103,7 +101,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const { loadGraph } = useGraph();
 
   const navigate = useNavigate();
-  const { selectedBoard, updateBoardItem } = useBoardContext() || {};
+  const { selectedBoard } = useBoardContext() || {};
 
   const initialJoinState = post.collaborators?.some(c =>
     c.pending?.includes(user?.id || '')
@@ -113,7 +111,6 @@ const PostCard: React.FC<PostCardProps> = ({
   const [userJoinState, setUserJoinState] = useState<'NONE' | 'PENDING'>(initialJoinState);
   const [joinLoading, setJoinLoading] = useState(false);
   const [joinNotice, setJoinNotice] = useState('');
-  const [showTaskPicker, setShowTaskPicker] = useState(false);
 
   const dispatchTaskUpdated = (p: Post) => {
     if (p.type === 'task') {
@@ -150,32 +147,6 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const ctxBoardId = boardId || selectedBoard;
-
-  const handleSelectTask = async (taskId: string) => {
-    try {
-      const existing = post.linkedItems || [];
-      const already = existing.some(
-        (l) => l.itemId === taskId && l.itemType === 'post'
-      );
-      if (already) {
-        setShowTaskPicker(false);
-        return;
-      }
-      const updated = await updatePost(post.id, {
-        linkedItems: [
-          ...existing,
-          { itemId: taskId, itemType: 'post', linkType: 'task_edge', nodeId: '' },
-        ],
-      });
-      onUpdate?.(updated);
-      if (ctxBoardId) updateBoardItem?.(ctxBoardId, updated as BoardItem);
-    } catch (err) {
-      console.error('[PostCard] Failed to move post to task:', err);
-      alert('Failed to move to task.');
-    } finally {
-      setShowTaskPicker(false);
-    }
-  };
 
   const isQuestBoardRequest =
     post.tags?.includes('request') && ctxBoardId === 'quest-board';
@@ -380,22 +351,6 @@ const PostCard: React.FC<PostCardProps> = ({
           >
             Send Review
           </Button>
-        )}
-        {post.type === 'file' && (
-          <div className="relative mb-2">
-            <Button
-              variant="contrast"
-              onClick={() => setShowTaskPicker((p) => !p)}
-            >
-              Move to Task
-            </Button>
-            {showTaskPicker && (
-              <TaskLinkDropdown
-                onSelect={handleSelectTask}
-                onClose={() => setShowTaskPicker(false)}
-              />
-            )}
-          </div>
         )}
         <ReactionControls
           post={post}

--- a/ethos-frontend/src/components/ui/ActionMenu.tsx
+++ b/ethos-frontend/src/components/ui/ActionMenu.tsx
@@ -195,13 +195,13 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
             </button>
           )}
           {type === 'post' && (
-            postType === 'file' || postType === 'task' ? (
+            postType === 'file' || postType === 'task' || postType === 'free_speech' ? (
               <div className="relative">
                 <button
                   onClick={() => setShowTaskPicker((p) => !p)}
                   className={`${itemClasses} ${itemHover}`}
                 >
-                  <FaTasks className="inline mr-2" /> Add to Task Folder
+                  <FaTasks className="inline mr-2" /> Add to Folder
                 </button>
                 {showTaskPicker && (
                   <TaskLinkDropdown


### PR DESCRIPTION
## Summary
- remove "Move to Task" button from file posts
- extend action menu with "Add to Folder" option for free speech, task, and file posts
- update tests to use the action menu workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25ff712bc832f9a5c686f1de27f9a