### PR TITLE
Make seeder env loading self-contained

### DIFF
--- a/tools/seed/modules/db.mts
+++ b/tools/seed/modules/db.mts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+
+function getDbUrl() {
+  return (
+    process.env.ETHOS_DATABASE_URL ??
+    'postgres://ethos:ethos@localhost:5432/ethos'
+  );
+}
+
+export const pool = new Pool({ connectionString: getDbUrl() });
+
+export function loadEnv() {
+  return { databaseUrl: getDbUrl() };
+}


### PR DESCRIPTION
## Summary
- add a self-contained database module for the seeder that loads environment variables directly via dotenv
- provide a loadEnv shim and default connection fallback to avoid breaking existing imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f691aefd88832f815b0be0a45631f7