### PR TITLE
feat: add free speech preview component

### DIFF
--- a/ethos-frontend/src/components/post/ExpandedCard.tsx
+++ b/ethos-frontend/src/components/post/ExpandedCard.tsx
@@ -5,6 +5,7 @@ import MarkdownRenderer from '../ui/MarkdownRenderer';
 import MediaPreview from '../ui/MediaPreview';
 import { TAG_BASE } from '../../constants/styles';
 import type { Post, EnrichedPost } from '../../types/postTypes';
+import FreeSpeechView from './expanded/FreeSpeechView';
 
 const PREVIEW_LIMIT = 240;
 
@@ -18,35 +19,6 @@ interface ViewProps {
   onTaskClick?: () => void;
   questId?: string | null;
 }
-
-export const FreeSpeechView: React.FC<ViewProps> = ({ post, expanded, compact, onToggleTask }) => {
-  const content = post.renderedContent || post.content;
-  const isLong = content.length > PREVIEW_LIMIT;
-  return (
-    <div className="text-sm text-primary">
-      {isLong && !expanded ? (
-        <div className={compact ? 'clamp-3' : ''}>
-          <MarkdownRenderer content={content.slice(0, PREVIEW_LIMIT) + '…'} onToggleTask={onToggleTask} />
-        </div>
-      ) : (
-        <div className={compact ? 'clamp-3' : ''}>
-          <MarkdownRenderer content={content} onToggleTask={onToggleTask} />
-        </div>
-      )}
-      <MediaPreview media={post.mediaPreviews} />
-      {post.tags && post.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1 mt-1">
-          {Array.from(new Set(post.tags)).map(tag => (
-            <span key={tag} className={TAG_BASE}>#{tag}</span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
-
-export const FileView: React.FC<ViewProps> = (props) => <FreeSpeechView {...props} />;
-export const ProjectView: React.FC<ViewProps> = (props) => <FreeSpeechView {...props} />;
 
 export const TaskView: React.FC<ViewProps> = ({ post, expanded, compact, onToggleTask, onTaskClick, questId }) => {
   const isLong = (post.details || '').length > PREVIEW_LIMIT;
@@ -87,9 +59,9 @@ const ExpandedCard: React.FC<ViewProps> = (props) => {
     case 'task':
       return <TaskView {...props} />;
     case 'file':
-      return <FileView {...props} />;
     case 'project':
-      return <ProjectView {...props} />;
+    case 'free_speech':
+      return <FreeSpeechView {...props} />;
     default:
       return <FreeSpeechView {...props} />;
   }

--- a/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
+++ b/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import MarkdownRenderer from '../../ui/MarkdownRenderer';
+import MediaPreview from '../../ui/MediaPreview';
+import { TAG_BASE } from '../../../constants/styles';
+import { ROUTES } from '../../../constants/routes';
+import type { Post, EnrichedPost } from '../../../types/postTypes';
+
+const PREVIEW_LIMIT = 240;
+
+export type PostWithExtras = Post & Partial<EnrichedPost>;
+
+interface ViewProps {
+  post: PostWithExtras;
+  expanded: boolean;
+  compact?: boolean;
+  onToggleTask?: (index: number, checked: boolean) => void;
+}
+
+const FreeSpeechView: React.FC<ViewProps> = ({ post, expanded, compact, onToggleTask }) => {
+  const content = post.renderedContent || post.content;
+  const isLong = content.length > PREVIEW_LIMIT;
+  const displayContent = isLong && !expanded ? content.slice(0, PREVIEW_LIMIT) + '…' : content;
+  const clampClass = expanded ? '' : compact ? 'clamp-3' : 'clamp-4';
+  const navigate = useNavigate();
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter') {
+      navigate(ROUTES.POST(post.id));
+    }
+  };
+
+  return (
+    <div className="text-sm text-primary">
+      <Link
+        to={ROUTES.POST(post.id)}
+        className="block focus:outline-none"
+        onKeyDown={handleKeyDown}
+      >
+        {post.title && <div className="font-semibold">{post.title}</div>}
+        <div className={clampClass}>
+          <MarkdownRenderer content={displayContent} onToggleTask={onToggleTask} />
+        </div>
+      </Link>
+      <MediaPreview media={post.mediaPreviews} />
+      {post.tags && post.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1">
+          {Array.from(new Set(post.tags)).map(tag => (
+            <span key={tag} className={TAG_BASE}>#{tag}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FreeSpeechView;

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -12,6 +12,13 @@
   overflow: hidden;
 }
 
+.clamp-4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 
 :root {
   --color-primary: #111827;


### PR DESCRIPTION
## Summary
- create FreeSpeechView component for free speech posts with accessible link
- clamp free speech previews to 3-4 lines with ellipsis
- integrate FreeSpeechView into ExpandedCard for `free_speech` type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c530e030832fb1b2e9946ddf0988