### PR TITLE
Show linked item titles on quest board requests and reviews

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.reviewLinkedTitle.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.reviewLinkedTitle.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PostCard from './PostCard';
+import type { Post } from '../../types/postTypes';
+import type { User } from '../../types/userTypes';
+import { jest } from '@jest/globals';
+
+jest.mock('../../api/post', () => ({
+  __esModule: true,
+  fetchRepliesByPostId: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../api/auth', () => ({
+  __esModule: true,
+  fetchUserById: jest.fn((id) => Promise.resolve({ id, username: 'alice' })),
+}));
+
+jest.mock('../../contexts/BoardContext', () => ({
+  __esModule: true,
+  useBoardContext: () => ({ selectedBoard: 'quest-board' }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    __esModule: true,
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+describe('PostCard review linked title', () => {
+  it('shows linked post title for review posts on quest board', async () => {
+    const post: Post = {
+      id: 'p1',
+      authorId: 'u1',
+      type: 'review',
+      content: 'review',
+      visibility: 'public',
+      timestamp: '',
+      tags: ['review'],
+      collaborators: [],
+      linkedItems: [
+        { itemId: 'f1', itemType: 'post', title: 'File Header' },
+      ],
+    } as Post;
+    render(
+      <BrowserRouter>
+        <PostCard post={post} user={{ id: 'u1' } as User} boardId="quest-board" />
+      </BrowserRouter>
+    );
+    expect(await screen.findByText('File Header')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/components/post/PostCard.tsx
+++ b/ethos-frontend/src/components/post/PostCard.tsx
@@ -201,7 +201,12 @@ const PostCard: React.FC<PostCardProps> = ({
     : 'Unknown time';
 
   const content = post.renderedContent || post.content;
-  const titleText = post.title || makeHeader(post.content);
+  const linkedTitle =
+    ctxBoardId === 'quest-board' &&
+    (post.tags?.includes('review') || post.type === 'review')
+      ? post.linkedItems?.find(li => li.title)?.title
+      : undefined;
+  const titleText = linkedTitle || post.title || makeHeader(post.content);
   const [summaryTags, setSummaryTags] = useState<SummaryTagData[]>([]);
   useEffect(() => {
     let active = true;

--- a/ethos-frontend/src/components/request/RequestCard.linkedTitle.test.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.linkedTitle.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import RequestCard from './RequestCard';
+import type { EnrichedPost } from '../../types/postTypes';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', xp: 0 } }),
+}));
+
+jest.mock('../../api/post', () => ({
+  acceptRequest: jest.fn(),
+  unacceptRequest: jest.fn(),
+}));
+
+describe('RequestCard linked title', () => {
+  it('shows linked item title when post title missing', () => {
+    const post: EnrichedPost = {
+      id: 'p1',
+      authorId: 'u2',
+      type: 'task',
+      content: 'content',
+      visibility: 'public',
+      timestamp: '',
+      tags: ['request'],
+      collaborators: [],
+      linkedItems: [
+        { itemId: 'p2', itemType: 'post', title: 'Linked Task' },
+      ],
+    } as EnrichedPost;
+    render(
+      <BrowserRouter>
+        <RequestCard post={post} />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Linked Task')).toBeInTheDocument();
+  });
+});

--- a/ethos-frontend/src/components/request/RequestCard.tsx
+++ b/ethos-frontend/src/components/request/RequestCard.tsx
@@ -37,6 +37,9 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
   const difficulty = difficultyTag ? difficultyTag.split(':')[1] : undefined;
   const userRank = getRank(user?.xp ?? 0);
 
+  const linkedTitle = post.linkedItems?.find(li => li.title)?.title;
+  const displayTitle = linkedTitle || post.title;
+
   const handleJoin = async () => {
     if (!user) return;
     try {
@@ -94,8 +97,10 @@ const RequestCard: React.FC<RequestCardProps> = ({ post, onUpdate, className }) 
           />
         )}
       </div>
-      {post.title && (
-        <h3 className="font-semibold text-lg truncate">{toTitleCase(post.title)}</h3>
+      {displayTitle && (
+        <h3 className="font-semibold text-lg truncate">
+          {toTitleCase(displayTitle)}
+        </h3>
       )}
       {post.content && <p className="text-sm text-primary">{post.content}</p>}
       <div className="flex items-center gap-2 text-xs text-secondary">

--- a/ethos-frontend/src/utils/displayUtils.ts
+++ b/ethos-frontend/src/utils/displayUtils.ts
@@ -94,6 +94,14 @@ export const getDisplayTitle = (
     return post.title;
   }
 
+  const linked = post.linkedItems?.find((li) => li.title)?.title;
+  if (
+    linked &&
+    (post.tags?.includes('request') || post.tags?.includes('review') || post.type === 'review')
+  ) {
+    return linked;
+  }
+
   if (post.nodeId || post.questId) {
     return getQuestLinkLabel(post, questName, includeQuestName);
   }


### PR DESCRIPTION
## Summary
- Display linked task/file title on quest board request cards
- Use linked post title for review posts and display utils
- Add tests for linked titles on quest board posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ce7262fc832f89fc79aa4d173429