### PR TITLE
feat: add read-only file view with edit toggle

### DIFF
--- a/ethos-frontend/src/components/post/ExpandedCard.tsx
+++ b/ethos-frontend/src/components/post/ExpandedCard.tsx
@@ -6,6 +6,7 @@ import MediaPreview from '../ui/MediaPreview';
 import { TAG_BASE } from '../../constants/styles';
 import type { Post, EnrichedPost } from '../../types/postTypes';
 import FreeSpeechView from './expanded/FreeSpeechView';
+import FileView from './expanded/FileView';
 
 const PREVIEW_LIMIT = 240;
 
@@ -59,6 +60,7 @@ const ExpandedCard: React.FC<ViewProps> = (props) => {
     case 'task':
       return <TaskView {...props} />;
     case 'file':
+      return <FileView {...props} />;
     case 'project':
     case 'free_speech':
       return <FreeSpeechView {...props} />;

--- a/ethos-frontend/src/components/post/expanded/FileView.tsx
+++ b/ethos-frontend/src/components/post/expanded/FileView.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef, useState } from 'react';
+import FileEditorPanel from '../../quest/FileEditorPanel';
+import { useAuth } from '../../../contexts/AuthContext';
+import { updatePost } from '../../../api/post';
+import type { Post, EnrichedPost } from '../../../types/postTypes';
+
+export type PostWithExtras = Post & Partial<EnrichedPost>;
+
+interface ViewProps {
+  post: PostWithExtras;
+  expanded: boolean;
+  compact?: boolean;
+}
+
+const FileView: React.FC<ViewProps> = ({ post, expanded }) => {
+  const { user } = useAuth();
+  const canEdit = user?.id === post.authorId || post.collaborators?.some(c => c.userId === user?.id);
+  const [content, setContent] = useState(post.content);
+  const [draft, setDraft] = useState(post.content);
+  const [editing, setEditing] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (containerRef.current) {
+        setWidth(containerRef.current.offsetWidth);
+      }
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const panelStyle = expanded
+    ? { height: width * 1.41, overflowY: 'auto' as const }
+    : { maxHeight: width * 1.5, overflowY: 'auto' as const };
+
+  const handleEdit = () => {
+    setDraft(content);
+    setEditing(true);
+    setTimeout(() => {
+      const el = textareaRef.current;
+      if (el) {
+        el.focus();
+        el.setSelectionRange(el.value.length, el.value.length);
+      }
+    }, 0);
+  };
+
+  const handleSave = async () => {
+    try {
+      const updated = await updatePost(post.id, { content: draft });
+      setContent(updated.content);
+      setEditing(false);
+    } catch (err) {
+      console.error('Failed to save file', err);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      void handleSave();
+    }
+  };
+
+  return (
+    <div className="text-sm text-primary">
+      {post.title && <div className="font-semibold mb-2">{post.title}</div>}
+      <div ref={containerRef} style={panelStyle}>
+        {editing ? (
+          <textarea
+            ref={textareaRef}
+            className="w-full border border-secondary rounded p-2 font-mono text-sm"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            style={{ height: panelStyle.height ?? panelStyle.maxHeight }}
+          />
+        ) : (
+          <FileEditorPanel
+            questId={post.questId || ''}
+            filePath={post.gitFilePath || ''}
+            content={content}
+            readOnly
+          />
+        )}
+      </div>
+      {canEdit && !editing && (
+        <button className="text-xs underline mt-1" onClick={handleEdit}>
+          Edit
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default FileView;

--- a/ethos-frontend/src/components/quest/FileEditorPanel.tsx
+++ b/ethos-frontend/src/components/quest/FileEditorPanel.tsx
@@ -5,9 +5,11 @@ interface FileEditorPanelProps {
   questId: string;
   filePath: string;
   content: string;
+  /** Render a static, non-editable view */
+  readOnly?: boolean;
 }
 
-const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, content }) => {
+const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, content, readOnly }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(content + '\n');
@@ -21,7 +23,7 @@ const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, co
     }
   };
 
-  if (editing) {
+  if (!readOnly && editing) {
     return (
       <div className="space-y-2">
         <textarea
@@ -58,22 +60,26 @@ const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, co
               {idx + 1}
             </span>
             {line}
-            <button
-              className="ml-2 text-accent underline text-xs"
-              onClick={() => setExpandedLine(expandedLine === idx + 1 ? null : idx + 1)}
-            >
-              {expandedLine === idx + 1 ? 'Hide' : 'History'}
-            </button>
-            <button
-              className="ml-1 text-accent underline text-xs"
-              onClick={() => {
-                setEditing(true);
-                setDraft(lines.join('\n') + '\n');
-              }}
-            >
-              Edit
-            </button>
-            {expandedLine === idx + 1 && (
+            {!readOnly && (
+              <>
+                <button
+                  className="ml-2 text-accent underline text-xs"
+                  onClick={() => setExpandedLine(expandedLine === idx + 1 ? null : idx + 1)}
+                >
+                  {expandedLine === idx + 1 ? 'Hide' : 'History'}
+                </button>
+                <button
+                  className="ml-1 text-accent underline text-xs"
+                  onClick={() => {
+                    setEditing(true);
+                    setDraft(lines.join('\n') + '\n');
+                  }}
+                >
+                  Edit
+                </button>
+              </>
+            )}
+            {!readOnly && expandedLine === idx + 1 && (
               <div className="mt-1">
                 <LineVersionThread
                   questId={questId}
@@ -86,15 +92,17 @@ const FileEditorPanel: React.FC<FileEditorPanelProps> = ({ questId, filePath, co
           </div>
         ))}
       </pre>
-      <button
-        onClick={() => {
-          setEditing(true);
-          setDraft(content + '\n');
-        }}
-        className="mt-2 text-accent underline text-sm"
-      >
-        Edit File
-      </button>
+      {!readOnly && (
+        <button
+          onClick={() => {
+            setEditing(true);
+            setDraft(content + '\n');
+          }}
+          className="mt-2 text-accent underline text-sm"
+        >
+          Edit File
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add FileView component that renders posts with file content using FileEditorPanel in read-only mode and supports editing via Ctrl+S
- extend FileEditorPanel with `readOnly` option
- show FileView in ExpandedCard for file posts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c7c53f94832f82ef67741f8abaac