### PR TITLE
Add line clamp utilities and responsive view layouts

### DIFF
--- a/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
+++ b/ethos-frontend/src/components/post/PostCard.expandedView.test.tsx
@@ -113,7 +113,7 @@ test('renders free speech post with clamped text and navigates on click', () => 
       <PostCard post={freeSpeech} />
     </BrowserRouter>
   );
-  expect(container.querySelector('.clamp-4')).toBeInTheDocument();
+  expect(container.querySelector('.line-clamp-4')).toBeInTheDocument();
   const link = screen.getByRole('link');
   fireEvent.keyDown(link, { key: 'Enter' });
   expect(navMock).toHaveBeenCalledWith(ROUTES.POST('fs1'));

--- a/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
+++ b/ethos-frontend/src/components/post/expanded/FreeSpeechView.tsx
@@ -22,7 +22,7 @@ const FreeSpeechView: React.FC<ViewProps> = ({ post, expanded, compact, onToggle
   const content = post.renderedContent || post.content;
   const isLong = content.length > PREVIEW_LIMIT;
   const displayContent = isLong && !expanded ? content.slice(0, PREVIEW_LIMIT) + '…' : content;
-  const clampClass = expanded ? '' : compact ? 'clamp-3' : 'clamp-4';
+  const clampClass = expanded ? '' : compact ? 'line-clamp-3' : 'line-clamp-4';
   const navigate = useNavigate();
   const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
     if (e.key === 'Enter') {

--- a/ethos-frontend/src/components/post/expanded/ProjectView.tsx
+++ b/ethos-frontend/src/components/post/expanded/ProjectView.tsx
@@ -69,7 +69,7 @@ const ProjectView: React.FC<ProjectViewProps> = ({ post }) => {
   };
 
   return (
-    <div className="flex gap-2 text-sm text-primary" data-testid="project-view">
+    <div className="flex flex-col md:flex-row gap-2 text-sm text-primary" data-testid="project-view">
       <div className="border border-secondary rounded p-2 w-72 overflow-auto">
         <GraphLayout
           items={allNodes}

--- a/ethos-frontend/src/components/post/expanded/TaskView.tsx
+++ b/ethos-frontend/src/components/post/expanded/TaskView.tsx
@@ -133,7 +133,7 @@ const TaskView: React.FC<TaskViewProps> = ({ post }) => {
   };
 
   return (
-    <div className="flex gap-2 text-sm text-primary" data-testid="task-view">
+    <div className="flex flex-col md:flex-row gap-2 text-sm text-primary" data-testid="task-view">
       <div className="border border-secondary rounded p-2 w-64 overflow-auto">
         <ul role="tree">{renderNode(tree)}</ul>
       </div>

--- a/ethos-frontend/src/index.css
+++ b/ethos-frontend/src/index.css
@@ -5,14 +5,16 @@
 @tailwind components;
 @tailwind utilities;
 
-.clamp-3 {
+
+/* Multi-line truncation utilities */
+.line-clamp-3 {
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.clamp-4 {
+.line-clamp-4 {
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
## Summary
- Define global `.line-clamp-3` and `.line-clamp-4` CSS utilities
- Use new line clamp classes in FreeSpeechView and updated test
- Make TaskView and ProjectView containers flex-column by default and switch to rows on medium screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7c1987004832f9cf9e7cb9de77b6c