### PR TITLE
feat: add review summary tag

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.summary.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.summary.test.tsx
@@ -115,4 +115,28 @@ describe('PostCard summary tags', () => {
     expect(tags).toHaveLength(3);
     expect(tags[0].textContent).toContain('File');
   });
+
+  it('renders review tag for review request posts', async () => {
+    const reviewReq: Post = {
+      id: 'p3',
+      authorId: 'u1',
+      type: 'request' as unknown as Post['type'],
+      nodeId: 'Q:slug:T01:F00',
+      content: 'Review request',
+      visibility: 'public',
+      timestamp: '',
+      tags: ['review', 'request'],
+      collaborators: [],
+      linkedItems: [],
+    } as unknown as Post;
+    const enriched = { ...reviewReq, author: { id: 'u1', username: 'alice' } } as Post;
+    render(
+      <BrowserRouter>
+        <PostCard post={enriched} questTitle="Quest A" />
+      </BrowserRouter>
+    );
+    expect(await screen.findByText('Review')).toBeInTheDocument();
+    const tags = await screen.findAllByTestId('summary-tag');
+    expect(tags[1].textContent).toContain('Review');
+  });
 });

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -198,6 +198,13 @@ export const buildSummaryTags = async (
 
   tags.push(primaryTag);
 
+  if (
+    post.type === 'request' &&
+    (post.subtype === 'file' || post.tags?.includes('review'))
+  ) {
+    tags.push({ type: 'review', label: 'Review', detailLink: ROUTES.POST(post.id) });
+  }
+
   if (post.authorId) {
     const username = await getUsernameFromId(post.authorId);
     tags.push({
@@ -219,6 +226,12 @@ export const buildSummaryTags = async (
   if (post.tags && post.tags.length > 0) {
     const blockedPrefixes = ['summary:', 'pending:'];
     const blockedTags = ['system'];
+    if (
+      post.type === 'request' &&
+      (post.subtype === 'file' || post.tags?.includes('review'))
+    ) {
+      blockedTags.push('review');
+    }
     post.tags.forEach((rawTag) => {
       const lower = rawTag.toLowerCase();
       if (


### PR DESCRIPTION
## Summary
- show a `Review` summary tag on review request posts
- test presence of the review tag on review request posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2a4173418832fa27f7d8ae5820803