### PR TITLE
Add invitation forms and privacy cascade to task and project views

### DIFF
--- a/ethos-frontend/src/api/joinRequest.ts
+++ b/ethos-frontend/src/api/joinRequest.ts
@@ -5,9 +5,11 @@ const BASE_URL = '/join-requests';
 
 export const createJoinRequest = async (
   taskId: string,
+  requesterId: string,
   requestPostId?: string,
+  meta?: Record<string, unknown>,
 ): Promise<JoinRequest> => {
-  const res = await axiosWithAuth.post(BASE_URL, { taskId, requestPostId });
+  const res = await axiosWithAuth.post(BASE_URL, { taskId, requesterId, requestPostId, meta });
   return res.data;
 };
 
@@ -20,4 +22,3 @@ export const declineJoinRequest = async (id: string): Promise<JoinRequest> => {
   const res = await axiosWithAuth.patch(`${BASE_URL}/${id}/decline`);
   return res.data;
 };
-

--- a/ethos-frontend/src/components/post/expanded/ProjectView.tsx
+++ b/ethos-frontend/src/components/post/expanded/ProjectView.tsx
@@ -3,9 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useGraph } from '../../../hooks/useGraph';
 import GraphLayout from '../../layout/GraphLayout';
 import GitFileBrowserInline from '../../git/GitFileBrowserInline';
-import TeamPanel from '../../quest/TeamPanel';
-import { Select } from '../../ui';
-import { VISIBILITY_OPTIONS } from '../../../constants/options';
+import InviteForm from '../../quest/InviteForm';
 import { ROUTES } from '../../../constants/routes';
 import { updatePost } from '../../../api/post';
 import type { Post, EnrichedPost } from '../../../types/postTypes';
@@ -146,14 +144,29 @@ const ProjectView: React.FC<ProjectViewProps> = ({ post }) => {
           hidden={activeTab !== 'options'}
           className="space-y-4"
         >
-          <TeamPanel questId={post.questId || ''} node={selected} />
+          <div>
+            <label className="block mb-1 text-xs font-semibold">Members</label>
+            <ul className="ml-4 list-disc text-sm">
+              {(selected.collaborators || []).map((c, i) => (
+                <li key={i}>
+                  {c.username ? `@${c.username}` : 'Unknown'}
+                  {c.roles && c.roles.length ? ` - ${c.roles.join(', ')}` : ''}
+                </li>
+              ))}
+            </ul>
+          </div>
+          {selected.type === 'task' && <InviteForm taskId={selected.id} />}
           <div>
             <label className="block mb-1 text-xs font-semibold">Visibility</label>
-            <Select
-              value={visibility}
-              onChange={e => handleVisibilityChange(e.target.value as Visibility)}
-              options={VISIBILITY_OPTIONS}
-            />
+            <label className="inline-flex items-center text-xs">
+              <input
+                type="checkbox"
+                className="mr-2"
+                checked={visibility === 'private'}
+                onChange={e => handleVisibilityChange(e.target.checked ? 'private' : 'public')}
+              />
+              Private
+            </label>
             <label className="mt-1 inline-flex items-center text-xs">
               <input
                 type="checkbox"

--- a/ethos-frontend/src/components/post/expanded/TaskView.tsx
+++ b/ethos-frontend/src/components/post/expanded/TaskView.tsx
@@ -3,9 +3,7 @@ import { FaChevronRight, FaChevronDown } from 'react-icons/fa';
 import { useGraph } from '../../../hooks/useGraph';
 import TaskKanbanBoard from '../../quest/TaskKanbanBoard';
 import SubtaskChecklist from '../../quest/SubtaskChecklist';
-import TeamPanel from '../../quest/TeamPanel';
-import { Select } from '../../ui';
-import { VISIBILITY_OPTIONS } from '../../../constants/options';
+import InviteForm from '../../quest/InviteForm';
 import { updatePost } from '../../../api/post';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../../constants/routes';
@@ -36,6 +34,7 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
   const [visibility, setVisibility] = useState<Visibility>(
     post.visibility || 'public'
   );
+  const [cascade, setCascade] = useState(false);
 
   useEffect(() => {
     if (post.questId) {
@@ -127,7 +126,7 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
   const handleVisibilityChange = async (val: Visibility) => {
     setVisibility(val);
     try {
-      await updatePost(selected.id, { visibility: val });
+      await updatePost(selected.id, { visibility: val, cascade });
     } catch (err) {
       console.error('[TaskView] failed to update visibility', err);
     }
@@ -182,14 +181,38 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
           hidden={activeTab !== 'options'}
           className="space-y-4"
         >
-          <TeamPanel questId={post.questId || ''} node={selected} />
+          <div>
+            <label className="block mb-1 text-xs font-semibold">Members</label>
+            <ul className="ml-4 list-disc text-sm">
+              {(selected.collaborators || []).map((c, i) => (
+                <li key={i}>
+                  {c.username ? `@${c.username}` : 'Unknown'}
+                  {c.roles && c.roles.length ? ` - ${c.roles.join(', ')}` : ''}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <InviteForm taskId={selected.id} />
           <div>
             <label className="block mb-1 text-xs font-semibold">Visibility</label>
-            <Select
-              value={visibility}
-              onChange={e => handleVisibilityChange(e.target.value as Visibility)}
-              options={VISIBILITY_OPTIONS}
-            />
+            <label className="inline-flex items-center text-xs">
+              <input
+                type="checkbox"
+                className="mr-2"
+                checked={visibility === 'private'}
+                onChange={e => handleVisibilityChange(e.target.checked ? 'private' : 'public')}
+              />
+              Private
+            </label>
+            <label className="mt-1 inline-flex items-center text-xs">
+              <input
+                type="checkbox"
+                className="mr-1"
+                checked={cascade}
+                onChange={e => setCascade(e.target.checked)}
+              />
+              Cascade to subtasks
+            </label>
           </div>
         </div>
       </div>

--- a/ethos-frontend/src/components/quest/InviteForm.tsx
+++ b/ethos-frontend/src/components/quest/InviteForm.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { createJoinRequest } from '../../api/joinRequest';
+import { searchUsers } from '../../api/auth';
+
+interface InviteFormProps {
+  taskId: string;
+}
+
+const InviteForm: React.FC<InviteFormProps> = ({ taskId }) => {
+  const [username, setUsername] = useState('');
+  const [role, setRole] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleInviteUser = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = username.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    try {
+      const results = await searchUsers(trimmed);
+      const user = results[0];
+      if (!user) {
+        alert('User not found');
+        return;
+      }
+      await createJoinRequest(taskId, user.id);
+      alert('Invitation sent');
+      setUsername('');
+    } catch (err) {
+      console.error('[InviteForm] failed to invite user', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInviteRole = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = role.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    try {
+      await createJoinRequest(taskId, `role:${trimmed}`, undefined, { role: trimmed });
+      alert('Role request sent');
+      setRole('');
+    } catch (err) {
+      console.error('[InviteForm] failed to create role request', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <form onSubmit={handleInviteUser} className="flex gap-2">
+        <input
+          type="text"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          placeholder="Invite by username"
+          className="flex-1 border px-2 py-1 rounded"
+        />
+        <button type="submit" className="text-xs px-2 py-1 bg-blue-600 text-white rounded" disabled={loading}>
+          Invite
+        </button>
+      </form>
+      <form onSubmit={handleInviteRole} className="flex gap-2">
+        <input
+          type="text"
+          value={role}
+          onChange={e => setRole(e.target.value)}
+          placeholder="Request by role"
+          className="flex-1 border px-2 py-1 rounded"
+        />
+        <button type="submit" className="text-xs px-2 py-1 bg-blue-600 text-white rounded" disabled={loading}>
+          Request
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default InviteForm;


### PR DESCRIPTION
## Summary
- allow inviting collaborators by username or role via new invite form
- add privacy toggle with optional cascade to subtasks
- show current members and roles from post.collaborators
- replace `any` meta type in join request API with `unknown` to satisfy lint rules

## Testing
- `npm run lint`
- `npm test` (fails: PostCard request CTA shows request tag and allows cancel)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a65867f210832fb9b7bba693f11eab