### PR TITLE
Convert post titles to anchor links

### DIFF
--- a/ethos-frontend/src/App.tsx
+++ b/ethos-frontend/src/App.tsx
@@ -92,6 +92,7 @@ const App: React.FC = () => {
                   <Route path={ROUTES.QUEST()} element={<Quest />} />
                   <Route path={ROUTES.PROJECT()} element={<Project />} />
                     <Route path={ROUTES.POST()} element={<Post />} />
+                    <Route path={ROUTES.TASK()} element={<Post />} />
                     <Route path="/board/quests" element={<Navigate to={ROUTES.BOARD('quest-board')} replace />} />
                     <Route path={ROUTES.BOARD()} element={<Board />} />
                     <Route path={ROUTES.TEAM_BOARD()} element={<TeamBoard />} />

--- a/ethos-frontend/src/components/post/expanded/FileView.tsx
+++ b/ethos-frontend/src/components/post/expanded/FileView.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import FileEditorPanel from '../../quest/FileEditorPanel';
 import { useAuth } from '../../../contexts/AuthContext';
 import { updatePost } from '../../../api/post';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../../constants/routes';
 import type { Post, EnrichedPost } from '../../../types/postTypes';
 import styles from './expandedCard.module.css';
 
@@ -15,6 +17,12 @@ interface ViewProps {
 
 const FileView: React.FC<ViewProps> = ({ post, expanded }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter') {
+      navigate(ROUTES.POST(post.id));
+    }
+  };
   const canEdit = user?.id === post.authorId || post.collaborators?.some(c => c.userId === user?.id);
   const [content, setContent] = useState(post.content);
   const [draft, setDraft] = useState(post.content);
@@ -69,7 +77,19 @@ const FileView: React.FC<ViewProps> = ({ post, expanded }) => {
 
   return (
     <div className={styles.base}>
-      {post.title && <div className="font-semibold mb-2">{post.title}</div>}
+      {post.title && (
+        <a
+          href={ROUTES.POST(post.id)}
+          className="font-semibold mb-2 block"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate(ROUTES.POST(post.id));
+          }}
+          onKeyDown={handleTitleKeyDown}
+        >
+          {post.title}
+        </a>
+      )}
       <div ref={containerRef} style={panelStyle}>
         {editing ? (
           <textarea

--- a/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
+++ b/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import MarkdownRenderer from '../../ui/MarkdownRenderer';
 import MediaPreview from '../../ui/MediaPreview';
 import { TAG_BASE } from '../../../constants/styles';
@@ -32,16 +32,20 @@ const FreeSpeechView: React.FC<ViewProps> = ({ post, expanded, compact, onToggle
 
   return (
     <div className={styles.base}>
-      <Link
-        to={ROUTES.POST(post.id)}
+      <a
+        href={ROUTES.POST(post.id)}
         className="block focus:outline-none"
+        onClick={(e) => {
+          e.preventDefault();
+          navigate(ROUTES.POST(post.id));
+        }}
         onKeyDown={handleKeyDown}
       >
         {post.title && <div className="font-semibold">{post.title}</div>}
         <div className={clampClass}>
           <MarkdownRenderer content={displayContent} onToggleTask={onToggleTask} />
         </div>
-      </Link>
+      </a>
       <MediaPreview media={post.mediaPreviews} />
       {post.tags && post.tags.length > 0 && (
         <div className="flex flex-wrap gap-1 mt-1">

--- a/ethos-frontend/src/components/post/expanded/ProjectView.tsx
+++ b/ethos-frontend/src/components/post/expanded/ProjectView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useGraph } from '../../../hooks/useGraph';
 import GraphLayout from '../../layout/GraphLayout';
 import GitFileBrowserInline from '../../git/GitFileBrowserInline';
@@ -117,12 +117,22 @@ const ProjectView: React.FC<ProjectViewProps> = ({ post }) => {
         >
           {selected.type === 'task' ? (
             <>
-              <Link
-                to={ROUTES.POST(selected.id)}
+              <a
+                href={ROUTES.TASK(selected.id)}
                 className="text-sm text-accent underline"
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate(ROUTES.TASK(selected.id));
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    navigate(ROUTES.TASK(selected.id));
+                  }
+                }}
               >
                 {selected.content}
-              </Link>
+              </a>
               <GitFileBrowserInline questId={selected.questId || ''} />
             </>
           ) : (

--- a/ethos-frontend/src/components/post/expanded/TaskView.tsx
+++ b/ethos-frontend/src/components/post/expanded/TaskView.tsx
@@ -7,6 +7,8 @@ import TeamPanel from '../../quest/TeamPanel';
 import { Select } from '../../ui';
 import { VISIBILITY_OPTIONS } from '../../../constants/options';
 import { updatePost } from '../../../api/post';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../../constants/routes';
 import type { Post, EnrichedPost } from '../../../types/postTypes';
 import type { Visibility } from '../../../types/common';
 import styles from './expandedCard.module.css';
@@ -26,6 +28,7 @@ type TreeNode = {
 
 const TaskView: React.FC<TaskViewProps> = ({ post }) => {
   const graph = useGraph();
+  const navigate = useNavigate();
   const loadGraph = graph.loadGraph;
   const [selected, setSelected] = useState<Post>(post);
   const [expandedNodes, setExpandedNodes] = useState<Record<string, boolean>>({ [post.id]: true });
@@ -78,18 +81,7 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
     const hasChildren = node.children.length > 0;
     return (
       <li key={node.post.id} className="pl-2">
-        <div
-          role="treeitem"
-          aria-expanded={hasChildren ? isExpanded : undefined}
-          tabIndex={0}
-          className="flex items-center cursor-pointer"
-          onClick={() => setSelected(node.post)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') setSelected(node.post);
-            if (e.key === 'ArrowRight' && hasChildren && !isExpanded) toggle(node.post.id);
-            if (e.key === 'ArrowLeft' && hasChildren && isExpanded) toggle(node.post.id);
-          }}
-        >
+        <div className="flex items-center">
           {hasChildren && (
             <button
               type="button"
@@ -100,9 +92,28 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
               {isExpanded ? <FaChevronDown /> : <FaChevronRight />}
             </button>
           )}
-          <span className={selected.id === node.post.id ? 'font-semibold truncate' : 'truncate'}>
+          <a
+            role="treeitem"
+            aria-expanded={hasChildren ? isExpanded : undefined}
+            href={ROUTES.TASK(node.post.id)}
+            className={selected.id === node.post.id ? 'font-semibold truncate cursor-pointer' : 'truncate cursor-pointer'}
+            onClick={(e) => {
+              e.preventDefault();
+              setSelected(node.post);
+              navigate(ROUTES.TASK(node.post.id));
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                setSelected(node.post);
+                navigate(ROUTES.TASK(node.post.id));
+              }
+              if (e.key === 'ArrowRight' && hasChildren && !isExpanded) toggle(node.post.id);
+              if (e.key === 'ArrowLeft' && hasChildren && isExpanded) toggle(node.post.id);
+            }}
+          >
             {node.post.content}
-          </span>
+          </a>
         </div>
         {hasChildren && isExpanded && (
           <ul className="ml-4" role="group">

--- a/ethos-frontend/src/constants/routes.ts
+++ b/ethos-frontend/src/constants/routes.ts
@@ -55,7 +55,14 @@ export const ROUTES = {
      * @param id - Project ID
      */
     PROJECT: (id = ':id') => `/project/${id}`,
-  
+
+    /**
+     * Task page by ID
+     * @param id - Task ID
+     * @returns A route string like `/task/abc123`
+     */
+    TASK: (id = ':id') => `/task/${id}`,
+
     /**
      * Post page by ID (private)
      * @param id - Post ID


### PR DESCRIPTION
## Summary
- Replace clickable div/span wrappers with `<a>` elements for post and task titles across view components
- Add `ROUTES.TASK` path and corresponding route
- Ensure keyboard navigation uses Enter to open posts or tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a651761054832f973ac6f2fe974caa