### PR TITLE
Update reaction request handlers to refresh cards and board

### DIFF
--- a/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.reviewRequest.test.tsx
@@ -63,7 +63,7 @@ describe('review request quest board flow', () => {
     const onUpdate = jest.fn();
     requestHelp.mockResolvedValue({
       post: {
-        id: 'f1',
+        id: 'req1',
         authorId: 'u1',
         type: 'file',
         content: 'file',
@@ -83,6 +83,7 @@ describe('review request quest board flow', () => {
               id: 'f1',
               authorId: 'u1',
               type: 'file',
+              title: 'file',
               content: 'file',
               visibility: 'public',
               tags: [],
@@ -104,7 +105,10 @@ describe('review request quest board flow', () => {
 
     await waitFor(() => expect(requestHelp).toHaveBeenCalledWith('f1', 'file'));
     await waitFor(() => expect(onUpdate).toHaveBeenCalled());
-    expect(appendToBoard).toHaveBeenCalledWith('quest-board', expect.objectContaining({ id: 'f1' }));
+    expect(appendToBoard).toHaveBeenCalledWith(
+      'quest-board',
+      expect.objectContaining({ id: 'req1', title: 'file' })
+    );
 
     const updatedPost = onUpdate.mock.calls[0][0];
     render(

--- a/ethos-frontend/src/components/controls/ReactionControls.tsx
+++ b/ethos-frontend/src/components/controls/ReactionControls.tsx
@@ -174,12 +174,16 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         setReviewRequested(false);
       } else {
         const res = await requestHelp(post.id, 'file');
-        const updated = {
-          ...res.post,
-          tags: [...new Set([...(res.post.tags || []), 'request'])],
+        const updatedOriginal = {
+          ...post,
+          tags: [...new Set([...(post.tags || []), 'review', 'request'])],
+          helpRequest: true,
         } as Post;
-        onUpdate?.(updated);
-        appendToBoard?.('quest-board', updated as unknown as BoardItem);
+        onUpdate?.(updatedOriginal);
+        appendToBoard?.(
+          'quest-board',
+          { ...res.post, title: res.post.title || post.title } as unknown as BoardItem
+        );
         setReviewRequested(true);
       }
     } catch (err) {
@@ -206,8 +210,16 @@ const ReactionControls: React.FC<ReactionControlsProps> = ({
         setHelpRequested(false);
       } else {
         const res = await requestHelp(post.id, 'task');
-        onUpdate?.(res.post);
-        appendToBoard?.('quest-board', res.post as unknown as BoardItem);
+        const updatedOriginal = {
+          ...post,
+          tags: [...new Set([...(post.tags || []), 'request'])],
+          helpRequest: true,
+        } as Post;
+        onUpdate?.(updatedOriginal);
+        appendToBoard?.(
+          'quest-board',
+          { ...res.post, title: res.post.title || post.title } as unknown as BoardItem
+        );
         setHelpRequested(true);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure review and help requests update original post and quest board
- test quest board receives request id and original title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a362f22184832fa109f2c0bf470fc1